### PR TITLE
test: CoursesModule and CanvasClient facade tests

### DIFF
--- a/tests/canvas/courses.test.ts
+++ b/tests/canvas/courses.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { CoursesModule } from '../../src/canvas/courses'
+import { CanvasHttpClient } from '../../src/canvas/client'
+import type { CanvasCourse } from '../../src/canvas/types'
+
+describe('CoursesModule', () => {
+  let client: CanvasHttpClient
+  let courses: CoursesModule
+
+  beforeEach(() => {
+    client = new CanvasHttpClient({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+    })
+    courses = new CoursesModule(client)
+  })
+
+  describe('list', () => {
+    it('lists courses with pagination', async () => {
+      const mockCourses: CanvasCourse[] = [
+        { id: 1, name: 'CS 101', course_code: 'CS101', workflow_state: 'available' },
+        { id: 2, name: 'Math 201', course_code: 'MATH201', workflow_state: 'available' },
+      ]
+
+      vi.spyOn(client, 'paginate').mockResolvedValueOnce(mockCourses)
+
+      const result = await courses.list()
+      expect(result).toEqual(mockCourses)
+      expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses', {
+        'include[]': 'term',
+      })
+    })
+
+    it('passes enrollment_state filter', async () => {
+      vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+
+      await courses.list({ enrollment_state: 'completed' })
+      expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses', {
+        'include[]': 'term',
+        enrollment_state: 'completed',
+      })
+    })
+
+    it('omits enrollment_state when not provided', async () => {
+      vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+
+      await courses.list()
+      expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses', {
+        'include[]': 'term',
+      })
+    })
+
+    it('returns empty array when no courses', async () => {
+      vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+
+      const result = await courses.list()
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('get', () => {
+    it('gets a single course with term and total_students includes', async () => {
+      const mockCourse: CanvasCourse = {
+        id: 1,
+        name: 'CS 101',
+        course_code: 'CS101',
+        workflow_state: 'available',
+        total_students: 35,
+        term: { id: 1, name: 'Fall 2026', start_at: null, end_at: null },
+      }
+
+      vi.spyOn(client, 'request').mockResolvedValueOnce(mockCourse)
+
+      const result = await courses.get(1)
+      expect(result).toEqual(mockCourse)
+      expect(client.request).toHaveBeenCalledWith(
+        '/api/v1/courses/1?include[]=term&include[]=total_students',
+      )
+    })
+
+    it('constructs correct URL for different course IDs', async () => {
+      vi.spyOn(client, 'request').mockResolvedValueOnce({
+        id: 42,
+        name: 'Art 300',
+        course_code: 'ART300',
+        workflow_state: 'available',
+      })
+
+      await courses.get(42)
+      expect(client.request).toHaveBeenCalledWith(
+        '/api/v1/courses/42?include[]=term&include[]=total_students',
+      )
+    })
+  })
+
+  describe('getSyllabus', () => {
+    it('returns syllabus body when present', async () => {
+      const mockCourse: CanvasCourse = {
+        id: 1,
+        name: 'CS 101',
+        course_code: 'CS101',
+        workflow_state: 'available',
+        syllabus_body: '<p>Welcome to CS 101</p>',
+      }
+
+      vi.spyOn(client, 'request').mockResolvedValueOnce(mockCourse)
+
+      const result = await courses.getSyllabus(1)
+      expect(result).toBe('<p>Welcome to CS 101</p>')
+      expect(client.request).toHaveBeenCalledWith(
+        '/api/v1/courses/1?include[]=syllabus_body',
+      )
+    })
+
+    it('returns null when syllabus_body is undefined', async () => {
+      const mockCourse: CanvasCourse = {
+        id: 1,
+        name: 'CS 101',
+        course_code: 'CS101',
+        workflow_state: 'available',
+      }
+
+      vi.spyOn(client, 'request').mockResolvedValueOnce(mockCourse)
+
+      const result = await courses.getSyllabus(1)
+      expect(result).toBeNull()
+    })
+
+    it('constructs correct URL for different course IDs', async () => {
+      vi.spyOn(client, 'request').mockResolvedValueOnce({
+        id: 99,
+        name: 'Bio 100',
+        course_code: 'BIO100',
+        workflow_state: 'available',
+      })
+
+      await courses.getSyllabus(99)
+      expect(client.request).toHaveBeenCalledWith(
+        '/api/v1/courses/99?include[]=syllabus_body',
+      )
+    })
+  })
+})

--- a/tests/canvas/facade.test.ts
+++ b/tests/canvas/facade.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { CanvasClient, CanvasHttpClient, CanvasApiError } from '../../src/canvas/index'
+import { CoursesModule } from '../../src/canvas/courses'
+
+describe('CanvasClient facade', () => {
+  it('creates a CanvasClient with courses module', () => {
+    const client = new CanvasClient({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+    })
+
+    expect(client.courses).toBeInstanceOf(CoursesModule)
+  })
+
+  it('re-exports CanvasHttpClient', () => {
+    expect(CanvasHttpClient).toBeDefined()
+    const httpClient = new CanvasHttpClient({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+    })
+    expect(httpClient).toBeInstanceOf(CanvasHttpClient)
+  })
+
+  it('re-exports CanvasApiError', () => {
+    expect(CanvasApiError).toBeDefined()
+    const error = new CanvasApiError('test', 404, '/api/v1/courses')
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(CanvasApiError)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds 9 unit tests for `CoursesModule` covering `list()`, `get()`, and `getSyllabus()` methods
- Adds 3 unit tests for `CanvasClient` facade verifying module composition and re-exports
- All tests use mocked `CanvasHttpClient` methods (no real Canvas API calls)
- Validates the module pattern established for all subsequent Canvas domain modules

**Task:** BRU-15 — Courses Module + CanvasClient Facade (Plan Task 5)

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 12/12 tests pass (courses + facade)
- [x] `pnpm build` — production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>