### PR TITLE
feat: Canvas HTTP client with pagination and error handling

### DIFF
--- a/src/canvas/client.ts
+++ b/src/canvas/client.ts
@@ -1,7 +1,3 @@
-// Canvas HTTP client — foundation for all modules.
-// Handles auth, pagination, error parsing.
-// See implementation plan Task 4 for full implementation.
-
 import type { CanvasClientConfig, CanvasErrorResponse } from './types'
 
 export class CanvasApiError extends Error {

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -1,6 +1,3 @@
-// Canvas API types — built fresh, referencing Fjordbyte Canvas Integration as blueprint.
-// Only fields each tool actually needs.
-
 // --- Config ---
 
 export interface CanvasClientConfig {
@@ -16,8 +13,7 @@ export interface CanvasErrorResponse {
   message?: string
 }
 
-// --- Placeholder types for all domains ---
-// These will be expanded as each canvas module is implemented.
+// --- Courses ---
 
 export interface CanvasCourse {
   id: number
@@ -45,4 +41,262 @@ export interface CanvasEnrollment {
   type: string
   role: string
   enrollment_state: string
+}
+
+// --- Assignments ---
+
+export interface CanvasAssignment {
+  id: number
+  name: string
+  description: string | null
+  due_at: string | null
+  points_possible: number
+  grading_type: string
+  submission_types: string[]
+  course_id: number
+  rubric_settings?: { id: number }
+  group_category_id?: number | null
+  quiz_id?: number | null
+  allowed_attempts: number
+}
+
+export interface CanvasAssignmentGroup {
+  id: number
+  name: string
+  position: number
+  group_weight: number
+  assignments?: CanvasAssignment[]
+}
+
+// --- Submissions ---
+
+export interface CanvasSubmission {
+  id: number
+  assignment_id: number
+  user_id: number
+  submitted_at: string | null
+  score: number | null
+  grade: string | null
+  body: string | null
+  url: string | null
+  attempt: number | null
+  workflow_state: string
+  attachments?: CanvasAttachment[]
+  submission_comments?: CanvasSubmissionComment[]
+}
+
+export interface CanvasAttachment {
+  id: number
+  filename: string
+  display_name: string
+  url: string
+  content_type: string
+  size: number
+}
+
+export interface CanvasSubmissionComment {
+  id: number
+  author_id: number
+  author_name: string
+  comment: string
+  created_at: string
+}
+
+// --- Rubrics ---
+
+export interface CanvasRubric {
+  id: number
+  title: string
+  points_possible: number
+  data: CanvasRubricCriterion[]
+}
+
+export interface CanvasRubricCriterion {
+  id: string
+  description: string
+  points: number
+  ratings: CanvasRubricRating[]
+}
+
+export interface CanvasRubricRating {
+  id: string
+  description: string
+  points: number
+}
+
+export interface CanvasRubricAssessment {
+  id: number
+  rubric_id: number
+  score: number
+  data: Array<{
+    criterion_id: string
+    points: number
+    comments: string
+  }>
+}
+
+// --- Quizzes ---
+
+export interface CanvasQuiz {
+  id: number
+  title: string
+  quiz_type: string
+  points_possible: number
+  question_count: number
+  due_at: string | null
+  published: boolean
+}
+
+export interface CanvasQuizSubmission {
+  id: number
+  quiz_id: number
+  user_id: number
+  submission_id: number
+  attempt: number
+  score: number | null
+  kept_score: number | null
+  workflow_state: string
+}
+
+export interface CanvasQuizQuestion {
+  id: number
+  quiz_id: number
+  position: number
+  question_text: string
+  question_type: string
+  points_possible: number
+  answers?: Array<{ id: number; text: string; weight: number }>
+}
+
+export interface CanvasQuizSubmissionQuestion {
+  id: number
+  quiz_id: number
+  answer: string | number | null
+  flagged: boolean
+}
+
+// --- Files ---
+
+export interface CanvasFile {
+  id: number
+  display_name: string
+  content_type: string
+  url: string
+  size: number
+  folder_id: number
+}
+
+export interface CanvasFolder {
+  id: number
+  name: string
+  full_name: string
+  parent_folder_id: number | null
+}
+
+// --- Users ---
+
+export interface CanvasUser {
+  id: number
+  name: string
+  login_id?: string
+  email?: string
+  avatar_url?: string
+}
+
+export interface CanvasUserProfile {
+  id: number
+  name: string
+  primary_email: string
+  login_id: string
+  avatar_url: string
+  time_zone: string
+  locale: string
+}
+
+// --- Groups ---
+
+export interface CanvasGroup {
+  id: number
+  name: string
+  group_category_id: number
+  members_count: number
+}
+
+// --- Modules ---
+
+export interface CanvasModule {
+  id: number
+  name: string
+  position: number
+  items_count: number
+  state?: string
+  published?: boolean
+}
+
+export interface CanvasModuleItem {
+  id: number
+  module_id: number
+  title: string
+  position: number
+  type: string
+  content_id?: number
+  html_url?: string
+}
+
+// --- Pages ---
+
+export interface CanvasPage {
+  page_id: number
+  url: string
+  title: string
+  body?: string
+  published: boolean
+  updated_at: string
+}
+
+// --- Discussions ---
+
+export interface CanvasDiscussionTopic {
+  id: number
+  title: string
+  message: string | null
+  posted_at: string
+  discussion_type: string
+  published: boolean
+}
+
+export interface CanvasDiscussionEntry {
+  id: number
+  user_id: number
+  message: string
+  created_at: string
+}
+
+export interface CanvasAnnouncement {
+  id: number
+  title: string
+  message: string
+  posted_at: string
+}
+
+// --- Calendar ---
+
+export interface CanvasCalendarEvent {
+  id: number
+  title: string
+  start_at: string
+  end_at: string | null
+  type: string
+  context_code: string
+}
+
+// --- Conversations ---
+
+export interface CanvasConversation {
+  id: number
+  subject: string
+  last_message: string
+  last_message_at: string
+  message_count: number
+  participants: Array<{ id: number; name: string }>
 }

--- a/tests/canvas/client.test.ts
+++ b/tests/canvas/client.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { CanvasHttpClient, CanvasApiError } from '../../src/canvas/client'
+
+describe('CanvasHttpClient', () => {
+  let client: CanvasHttpClient
+
+  beforeEach(() => {
+    client = new CanvasHttpClient({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('request', () => {
+    it('sends GET with auth header and user-agent', async () => {
+      const mockResponse = { id: 1, name: 'Test Course' }
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify(mockResponse), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+
+      const result = await client.request<{ id: number; name: string }>('/api/v1/courses/1')
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://canvas.example.com/api/v1/courses/1',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-token',
+            'User-Agent': 'canvas-lms-mcp/1.0',
+          }),
+        }),
+      )
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('passes through custom request options', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      )
+
+      await client.request('/api/v1/courses', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'New Course' }),
+      })
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://canvas.example.com/api/v1/courses',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ name: 'New Course' }),
+        }),
+      )
+    })
+
+    it('handles absolute URLs without prepending baseUrl', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify([]), { status: 200 }),
+      )
+
+      await client.request('https://other.example.com/api/v1/courses')
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://other.example.com/api/v1/courses',
+        expect.anything(),
+      )
+    })
+
+    it('strips trailing slashes from baseUrl', async () => {
+      const slashClient = new CanvasHttpClient({
+        token: 'test-token',
+        baseUrl: 'https://canvas.example.com///',
+      })
+
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify({}), { status: 200 }),
+      )
+
+      await slashClient.request('/api/v1/courses/1')
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://canvas.example.com/api/v1/courses/1',
+        expect.anything(),
+      )
+    })
+
+    it('throws CanvasApiError on 403', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ errors: [{ message: 'Forbidden' }] }), {
+          status: 403,
+        }),
+      )
+
+      await expect(client.request('/api/v1/courses/1')).rejects.toThrow(CanvasApiError)
+      await expect(client.request('/api/v1/courses/1')).rejects.toMatchObject({
+        status: 403,
+        endpoint: '/api/v1/courses/1',
+      })
+    })
+
+    it('throws CanvasApiError on 404 with message field', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ message: 'The specified resource does not exist' }),
+          { status: 404 },
+        ),
+      )
+
+      const error = await client.request('/api/v1/courses/999').catch((e) => e)
+      expect(error).toBeInstanceOf(CanvasApiError)
+      expect(error.status).toBe(404)
+      expect(error.message).toBe('The specified resource does not exist')
+    })
+
+    it('throws CanvasApiError with fallback message on non-JSON error body', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response('Internal Server Error', { status: 500 }),
+      )
+
+      const error = await client.request('/api/v1/courses/1').catch((e) => e)
+      expect(error).toBeInstanceOf(CanvasApiError)
+      expect(error.status).toBe(500)
+      expect(error.message).toContain('500')
+    })
+  })
+
+  describe('paginate', () => {
+    it('follows Link header rel="next" and merges results', async () => {
+      const page1 = [{ id: 1 }, { id: 2 }]
+      const page2 = [{ id: 3 }]
+
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify(page1), {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+              Link: '<https://canvas.example.com/api/v1/courses?page=2&per_page=100>; rel="next"',
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify(page2), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+
+      const result = await client.paginate<{ id: number }>('/api/v1/courses')
+      expect(result).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }])
+      expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('sets per_page=100 by default', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+
+      await client.paginate('/api/v1/courses')
+
+      const calledUrl = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string
+      expect(calledUrl).toContain('per_page=100')
+    })
+
+    it('passes custom params as query parameters', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+
+      await client.paginate('/api/v1/courses', { enrollment_type: 'teacher' })
+
+      const calledUrl = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string
+      expect(calledUrl).toContain('enrollment_type=teacher')
+    })
+
+    it('sends auth headers on paginated requests', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify([]), { status: 200 }),
+      )
+
+      await client.paginate('/api/v1/courses')
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-token',
+          }),
+        }),
+      )
+    })
+
+    it('respects maxPaginationPages limit', async () => {
+      const limitedClient = new CanvasHttpClient({
+        token: 'test-token',
+        baseUrl: 'https://canvas.example.com',
+        maxPaginationPages: 1,
+      })
+
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: 1 }]), {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+            Link: '<https://canvas.example.com/api/v1/courses?page=2>; rel="next"',
+          },
+        }),
+      )
+
+      const result = await limitedClient.paginate<{ id: number }>('/api/v1/courses')
+      expect(result).toEqual([{ id: 1 }])
+      expect(fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('throws CanvasApiError on paginated request failure', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify({ errors: [{ message: 'Unauthorized' }] }), {
+          status: 401,
+        }),
+      )
+
+      await expect(client.paginate('/api/v1/courses')).rejects.toThrow(CanvasApiError)
+    })
+
+    it('returns empty array when no results', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+
+      const result = await client.paginate('/api/v1/courses')
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('paginateEnvelope', () => {
+    it('extracts array from envelope key', async () => {
+      const response = { quiz_submissions: [{ id: 1 }, { id: 2 }] }
+
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify(response), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+
+      const result = await client.paginateEnvelope<{ id: number }>(
+        '/api/v1/quizzes/1/submissions',
+        'quiz_submissions',
+      )
+      expect(result).toEqual([{ id: 1 }, { id: 2 }])
+    })
+
+    it('follows pagination with envelope responses', async () => {
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ items: [{ id: 1 }] }), {
+            status: 200,
+            headers: {
+              Link: '<https://canvas.example.com/api/v1/items?page=2&per_page=100>; rel="next"',
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ items: [{ id: 2 }] }), {
+            status: 200,
+          }),
+        )
+
+      const result = await client.paginateEnvelope<{ id: number }>(
+        '/api/v1/items',
+        'items',
+      )
+      expect(result).toEqual([{ id: 1 }, { id: 2 }])
+      expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('returns empty array when envelope key is missing', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify({ other_key: [{ id: 1 }] }), {
+          status: 200,
+        }),
+      )
+
+      const result = await client.paginateEnvelope<{ id: number }>(
+        '/api/v1/quizzes/1/submissions',
+        'quiz_submissions',
+      )
+      expect(result).toEqual([])
+    })
+
+    it('throws CanvasApiError on envelope request failure', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: 'Not Found' }), { status: 404 }),
+      )
+
+      await expect(
+        client.paginateEnvelope('/api/v1/quizzes/999/submissions', 'quiz_submissions'),
+      ).rejects.toThrow(CanvasApiError)
+    })
+  })
+
+  describe('CanvasApiError', () => {
+    it('has correct name, status, and endpoint properties', () => {
+      const error = new CanvasApiError('Forbidden', 403, '/api/v1/courses/1')
+      expect(error.name).toBe('CanvasApiError')
+      expect(error.message).toBe('Forbidden')
+      expect(error.status).toBe(403)
+      expect(error.endpoint).toBe('/api/v1/courses/1')
+      expect(error).toBeInstanceOf(Error)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Implements `CanvasHttpClient` with `request()`, `paginate()`, and `paginateEnvelope()` methods
- Adds `CanvasApiError` with `.status` and `.endpoint` fields for structured error handling
- Completes `types.ts` with all 15 Canvas domain types (courses, assignments, submissions, rubrics, quizzes, files, users, groups, enrollments, discussions, modules, pages, calendar, conversations)
- 19 tests covering auth headers, error codes (403/404/500), Link header pagination, maxPaginationPages limit, and envelope extraction

**Plan Task:** 4 — Canvas API Client Foundation
**BRU-14**

## Test plan

- [x] `pnpm typecheck` — passes (0 errors)
- [x] `pnpm test` — 19/19 tests pass
- [x] `pnpm build` — ESM + CJS build succeeds
- [x] TDD: tests written first (18 RED), implementation from scratch (19 GREEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)