### PR TITLE
test: add CLI and stdio transport tests

### DIFF
--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { parseArgs, type CliConfig } from '../src/cli'
+
+describe('parseArgs', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    delete process.env.CANVAS_API_TOKEN
+    delete process.env.CANVAS_BASE_URL
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    vi.restoreAllMocks()
+  })
+
+  it('parses --token and --base-url from CLI args', () => {
+    const result = parseArgs(['--token', 'my-token', '--base-url', 'https://canvas.example.com'])
+
+    expect(result).toEqual<CliConfig>({
+      token: 'my-token',
+      baseUrl: 'https://canvas.example.com',
+      mode: 'stdio',
+      port: 3001,
+    })
+  })
+
+  it('falls back to CANVAS_API_TOKEN env var', () => {
+    process.env.CANVAS_API_TOKEN = 'env-token'
+    const result = parseArgs(['--base-url', 'https://canvas.example.com'])
+
+    expect(result.token).toBe('env-token')
+  })
+
+  it('falls back to CANVAS_BASE_URL env var', () => {
+    process.env.CANVAS_BASE_URL = 'https://env-canvas.example.com'
+    const result = parseArgs(['--token', 'my-token'])
+
+    expect(result.baseUrl).toBe('https://env-canvas.example.com')
+  })
+
+  it('CLI args override env vars', () => {
+    process.env.CANVAS_API_TOKEN = 'env-token'
+    process.env.CANVAS_BASE_URL = 'https://env-canvas.example.com'
+    const result = parseArgs(['--token', 'cli-token', '--base-url', 'https://cli-canvas.example.com'])
+
+    expect(result.token).toBe('cli-token')
+    expect(result.baseUrl).toBe('https://cli-canvas.example.com')
+  })
+
+  it('sets mode to http when serve subcommand is given', () => {
+    const result = parseArgs(['--token', 'my-token', '--base-url', 'https://canvas.example.com', 'serve'])
+
+    expect(result.mode).toBe('http')
+  })
+
+  it('defaults mode to stdio', () => {
+    const result = parseArgs(['--token', 'my-token', '--base-url', 'https://canvas.example.com'])
+
+    expect(result.mode).toBe('stdio')
+  })
+
+  it('parses --port', () => {
+    const result = parseArgs([
+      '--token', 'my-token',
+      '--base-url', 'https://canvas.example.com',
+      'serve',
+      '--port', '8080',
+    ])
+
+    expect(result.port).toBe(8080)
+  })
+
+  it('defaults port to 3001', () => {
+    const result = parseArgs(['--token', 'my-token', '--base-url', 'https://canvas.example.com'])
+
+    expect(result.port).toBe(3001)
+  })
+
+  it('defaults port to 3001 for invalid port value', () => {
+    const result = parseArgs([
+      '--token', 'my-token',
+      '--base-url', 'https://canvas.example.com',
+      '--port', 'not-a-number',
+    ])
+
+    expect(result.port).toBe(3001)
+  })
+
+  it('exits with error when token is missing', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect(() => parseArgs(['--base-url', 'https://canvas.example.com'])).toThrow('process.exit called')
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Error: Canvas API token required. Use --token or set CANVAS_API_TOKEN',
+    )
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+
+  it('exits with error when baseUrl is missing', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect(() => parseArgs(['--token', 'my-token'])).toThrow('process.exit called')
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Error: Canvas base URL required. Use --base-url or set CANVAS_BASE_URL',
+    )
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+
+  it('exits with error when both token and baseUrl are missing', () => {
+    vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect(() => parseArgs([])).toThrow('process.exit called')
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Error: Canvas API token required. Use --token or set CANVAS_API_TOKEN',
+    )
+  })
+
+  it('handles args in any order', () => {
+    const result = parseArgs([
+      'serve',
+      '--port', '9000',
+      '--base-url', 'https://canvas.example.com',
+      '--token', 'my-token',
+    ])
+
+    expect(result).toEqual<CliConfig>({
+      token: 'my-token',
+      baseUrl: 'https://canvas.example.com',
+      mode: 'http',
+      port: 9000,
+    })
+  })
+})

--- a/tests/stdio.test.ts
+++ b/tests/stdio.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+const mockConnect = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+  StdioServerTransport: class MockStdioServerTransport {},
+}))
+
+vi.mock('../src/server', () => ({
+  createCanvasMCPServer: vi.fn().mockReturnValue({
+    server: {
+      connect: mockConnect,
+    },
+    canvas: {},
+  }),
+}))
+
+vi.mock('../src/cli', () => ({
+  parseArgs: vi.fn().mockReturnValue({
+    token: 'test-token',
+    baseUrl: 'https://canvas.example.com',
+    mode: 'stdio',
+    port: 3001,
+  }),
+}))
+
+describe('stdio entry point', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('creates server with parsed config and connects StdioServerTransport', async () => {
+    const { createCanvasMCPServer } = await import('../src/server')
+    const { parseArgs } = await import('../src/cli')
+
+    // Import the entry point to trigger main()
+    await import('../src/stdio')
+
+    // Allow the async main() to settle
+    await vi.waitFor(() => {
+      expect(mockConnect).toHaveBeenCalled()
+    })
+
+    expect(parseArgs).toHaveBeenCalledWith(process.argv.slice(2))
+
+    expect(createCanvasMCPServer).toHaveBeenCalledWith({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+    })
+
+    expect(mockConnect).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- Adds comprehensive tests for `src/cli.ts` (parseArgs) covering all CLI flags, env var fallbacks, error exits, and argument ordering
- Adds integration test for `src/stdio.ts` verifying it wires StdioServerTransport to the MCP server via createCanvasMCPServer
- Implementation code already on main — this PR adds the missing test coverage for Plan Task 13

**Paperclip:** [BRU-27](/BRU/issues/BRU-27)

## Test plan

- [x] `pnpm test` — all 45 tests pass (12 new CLI tests + 1 stdio test)
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>