### PR TITLE
feat: add health_check and course MCP tools

### DIFF
--- a/src/tools/courses.ts
+++ b/src/tools/courses.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod'
+import type { CanvasClient } from '../canvas'
+import type { ToolDefinition } from './types'
+
+export function courseTools(canvas: CanvasClient): ToolDefinition[] {
+  return [
+    {
+      name: 'list_courses',
+      description:
+        'List courses for the authenticated user. Optionally filter by enrollment state.',
+      inputSchema: {
+        enrollment_state: z
+          .enum(['active', 'completed', 'all'])
+          .optional()
+          .describe('Filter courses by enrollment state'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const enrollment_state = params.enrollment_state as string | undefined
+        return canvas.courses.list({ enrollment_state })
+      },
+    },
+    {
+      name: 'get_course',
+      description:
+        'Get details for a single course by ID, including term and total student count.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const course_id = params.course_id as number
+        return canvas.courses.get(course_id)
+      },
+    },
+    {
+      name: 'get_syllabus',
+      description: 'Get the syllabus HTML body for a course.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const course_id = params.course_id as number
+        const syllabus_body = await canvas.courses.getSyllabus(course_id)
+        return { course_id, syllabus_body }
+      },
+    },
+  ]
+}

--- a/src/tools/health.ts
+++ b/src/tools/health.ts
@@ -1,0 +1,26 @@
+import type { CanvasClient } from '../canvas'
+import type { ToolDefinition } from './types'
+
+export function healthTools(canvas: CanvasClient): ToolDefinition[] {
+  return [
+    {
+      name: 'health_check',
+      description:
+        'Check if the Canvas API is reachable and the token is valid. Returns ok/error status.',
+      inputSchema: {},
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async () => {
+        try {
+          await canvas.courses.list()
+          return { status: 'ok', message: 'Canvas API is reachable' }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Unknown error'
+          return { status: 'error', message }
+        }
+      },
+    },
+  ]
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,12 +1,11 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { CanvasClient } from '../canvas'
 import type { ToolDefinition } from './types'
+import { healthTools } from './health'
+import { courseTools } from './courses'
 
-export function getAllTools(_canvas: CanvasClient): ToolDefinition[] {
-  return [
-    // Tool domain modules will be registered here as implemented.
-    // Pattern: ...courseTools(canvas), ...assignmentTools(canvas), etc.
-  ]
+export function getAllTools(canvas: CanvasClient): ToolDefinition[] {
+  return [...healthTools(canvas), ...courseTools(canvas)]
 }
 
 export function registerAllTools(server: McpServer, canvas: CanvasClient): void {

--- a/tests/tools/courses.test.ts
+++ b/tests/tools/courses.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { CanvasClient } from '../../src/canvas'
+import type { CanvasCourse } from '../../src/canvas/types'
+import { courseTools } from '../../src/tools/courses'
+
+describe('courseTools', () => {
+  const mockCourse: CanvasCourse = {
+    id: 1,
+    name: 'Intro to Testing',
+    course_code: 'TST101',
+    workflow_state: 'available',
+    enrollment_term_id: 1,
+    total_students: 30,
+  }
+
+  function buildMockCanvas(overrides: Partial<CanvasClient> = {}): CanvasClient {
+    return {
+      courses: {
+        list: vi.fn().mockResolvedValue([mockCourse]),
+        get: vi.fn().mockResolvedValue(mockCourse),
+        getSyllabus: vi.fn().mockResolvedValue('<p>Welcome to the course</p>'),
+      },
+      ...overrides,
+    } as unknown as CanvasClient
+  }
+
+  it('returns an array with 3 tool definitions', () => {
+    const canvas = buildMockCanvas()
+    const tools = courseTools(canvas)
+    expect(tools).toHaveLength(3)
+  })
+
+  it('exports tools with correct names', () => {
+    const canvas = buildMockCanvas()
+    const tools = courseTools(canvas)
+    const names = tools.map((t) => t.name)
+    expect(names).toContain('list_courses')
+    expect(names).toContain('get_course')
+    expect(names).toContain('get_syllabus')
+  })
+
+  describe('list_courses', () => {
+    it('has readOnlyHint and openWorldHint annotations', () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'list_courses')!
+      expect(tool.annotations).toEqual({
+        readOnlyHint: true,
+        openWorldHint: true,
+      })
+    })
+
+    it('has enrollment_state in input schema', () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'list_courses')!
+      expect(tool.inputSchema).toHaveProperty('enrollment_state')
+    })
+
+    it('calls canvas.courses.list with no params when none provided', async () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'list_courses')!
+      await tool.handler({})
+      expect(canvas.courses.list).toHaveBeenCalledWith({})
+    })
+
+    it('passes enrollment_state to canvas.courses.list', async () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'list_courses')!
+      await tool.handler({ enrollment_state: 'active' })
+      expect(canvas.courses.list).toHaveBeenCalledWith({ enrollment_state: 'active' })
+    })
+
+    it('returns the course list from Canvas', async () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'list_courses')!
+      const result = await tool.handler({})
+      expect(result).toEqual([mockCourse])
+    })
+
+    it('has a description', () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'list_courses')!
+      expect(tool.description).toBeTruthy()
+    })
+  })
+
+  describe('get_course', () => {
+    it('has readOnlyHint and openWorldHint annotations', () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'get_course')!
+      expect(tool.annotations).toEqual({
+        readOnlyHint: true,
+        openWorldHint: true,
+      })
+    })
+
+    it('has course_id in input schema', () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'get_course')!
+      expect(tool.inputSchema).toHaveProperty('course_id')
+    })
+
+    it('calls canvas.courses.get with the course_id', async () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'get_course')!
+      await tool.handler({ course_id: 42 })
+      expect(canvas.courses.get).toHaveBeenCalledWith(42)
+    })
+
+    it('returns the course from Canvas', async () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'get_course')!
+      const result = await tool.handler({ course_id: 1 })
+      expect(result).toEqual(mockCourse)
+    })
+
+    it('has a description', () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'get_course')!
+      expect(tool.description).toBeTruthy()
+    })
+  })
+
+  describe('get_syllabus', () => {
+    it('has readOnlyHint and openWorldHint annotations', () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'get_syllabus')!
+      expect(tool.annotations).toEqual({
+        readOnlyHint: true,
+        openWorldHint: true,
+      })
+    })
+
+    it('has course_id in input schema', () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'get_syllabus')!
+      expect(tool.inputSchema).toHaveProperty('course_id')
+    })
+
+    it('calls canvas.courses.getSyllabus with the course_id', async () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'get_syllabus')!
+      await tool.handler({ course_id: 42 })
+      expect(canvas.courses.getSyllabus).toHaveBeenCalledWith(42)
+    })
+
+    it('returns the syllabus HTML from Canvas', async () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'get_syllabus')!
+      const result = await tool.handler({ course_id: 1 })
+      expect(result).toEqual({ course_id: 1, syllabus_body: '<p>Welcome to the course</p>' })
+    })
+
+    it('returns null syllabus when none set', async () => {
+      const canvas = buildMockCanvas({
+        courses: {
+          list: vi.fn(),
+          get: vi.fn(),
+          getSyllabus: vi.fn().mockResolvedValue(null),
+        } as unknown as CanvasClient['courses'],
+      })
+      const tool = courseTools(canvas).find((t) => t.name === 'get_syllabus')!
+      const result = await tool.handler({ course_id: 1 })
+      expect(result).toEqual({ course_id: 1, syllabus_body: null })
+    })
+
+    it('has a description', () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'get_syllabus')!
+      expect(tool.description).toBeTruthy()
+    })
+  })
+})

--- a/tests/tools/health.test.ts
+++ b/tests/tools/health.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest'
+import { z } from 'zod'
+import type { CanvasClient } from '../../src/canvas'
+import type { ToolDefinition } from '../../src/tools/types'
+
+// We'll import healthTools once it exists
+// For now, this will fail at import time
+import { healthTools } from '../../src/tools/health'
+
+describe('healthTools', () => {
+  function buildMockCanvas(overrides: Partial<CanvasClient> = {}): CanvasClient {
+    return {
+      courses: {
+        list: vi.fn(),
+        get: vi.fn(),
+        getSyllabus: vi.fn(),
+      },
+      ...overrides,
+    } as unknown as CanvasClient
+  }
+
+  it('returns an array with one tool definition', () => {
+    const canvas = buildMockCanvas()
+    const tools = healthTools(canvas)
+    expect(tools).toHaveLength(1)
+    expect(tools[0].name).toBe('health_check')
+  })
+
+  it('has empty input schema', () => {
+    const canvas = buildMockCanvas()
+    const tools = healthTools(canvas)
+    const healthCheck = tools[0]
+    expect(healthCheck.inputSchema).toEqual({})
+  })
+
+  it('has correct annotations', () => {
+    const canvas = buildMockCanvas()
+    const tools = healthTools(canvas)
+    const healthCheck = tools[0]
+    expect(healthCheck.annotations).toEqual({
+      readOnlyHint: true,
+      openWorldHint: true,
+    })
+  })
+
+  it('returns ok status when Canvas API is reachable', async () => {
+    const canvas = buildMockCanvas({
+      courses: {
+        list: vi.fn().mockResolvedValue([{ id: 1, name: 'Test Course' }]),
+        get: vi.fn(),
+        getSyllabus: vi.fn(),
+      } as unknown as CanvasClient['courses'],
+    })
+    const tools = healthTools(canvas)
+    const result = await tools[0].handler({})
+    expect(result).toEqual({
+      status: 'ok',
+      message: 'Canvas API is reachable',
+    })
+  })
+
+  it('returns error status when Canvas API fails', async () => {
+    const canvas = buildMockCanvas({
+      courses: {
+        list: vi.fn().mockRejectedValue(new Error('fetch failed')),
+        get: vi.fn(),
+        getSyllabus: vi.fn(),
+      } as unknown as CanvasClient['courses'],
+    })
+    const tools = healthTools(canvas)
+    const result = await tools[0].handler({})
+    expect(result).toEqual({
+      status: 'error',
+      message: 'fetch failed',
+    })
+  })
+
+  it('has a description', () => {
+    const canvas = buildMockCanvas()
+    const tools = healthTools(canvas)
+    expect(tools[0].description).toBeTruthy()
+  })
+})

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -5,17 +5,26 @@ import type { CanvasClient } from '../../src/canvas'
 
 describe('getAllTools', () => {
   it('returns an array of tool definitions', () => {
-    const mockCanvas = {} as CanvasClient
+    const mockCanvas = {
+      courses: { list: async () => [], get: async () => ({}), getSyllabus: async () => null },
+    } as unknown as CanvasClient
     const tools = getAllTools(mockCanvas)
 
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns empty array when no tool modules registered', () => {
-    const mockCanvas = {} as CanvasClient
+  it('returns health and course tools', () => {
+    const mockCanvas = {
+      courses: { list: async () => [], get: async () => ({}), getSyllabus: async () => null },
+    } as unknown as CanvasClient
     const tools = getAllTools(mockCanvas)
+    const names = tools.map((t) => t.name)
 
-    expect(tools).toEqual([])
+    expect(names).toContain('health_check')
+    expect(names).toContain('list_courses')
+    expect(names).toContain('get_course')
+    expect(names).toContain('get_syllabus')
+    expect(tools).toHaveLength(4)
   })
 })
 
@@ -26,9 +35,10 @@ describe('registerAllTools', () => {
 
   it('registers tools on the MCP server', () => {
     const server = new McpServer({ name: 'test', version: '1.0.0' })
-    const mockCanvas = {} as CanvasClient
+    const mockCanvas = {
+      courses: { list: async () => [], get: async () => ({}), getSyllabus: async () => null },
+    } as unknown as CanvasClient
 
-    // Should not throw with empty tool list
     expect(() => registerAllTools(server, mockCanvas)).not.toThrow()
   })
 })


### PR DESCRIPTION
## Summary

- Adds 4 MCP tool definitions: `health_check`, `list_courses`, `get_course`, `get_syllabus`
- Establishes the tool definition pattern (Zod schemas, annotations, handler delegation) for all future domain tools
- Updates `getAllTools()` registry to wire health + course tools
- 25 new tests covering tool metadata, delegation, and edge cases

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — all 52 tests pass (25 new)
- [x] `pnpm build` succeeds
- [ ] QA verification that the tool pattern is clean and reusable

Closes BRU-17

🤖 Generated with [Claude Code](https://claude.com/claude-code)