### PR TITLE
feat: MCP server factory, tool types, and tool registry

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { CanvasClient } from './canvas'
-import { getAllTools, formatError } from './tools'
+import { registerAllTools } from './tools'
 
 export interface CanvasMCPServerConfig {
   token: string
@@ -23,23 +23,7 @@ export function createCanvasMCPServer(config: CanvasMCPServerConfig): CanvasMCPS
     version: '1.0.0',
   })
 
-  // Register all tools
-  const tools = getAllTools(canvas)
-  for (const tool of tools) {
-    server.tool(tool.name, tool.description, tool.annotations, async (params) => {
-      try {
-        const result = await tool.handler(params as Record<string, unknown>)
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
-        }
-      } catch (error) {
-        return {
-          content: [{ type: 'text' as const, text: formatError(error) }],
-          isError: true,
-        }
-      }
-    })
-  }
+  registerAllTools(server, canvas)
 
   return { server, canvas }
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,12 +1,37 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { CanvasClient } from '../canvas'
 import type { ToolDefinition } from './types'
 
 export function getAllTools(_canvas: CanvasClient): ToolDefinition[] {
   return [
     // Tool domain modules will be registered here as implemented.
-    // See implementation plan Tasks 7, 9, 11.
     // Pattern: ...courseTools(canvas), ...assignmentTools(canvas), etc.
   ]
+}
+
+export function registerAllTools(server: McpServer, canvas: CanvasClient): void {
+  const tools = getAllTools(canvas)
+  for (const tool of tools) {
+    server.tool(
+      tool.name,
+      tool.description,
+      tool.inputSchema,
+      tool.annotations,
+      async (params) => {
+        try {
+          const result = await tool.handler(params as Record<string, unknown>)
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          }
+        } catch (error) {
+          return {
+            content: [{ type: 'text' as const, text: formatError(error) }],
+            isError: true,
+          }
+        }
+      },
+    )
+  }
 }
 
 export function formatError(error: unknown): string {

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -10,7 +10,7 @@ export interface ToolAnnotations {
 export interface ToolDefinition {
   name: string
   description: string
-  inputSchema: z.ZodType
+  inputSchema: Record<string, z.ZodType>
   annotations: ToolAnnotations
   handler: (params: Record<string, unknown>) => Promise<unknown>
 }

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { createCanvasMCPServer } from '../src/server'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { CanvasClient } from '../src/canvas'
+
+describe('createCanvasMCPServer', () => {
+  it('creates an MCP server instance', () => {
+    const result = createCanvasMCPServer({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+    })
+
+    expect(result).toBeDefined()
+    expect(result.server).toBeDefined()
+    expect(result.canvas).toBeDefined()
+  })
+
+  it('returns an McpServer instance', () => {
+    const result = createCanvasMCPServer({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+    })
+
+    expect(result.server).toBeInstanceOf(McpServer)
+  })
+
+  it('returns a CanvasClient instance', () => {
+    const result = createCanvasMCPServer({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+    })
+
+    expect(result.canvas).toBeInstanceOf(CanvasClient)
+  })
+
+  it('uses registerAllTools to wire tools into server', () => {
+    // Verify factory completes without error — registerAllTools is called internally
+    const result = createCanvasMCPServer({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+    })
+
+    expect(result.server).toBeDefined()
+    expect(result.canvas).toBeDefined()
+  })
+})

--- a/tests/tools/format-error.test.ts
+++ b/tests/tools/format-error.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { formatError } from '../../src/tools'
+import { CanvasApiError } from '../../src/canvas'
+
+describe('formatError', () => {
+  it('maps 401 to token invalid message', () => {
+    const error = new CanvasApiError('Unauthorized', 401, '/api/v1/courses')
+    expect(formatError(error)).toBe('Canvas token is invalid or expired')
+  })
+
+  it('maps 403 to permission denied message', () => {
+    const error = new CanvasApiError('Forbidden', 403, '/api/v1/courses/1')
+    expect(formatError(error)).toBe(
+      "You don't have permission to perform this action in this course",
+    )
+  })
+
+  it('maps 404 to not found message', () => {
+    const error = new CanvasApiError('Not Found', 404, '/api/v1/courses/999')
+    expect(formatError(error)).toBe('Course/assignment/submission not found \u2014 check the ID')
+  })
+
+  it('maps other status codes to generic Canvas API error', () => {
+    const error = new CanvasApiError('Rate limited', 429, '/api/v1/courses')
+    expect(formatError(error)).toBe('Canvas API error (429): Rate limited')
+  })
+
+  it('maps fetch errors to connection message', () => {
+    const error = new TypeError('fetch failed')
+    expect(formatError(error)).toBe('Failed to connect to Canvas \u2014 check your base URL')
+  })
+
+  it('maps generic errors to their message', () => {
+    const error = new Error('Something broke')
+    expect(formatError(error)).toBe('Something broke')
+  })
+
+  it('maps non-error values to unexpected error message', () => {
+    expect(formatError('string error')).toBe('An unexpected error occurred')
+    expect(formatError(null)).toBe('An unexpected error occurred')
+    expect(formatError(undefined)).toBe('An unexpected error occurred')
+  })
+})

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest'
+import { registerAllTools, getAllTools } from '../../src/tools'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CanvasClient } from '../../src/canvas'
+
+describe('getAllTools', () => {
+  it('returns an array of tool definitions', () => {
+    const mockCanvas = {} as CanvasClient
+    const tools = getAllTools(mockCanvas)
+
+    expect(Array.isArray(tools)).toBe(true)
+  })
+
+  it('returns empty array when no tool modules registered', () => {
+    const mockCanvas = {} as CanvasClient
+    const tools = getAllTools(mockCanvas)
+
+    expect(tools).toEqual([])
+  })
+})
+
+describe('registerAllTools', () => {
+  it('is a function exported from tools module', () => {
+    expect(typeof registerAllTools).toBe('function')
+  })
+
+  it('registers tools on the MCP server', () => {
+    const server = new McpServer({ name: 'test', version: '1.0.0' })
+    const mockCanvas = {} as CanvasClient
+
+    // Should not throw with empty tool list
+    expect(() => registerAllTools(server, mockCanvas)).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

- Extracts `registerAllTools(server, canvas)` from inline registration in `server.ts` into `src/tools/index.ts` for testability and clean separation of concerns
- Updates `createCanvasMCPServer()` to delegate tool registration to `registerAllTools`
- Fixes `ToolDefinition.inputSchema` type from `z.ZodType` to `Record<string, z.ZodType>` to match MCP SDK's `ZodRawShapeCompat` expectation
- Adds comprehensive tests for server factory, tool registry, and error formatting

**Plan Task:** 6 — MCP Server Factory and Tool Types
**Paperclip Issue:** BRU-16

## Files Changed

| File | Change |
|------|--------|
| `src/server.ts` | Simplified to use `registerAllTools` |
| `src/tools/index.ts` | Added `registerAllTools` export |
| `src/tools/types.ts` | Fixed `inputSchema` type |
| `tests/server.test.ts` | New — factory creation tests |
| `tests/tools/registry.test.ts` | New — registry export/function tests |
| `tests/tools/format-error.test.ts` | New — error mapping tests (401/403/404/fetch/generic) |

## Test plan

- [x] `pnpm typecheck` passes (exit 0)
- [x] `pnpm test` passes (27/27 tests, 5 test files)
- [x] `pnpm build` passes (ESM + CJS)
- [x] All existing canvas/courses tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>