### PR TITLE
docs: add comprehensive end-user documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Once configured, try these prompts with your AI client:
 
 ## Tool Inventory
 
-### Read-Only Tools (34)
+### Read-Only Tools (36)
 
 | Category | Tool | Description |
 |----------|------|-------------|
@@ -145,7 +145,7 @@ Once configured, try these prompts with your AI client:
 | Calendar | `list_calendar_events` | List calendar events for a course |
 | Conversations | `list_conversations` | List inbox messages for the authenticated user |
 
-### Write Tools (8)
+### Write Tools (6)
 
 | Tool | Description | Idempotent |
 |------|-------------|------------|
@@ -253,7 +253,7 @@ const courses = await canvas.courses.list()
 | `CANVAS_API_TOKEN` | Yes | Canvas personal access token |
 | `CANVAS_BASE_URL` | Yes | Canvas instance URL (e.g., `https://school.instructure.com`) |
 | `CANVAS_ALLOWED_ORIGIN` | No | CORS origin for HTTP mode (default: `http://localhost:3000`) |
-| `CANVAS_MAX_PAGINATION_PAGES` | No | Max pages to fetch during pagination (default: `1000`) |
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -2,60 +2,258 @@
 
 [![CI](https://github.com/bruchris/canvas-lms-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/bruchris/canvas-lms-mcp/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Node](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org)
 
-MCP server for Canvas LMS. Read courses, assignments, submissions, rubrics, quizzes; grade and comment from any AI agent.
+MCP server for [Canvas LMS](https://www.instructure.com/canvas). Read courses, assignments, submissions, rubrics, quizzes; grade and comment from any AI agent.
 
-```bash
-npx canvas-lms-mcp --token $CANVAS_API_TOKEN --base-url https://institution.instructure.com
-```
-
-## Status
-
-**Under development.** See [design spec](docs/superpowers/specs/2026-04-12-canvas-lms-mcp-design.md) and [implementation plan](docs/superpowers/plans/2026-04-12-canvas-lms-mcp.md) for details.
-
-## Features (planned)
-
-- **41 MCP tools** across 15 Canvas domains (33 read, 8 write)
-- **3 deployment modes**: stdio (CLI), HTTP/SSE (remote), npm library import
-- **Selective writes**: grading, commenting, quiz scoring, discussion posting, messaging
-- **Standalone Canvas client**: importable via `canvas-lms-mcp/canvas` without MCP overhead
-- **Tool annotations**: `readOnlyHint`, `destructiveHint` for AI client safety decisions
+42 tools across 15 Canvas domains. Three deployment modes: stdio, HTTP, and library import.
 
 ## Quick Start
 
-### Claude Desktop
+### 1. Get a Canvas API Token
+
+1. Log in to your Canvas instance
+2. Go to **Account > Settings**
+3. Scroll to **Approved Integrations** and click **+ New Access Token**
+4. Give it a name (e.g., "MCP Server") and click **Generate Token**
+5. Copy the token immediately -- you won't see it again
+
+### 2. Configure Your AI Client
+
+#### Claude Desktop
+
+Add to your `claude_desktop_config.json`:
 
 ```json
 {
   "mcpServers": {
     "canvas-lms": {
       "command": "npx",
-      "args": ["canvas-lms-mcp"],
+      "args": ["-y", "canvas-lms-mcp"],
       "env": {
-        "CANVAS_API_TOKEN": "your-token",
-        "CANVAS_BASE_URL": "https://institution.instructure.com"
+        "CANVAS_API_TOKEN": "your-token-here",
+        "CANVAS_BASE_URL": "https://your-institution.instructure.com"
       }
     }
   }
 }
 ```
 
-### HTTP Server
+#### Cursor
+
+Add to `.cursor/mcp.json` in your project:
+
+```json
+{
+  "mcpServers": {
+    "canvas-lms": {
+      "command": "npx",
+      "args": ["-y", "canvas-lms-mcp"],
+      "env": {
+        "CANVAS_API_TOKEN": "your-token-here",
+        "CANVAS_BASE_URL": "https://your-institution.instructure.com"
+      }
+    }
+  }
+}
+```
+
+#### VS Code
+
+Add to your VS Code settings (`settings.json`):
+
+```json
+{
+  "mcp.servers": {
+    "canvas-lms": {
+      "command": "npx",
+      "args": ["-y", "canvas-lms-mcp"],
+      "env": {
+        "CANVAS_API_TOKEN": "your-token-here",
+        "CANVAS_BASE_URL": "https://your-institution.instructure.com"
+      }
+    }
+  }
+}
+```
+
+#### ChatGPT / HTTP Clients
+
+Run the server in HTTP mode, then point your client at the endpoint:
 
 ```bash
-canvas-lms-mcp serve --port 3001
+npx canvas-lms-mcp serve --port 3001 \
+  --token your-token-here \
+  --base-url https://your-institution.instructure.com
+```
+
+The MCP endpoint is `http://localhost:3001/mcp`. Per-request credentials can be passed via `X-Canvas-Token` and `X-Canvas-Base-URL` headers.
+
+## Example Prompts
+
+Once configured, try these prompts with your AI client:
+
+- "List all my active courses"
+- "Show me the assignments for course 12345"
+- "What's the average grade on the midterm exam?"
+- "Grade Alice's essay submission with a B+ and add feedback"
+- "Show me the rubric for the final project"
+- "What discussions are happening in my Biology course?"
+- "List all upcoming calendar events for course 12345"
+- "Send a message to student 67890 about their missing assignment"
+
+## Tool Inventory
+
+### Read-Only Tools (34)
+
+| Category | Tool | Description |
+|----------|------|-------------|
+| Health | `health_check` | Check if the Canvas API is reachable and token is valid |
+| Courses | `list_courses` | List courses (optionally filter by enrollment state) |
+| Courses | `get_course` | Get course details including term and student count |
+| Courses | `get_syllabus` | Get the syllabus HTML for a course |
+| Assignments | `list_assignments` | List all assignments in a course |
+| Assignments | `get_assignment` | Get details for a single assignment |
+| Assignments | `list_assignment_groups` | List assignment groups (Homework, Exams, etc.) |
+| Submissions | `list_submissions` | List all submissions for an assignment |
+| Submissions | `get_submission` | Get a specific student's submission with comments |
+| Rubrics | `list_rubrics` | List all rubrics in a course |
+| Rubrics | `get_rubric` | Get rubric details including criteria |
+| Rubrics | `get_rubric_assessment` | Get rubric assessment for a student submission |
+| Quizzes | `list_quizzes` | List all quizzes in a course |
+| Quizzes | `get_quiz` | Get details for a single quiz |
+| Quizzes | `list_quiz_submissions` | List all submissions for a quiz |
+| Quizzes | `list_quiz_questions` | List all questions in a quiz |
+| Quizzes | `get_quiz_submission_answers` | Get a student's quiz answers |
+| Files | `list_files` | List all files in a course |
+| Files | `list_folders` | List all folders in a course |
+| Files | `get_file` | Get file metadata including download URL |
+| Users | `list_students` | List all students enrolled in a course |
+| Users | `get_user` | Get details for a single user |
+| Users | `get_profile` | Get the authenticated user's profile |
+| Groups | `list_groups` | List all groups in a course |
+| Groups | `list_group_members` | List all members of a group |
+| Enrollments | `list_enrollments` | List enrollments for the authenticated user |
+| Discussions | `list_discussions` | List all discussion topics in a course |
+| Discussions | `get_discussion` | Get details for a discussion topic |
+| Discussions | `list_announcements` | List all announcements in a course |
+| Modules | `list_modules` | List all modules in a course |
+| Modules | `get_module` | Get details for a single module |
+| Modules | `list_module_items` | List all items within a module |
+| Pages | `list_pages` | List all wiki pages in a course |
+| Pages | `get_page` | Get a wiki page by its URL slug |
+| Calendar | `list_calendar_events` | List calendar events for a course |
+| Conversations | `list_conversations` | List inbox messages for the authenticated user |
+
+### Write Tools (8)
+
+| Tool | Description | Idempotent |
+|------|-------------|------------|
+| `grade_submission` | Post or update a grade for a submission | Yes |
+| `comment_on_submission` | Add a text comment to a submission | No |
+| `submit_rubric_assessment` | Submit rubric scores and comments per criterion | Yes |
+| `score_quiz_question` | Score a specific quiz question | Yes |
+| `post_discussion_entry` | Post a reply to a discussion topic | No |
+| `send_conversation` | Send a message to one or more recipients | No |
+
+All write tools require appropriate Canvas permissions. Canvas enforces its own permission model -- the MCP server does not bypass it.
+
+### MCP Resources (2)
+
+| Resource | URI Template | Type |
+|----------|-------------|------|
+| Course Syllabus | `canvas://course/{courseId}/syllabus` | text/html |
+| Assignment Description | `canvas://course/{courseId}/assignment/{assignmentId}/description` | text/html |
+
+## Deployment Modes
+
+### stdio (Default)
+
+For local AI clients like Claude Desktop, Cursor, and VS Code. The server communicates over stdin/stdout.
+
+```bash
+npx canvas-lms-mcp --token $CANVAS_API_TOKEN --base-url $CANVAS_BASE_URL
+```
+
+### HTTP
+
+For web-based clients or hosted services. Starts an HTTP server with Streamable HTTP transport.
+
+```bash
+npx canvas-lms-mcp serve \
+  --token $CANVAS_API_TOKEN \
+  --base-url $CANVAS_BASE_URL \
+  --port 3001 \
+  --allowed-origin https://your-app.example.com
+```
+
+Endpoints:
+- `POST /mcp` -- MCP protocol endpoint
+- `GET /health` -- Health check (returns `{"status":"ok"}`)
+
+### Docker
+
+```bash
+docker compose up -d
+```
+
+Requires `CANVAS_API_TOKEN` and `CANVAS_BASE_URL` environment variables. See `docker-compose.yml`.
+
+```yaml
+services:
+  canvas-lms-mcp:
+    build: .
+    ports:
+      - "3001:3001"
+    environment:
+      - CANVAS_API_TOKEN=${CANVAS_API_TOKEN}
+      - CANVAS_BASE_URL=${CANVAS_BASE_URL}
 ```
 
 ### Library Import
 
+Use the server factory directly in your own Node.js application:
+
 ```typescript
 import { createCanvasMCPServer } from 'canvas-lms-mcp'
 
-const server = createCanvasMCPServer({
+const { server, canvas } = createCanvasMCPServer({
   token: userToken,
   baseUrl: canvasBaseUrl,
 })
 ```
+
+Or use the Canvas client standalone (no MCP dependency):
+
+```typescript
+import { CanvasClient } from 'canvas-lms-mcp/canvas'
+
+const canvas = new CanvasClient({
+  token: userToken,
+  baseUrl: canvasBaseUrl,
+})
+
+const courses = await canvas.courses.list()
+```
+
+## CLI Reference
+
+| Flag | Env Variable | Default | Description |
+|------|-------------|---------|-------------|
+| `--token` | `CANVAS_API_TOKEN` | (required) | Canvas personal access token |
+| `--base-url` | `CANVAS_BASE_URL` | (required) | Canvas instance URL |
+| `serve` | -- | stdio mode | Switch to HTTP mode |
+| `--port` | -- | `3001` | HTTP server port |
+| `--allowed-origin` | `CANVAS_ALLOWED_ORIGIN` | `http://localhost:3000` | CORS allowed origin |
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `CANVAS_API_TOKEN` | Yes | Canvas personal access token |
+| `CANVAS_BASE_URL` | Yes | Canvas instance URL (e.g., `https://school.instructure.com`) |
+| `CANVAS_ALLOWED_ORIGIN` | No | CORS origin for HTTP mode (default: `http://localhost:3000`) |
+| `CANVAS_MAX_PAGINATION_PAGES` | No | Max pages to fetch during pagination (default: `1000`) |
 
 ## Development
 
@@ -63,20 +261,37 @@ const server = createCanvasMCPServer({
 pnpm install       # Install dependencies
 pnpm dev           # Watch mode build
 pnpm build         # Production build
-pnpm test          # Run tests
-pnpm lint          # Lint check
-pnpm typecheck     # Type check
+pnpm test          # Run tests (294 tests)
+pnpm lint          # ESLint + Prettier check
+pnpm lint:fix      # Auto-fix lint issues
+pnpm typecheck     # TypeScript strict type check
 ```
 
-## Architecture
+### Architecture
 
-Three layers:
+```
+src/canvas/       Standalone Canvas REST API client (pure fetch, no MCP dependency)
+src/tools/        MCP tool definitions with Zod input schemas
+src/resources/    MCP resource templates (syllabus, assignment description)
+src/server.ts     Factory: createCanvasMCPServer(config)
+src/stdio.ts      stdio transport entry point
+src/http.ts       HTTP transport entry point
+src/cli.ts        CLI argument parser
+```
 
-- `src/canvas/` — Standalone Canvas API client (no MCP dependency)
-- `src/tools/` — MCP tool definitions with Zod schemas
-- `src/server.ts` — `createCanvasMCPServer()` factory wiring tools + resources
+### Contributing
 
-See [AGENTS.md](AGENTS.md) for the full tool inventory and contributor guide.
+1. Fork the repo
+2. Create a feature branch (`git checkout -b feat/my-feature`)
+3. Use conventional commits (`feat:`, `fix:`, `chore:`, `test:`, `docs:`)
+4. Ensure `pnpm lint && pnpm typecheck && pnpm test` pass
+5. Open a pull request
+
+## Guides
+
+- [Student Guide](docs/student-guide.md) -- Token setup, AI client configuration, 10 example prompts
+- [Educator Guide](docs/educator-guide.md) -- Grading workflows, write operations, privacy considerations
+- [Integration Guide](docs/integration-guide.md) -- Three integration patterns with code examples
 
 ## License
 

--- a/docs/educator-guide.md
+++ b/docs/educator-guide.md
@@ -66,7 +66,7 @@ Posts a reply to a discussion topic. Supports HTML formatting.
 
 ## Write Operations Reference
 
-The server includes 8 write tools. All require appropriate Canvas permissions.
+The server includes 6 write tools. All require appropriate Canvas permissions.
 
 | Operation | Tool | What It Does | Reversible? |
 |-----------|------|--------------|-------------|

--- a/docs/educator-guide.md
+++ b/docs/educator-guide.md
@@ -1,0 +1,123 @@
+# Educator Guide
+
+Use AI assistants to streamline grading, review submissions, and manage course interactions through Canvas. This guide covers setup, grading workflows, write operations, and privacy considerations.
+
+## Setup
+
+Follow the same token and configuration steps as the [Student Guide](student-guide.md). The only difference is that your Canvas token will carry instructor-level permissions, enabling write operations like grading and commenting.
+
+Your token inherits your Canvas role. If you are an instructor or TA for a course, the MCP server can perform any action you could do in the Canvas UI.
+
+## Grading Workflows
+
+### Batch Grading with Feedback
+
+The most common workflow: review submissions, assign grades, and leave comments.
+
+**1. "List all submissions for assignment 67890 in course 12345"**
+
+Start by pulling the full submission list. This shows each student's submission status, any existing grades, and submission timestamps.
+
+**2. "Show me the submission from student 11111 on assignment 67890 in course 12345"**
+
+Drill into a specific submission to see the full details including any prior comments and attachments.
+
+**3. "Grade student 11111 on assignment 67890 in course 12345 with a B+ and comment 'Strong thesis, but the conclusion needs more evidence from primary sources.'"**
+
+This calls `grade_submission` to set the grade and `comment_on_submission` to attach feedback. The AI client typically handles both in one interaction.
+
+### Rubric-Based Grading
+
+For assignments with rubrics, you can view criteria and submit assessments per criterion.
+
+**4. "Show me the rubric for assignment 67890 in course 12345"**
+
+Retrieves the rubric with all criteria, descriptions, and point scales. Useful for calibrating your grading before you start.
+
+**5. "What's the rubric assessment for student 11111 on assignment 67890?"**
+
+Check if a student already has rubric scores before overwriting.
+
+**6. "Submit a rubric assessment for student 11111: Thesis 8/10 'Clear and well-argued', Evidence 6/10 'Needs more primary sources', Writing 9/10 'Excellent flow'"**
+
+The AI assistant will call `submit_rubric_assessment` with per-criterion scores and comments. This is idempotent -- submitting again overwrites the previous assessment.
+
+### Quiz Grading
+
+For manually-graded quiz questions (essay questions, etc.):
+
+**7. "Show me the quiz submissions for quiz 55555 in course 12345"**
+
+Lists all student submissions with scores.
+
+**8. "Show me student 11111's answers for quiz submission 99999"**
+
+Retrieves the student's actual answers for review.
+
+**9. "Score question 77777 on quiz 55555, submission 44444 with 8 points and comment 'Good analysis but missed the second part'"**
+
+Calls `score_quiz_question`. You can optionally specify which attempt to score.
+
+### Course Communication
+
+**10. "Post to the Week 5 Discussion in course 12345: 'Great points everyone. For next week, consider how this applies to the case study we discussed in lecture.'"**
+
+Posts a reply to a discussion topic. Supports HTML formatting.
+
+## Write Operations Reference
+
+The server includes 8 write tools. All require appropriate Canvas permissions.
+
+| Operation | Tool | What It Does | Reversible? |
+|-----------|------|--------------|-------------|
+| Grade a submission | `grade_submission` | Sets/updates a grade (e.g., "95", "A", "pass") | Yes (re-grade) |
+| Comment on submission | `comment_on_submission` | Adds a text comment | No (comments cannot be deleted via API) |
+| Rubric assessment | `submit_rubric_assessment` | Scores each rubric criterion with comments | Yes (re-submit) |
+| Score quiz question | `score_quiz_question` | Scores a manually-graded quiz question | Yes (re-score) |
+| Post discussion reply | `post_discussion_entry` | Posts a reply to a discussion topic | No |
+| Send message | `send_conversation` | Sends a Canvas inbox message | No |
+
+**Idempotent operations** (grade, rubric, quiz score) can be safely retried -- they overwrite the previous value. **Non-idempotent operations** (comment, discussion post, message) create new entries each time.
+
+## Privacy and Data Considerations
+
+### What the Token Can Access
+
+Your Canvas API token grants the same access as your Canvas login:
+
+- **Courses you teach**: Full read/write access to course content, submissions, grades
+- **Courses you're enrolled in**: Read access appropriate to your role
+- **Student data**: Names, submissions, grades, comments for your courses
+- **Personal data**: Your profile, inbox messages, calendar
+
+### Best Practices
+
+1. **Token lifecycle**: Set an expiration date on your token. Regenerate it at the start of each semester.
+
+2. **Don't share tokens**: Your token carries your full permissions. Never paste it in shared documents, emails, or chat. Store it only in your local configuration file.
+
+3. **Audit trail**: All actions performed via the MCP server appear in Canvas as actions taken by you. Grades set through the API show in the grade history just like manual grades.
+
+4. **FERPA compliance**: Student educational records accessed through the API are subject to the same FERPA protections as data accessed through the Canvas UI. Follow your institution's data handling policies.
+
+5. **AI-generated feedback**: If using AI to help draft feedback comments, review them before submission. You are responsible for the accuracy and appropriateness of all grading actions.
+
+6. **Minimal access**: If you only need read access (e.g., reviewing submissions without grading), consider using a token from a TA account with limited permissions.
+
+### What the Server Does NOT Do
+
+- Does not store or cache any Canvas data
+- Does not bypass Canvas permissions -- if Canvas would deny the action, the API will too
+- Does not transmit data to third parties (data flows only between your AI client and Canvas)
+- Does not have access to data outside your Canvas permissions
+
+## Troubleshooting
+
+**"You don't have permission to perform this action in this course"**
+Your Canvas role may not have the required permissions. Check your course role (instructor vs TA vs designer) in Canvas.
+
+**"Invalid data sent to Canvas"**
+Double-check the IDs and data format. For grades, Canvas accepts strings like "95", "A-", "pass", "fail", "complete", "incomplete".
+
+**"Canvas API rate limit exceeded"**
+Canvas limits API requests. If grading many submissions, pause between batches. The server handles pagination automatically, but rapid sequential writes can trigger rate limits.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1,0 +1,220 @@
+# Integration Guide
+
+Three patterns for integrating the Canvas LMS MCP server into your application.
+
+## Pattern 1: stdio Transport (Local AI Client)
+
+The simplest integration. The MCP server runs as a child process and communicates over stdin/stdout. This is the pattern used by Claude Desktop, Cursor, and VS Code.
+
+### How It Works
+
+```
+AI Client  <--stdin/stdout-->  canvas-lms-mcp process
+```
+
+The AI client spawns `canvas-lms-mcp` as a subprocess. The MCP protocol messages flow over stdio. No network exposure, no ports, no CORS.
+
+### Configuration
+
+```json
+{
+  "mcpServers": {
+    "canvas-lms": {
+      "command": "npx",
+      "args": ["-y", "canvas-lms-mcp"],
+      "env": {
+        "CANVAS_API_TOKEN": "token",
+        "CANVAS_BASE_URL": "https://school.instructure.com"
+      }
+    }
+  }
+}
+```
+
+### When to Use
+
+- Desktop AI clients (Claude Desktop, Cursor, VS Code)
+- Single-user local setups
+- Development and testing
+- Maximum simplicity -- no server management
+
+### Limitations
+
+- One process per user (no shared server)
+- Credentials baked into config (no multi-tenant)
+- Only works with clients that support MCP stdio transport
+
+## Pattern 2: HTTP Transport (Multi-Tenant Service)
+
+Run the server as an HTTP service. Each request carries its own Canvas credentials via headers, enabling multi-user deployments.
+
+### How It Works
+
+```
+Client A  --POST /mcp-->  canvas-lms-mcp HTTP server  --REST-->  Canvas API
+Client B  --POST /mcp-->       (port 3001)            --REST-->  Canvas API
+```
+
+Each `POST /mcp` request creates a fresh MCP server instance with the credentials from that request's headers. No state is shared between requests.
+
+### Running the Server
+
+```bash
+# CLI
+npx canvas-lms-mcp serve \
+  --port 3001 \
+  --allowed-origin https://your-app.example.com
+
+# Docker
+docker compose up -d
+
+# Docker with custom config
+docker run -p 3001:3001 \
+  -e CANVAS_API_TOKEN=fallback-token \
+  -e CANVAS_BASE_URL=https://school.instructure.com \
+  canvas-lms-mcp
+```
+
+### Client Request
+
+```typescript
+const response = await fetch('http://localhost:3001/mcp', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'X-Canvas-Token': userToken,
+    'X-Canvas-Base-URL': 'https://school.instructure.com',
+  },
+  body: JSON.stringify({
+    jsonrpc: '2.0',
+    method: 'tools/call',
+    params: {
+      name: 'list_courses',
+      arguments: { enrollment_state: 'active' },
+    },
+    id: 1,
+  }),
+})
+```
+
+### Per-Request vs Default Credentials
+
+The HTTP handler supports two credential modes:
+
+1. **Per-request headers**: `X-Canvas-Token` and `X-Canvas-Base-URL` override defaults
+2. **Default config**: Falls back to `--token` and `--base-url` CLI args or env vars
+
+If neither is provided, the server returns `400 Missing Canvas credentials`.
+
+### Security
+
+- **CORS**: Configured via `--allowed-origin` (default: `http://localhost:3000`). Set to your application's domain in production.
+- **SSRF protection**: The server validates `X-Canvas-Base-URL` -- rejects private IPs (127.x, 10.x, 172.16-31.x, 192.168.x, 169.254.x, localhost) and requires HTTPS in production (`NODE_ENV !== development`).
+- **No session state**: Each request is stateless. No tokens are stored server-side.
+
+### Health Check
+
+```bash
+curl http://localhost:3001/health
+# {"status":"ok"}
+```
+
+### When to Use
+
+- Web applications with multiple users
+- Hosted services (ChatGPT plugins, custom AI clients)
+- Docker/Kubernetes deployments
+- Multi-tenant setups where each user provides their own Canvas token
+
+## Pattern 3: Library Import (Embedded Server)
+
+Import the server factory or the standalone Canvas client directly into your Node.js application. No subprocess, no HTTP -- just function calls.
+
+### MCP Server Factory
+
+Create an MCP server instance and connect it to your own transport:
+
+```typescript
+import { createCanvasMCPServer } from 'canvas-lms-mcp'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+
+const { server, canvas } = createCanvasMCPServer({
+  token: process.env.CANVAS_API_TOKEN!,
+  baseUrl: process.env.CANVAS_BASE_URL!,
+})
+
+// Connect to any MCP transport
+const transport = new StdioServerTransport()
+await server.connect(transport)
+```
+
+The `server` is a standard `McpServer` instance with all 42 tools and 2 resources registered. The `canvas` is the underlying `CanvasClient` instance if you need direct API access.
+
+### Standalone Canvas Client
+
+Use the Canvas client without MCP for direct API access:
+
+```typescript
+import { CanvasClient } from 'canvas-lms-mcp/canvas'
+
+const canvas = new CanvasClient({
+  token: process.env.CANVAS_API_TOKEN!,
+  baseUrl: process.env.CANVAS_BASE_URL!,
+})
+
+// Typed, paginated API calls
+const courses = await canvas.courses.list()
+const assignment = await canvas.assignments.get(courseId, assignmentId)
+const submissions = await canvas.submissions.list(courseId, assignmentId)
+
+// Write operations
+await canvas.submissions.grade(courseId, assignmentId, userId, 'A')
+await canvas.submissions.comment(courseId, assignmentId, userId, 'Great work!')
+```
+
+### Available Canvas Client Modules
+
+The `CanvasClient` facade exposes 14 domain modules:
+
+| Module | Methods |
+|--------|---------|
+| `canvas.courses` | `list()`, `get(id)`, `getSyllabus(id)` |
+| `canvas.assignments` | `list(courseId)`, `get(courseId, id)`, `listGroups(courseId)` |
+| `canvas.submissions` | `list(courseId, assignmentId)`, `get(courseId, assignmentId, userId)`, `grade(...)`, `comment(...)` |
+| `canvas.rubrics` | `list(courseId)`, `get(courseId, id)`, `getAssessment(...)`, `submitAssessment(...)` |
+| `canvas.quizzes` | `list(courseId)`, `get(courseId, id)`, `listSubmissions(...)`, `listQuestions(...)`, `getSubmissionAnswers(id)`, `scoreQuestion(...)` |
+| `canvas.files` | `listFiles(courseId)`, `listFolders(courseId)`, `get(courseId, id)` |
+| `canvas.users` | `listStudents(courseId)`, `get(id)`, `getProfile()` |
+| `canvas.groups` | `list(courseId)`, `listMembers(groupId)` |
+| `canvas.enrollments` | `list()` |
+| `canvas.discussions` | `list(courseId)`, `get(courseId, id)`, `listAnnouncements(courseId)`, `postEntry(...)` |
+| `canvas.modules` | `list(courseId)`, `get(courseId, id)`, `listItems(courseId, moduleId)` |
+| `canvas.pages` | `list(courseId)`, `get(courseId, pageUrl)` |
+| `canvas.calendar` | `listEvents(courseId)` |
+| `canvas.conversations` | `list()`, `send(recipients, subject, body)` |
+
+### Error Handling
+
+All Canvas client methods throw `CanvasApiError` on failure:
+
+```typescript
+import { CanvasApiError } from 'canvas-lms-mcp/canvas'
+
+try {
+  const course = await canvas.courses.get(99999)
+} catch (error) {
+  if (error instanceof CanvasApiError) {
+    console.log(error.status)    // 404
+    console.log(error.endpoint)  // /api/v1/courses/99999
+    console.log(error.message)   // Not Found
+  }
+}
+```
+
+### When to Use
+
+- Building a custom MCP transport or proxy
+- Embedding Canvas access in an existing Node.js service
+- Creating batch scripts (e.g., export all grades for a course)
+- Testing and development
+- When you need the Canvas client without MCP overhead

--- a/docs/student-guide.md
+++ b/docs/student-guide.md
@@ -1,0 +1,125 @@
+# Student Guide
+
+Use AI assistants to interact with your Canvas courses through natural language. This guide walks you through setup and provides example prompts to get started.
+
+## Prerequisites
+
+- A Canvas LMS account at your institution
+- An AI client that supports MCP (Claude Desktop, Cursor, VS Code, etc.)
+- Node.js 22 or later installed on your computer
+
+## Step 1: Generate a Canvas API Token
+
+1. Log in to Canvas at your institution's URL (e.g., `https://school.instructure.com`)
+2. Click your profile picture in the top-left, then **Settings**
+3. Scroll down to **Approved Integrations**
+4. Click **+ New Access Token**
+5. Purpose: enter something like "AI Assistant"
+6. Expiry: optionally set an expiration date
+7. Click **Generate Token**
+8. **Copy the token immediately** -- it will not be shown again
+
+Keep this token private. It grants the same access as your Canvas login. If you suspect it has been compromised, return to Settings and delete it.
+
+## Step 2: Configure Claude Desktop
+
+1. Open Claude Desktop
+2. Go to **Settings > Developer > Edit Config**
+3. Add the following to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "canvas-lms": {
+      "command": "npx",
+      "args": ["-y", "canvas-lms-mcp"],
+      "env": {
+        "CANVAS_API_TOKEN": "paste-your-token-here",
+        "CANVAS_BASE_URL": "https://your-school.instructure.com"
+      }
+    }
+  }
+}
+```
+
+4. Replace `paste-your-token-here` with your actual token
+5. Replace `https://your-school.instructure.com` with your institution's Canvas URL
+6. Save and restart Claude Desktop
+
+You should see Canvas tools available in the tools menu.
+
+## Step 3: Start Asking Questions
+
+Once configured, you can use natural language to interact with Canvas. Here are 10 example prompts to try:
+
+### Courses and Navigation
+
+**1. "What courses am I enrolled in this semester?"**
+
+Lists all your active Canvas courses with names and IDs. Useful as a starting point to find course IDs for other queries.
+
+**2. "Show me the syllabus for my Biology course"**
+
+Retrieves the syllabus content directly. No more digging through course navigation to find it.
+
+**3. "What modules are in course 12345 and what's in each one?"**
+
+Lists the course modules and their items -- assignments, pages, files, quizzes -- so you can see the full course structure at a glance.
+
+### Assignments and Deadlines
+
+**4. "List all assignments in my English course and their due dates"**
+
+Shows every assignment with due dates, point values, and submission status. Helps you plan your week.
+
+**5. "What's my submission status for the midterm essay in course 12345?"**
+
+Checks whether you've submitted, what grade you received (if graded), and any comments from your instructor.
+
+### Grades and Feedback
+
+**6. "Show me my grades across all assignments in course 12345"**
+
+Lists all your submissions for a course so you can see your standing. Combined with assignment groups, you can estimate your overall grade.
+
+**7. "What feedback did my instructor leave on assignment 67890?"**
+
+Retrieves submission comments so you can read instructor feedback without opening Canvas.
+
+### Quizzes
+
+**8. "What quizzes are available in my Chemistry course?"**
+
+Lists all quizzes with their type, point values, and question counts. Helps you prepare for upcoming assessments.
+
+### Course Content
+
+**9. "Show me the discussion topics in course 12345"**
+
+Lists all discussion threads and announcements so you can stay up to date with class conversations.
+
+**10. "What files have been uploaded to my Math course?"**
+
+Lists all course files with names and sizes. Useful for finding lecture slides, handouts, or supplementary materials.
+
+## Tips
+
+- **Find your course ID**: Ask "list my courses" first. The course ID is the number shown next to each course name. You can also find it in your Canvas URL: `https://school.instructure.com/courses/12345`.
+- **Be specific**: Include course names or IDs when you have multiple courses. "Show assignments for Biology" is better than "show assignments."
+- **Read-only by default**: As a student, all operations are read-only. You can view your courses, assignments, grades, and submissions, but you cannot modify grades or course content.
+- **Token security**: Your token has the same permissions as your Canvas login. Never share it. Delete and regenerate it if you think it has been exposed.
+- **Rate limits**: Canvas has API rate limits. If you get a rate limit error, wait a moment and try again.
+
+## Troubleshooting
+
+**"Canvas token is invalid or expired"**
+Your token may have expired or been deleted. Generate a new one in Canvas Settings.
+
+**"Failed to connect to Canvas -- check your base URL"**
+Verify your `CANVAS_BASE_URL` is correct. It should be your institution's Canvas URL without a trailing `/api/v1`.
+
+**"Course not found -- check the ID"**
+Double-check the course ID. You can find it by asking "list my courses" or checking the URL in your browser.
+
+**Tools not appearing in Claude Desktop**
+Make sure you saved the config file and restarted Claude Desktop. Check that Node.js 22+ is installed by running `node --version` in your terminal.


### PR DESCRIPTION
## Summary

- Rewrite README.md with full tool inventory table (42 tools), config examples for Claude Desktop/Cursor/VS Code/ChatGPT, deployment modes, CLI reference, and environment variables
- Add `docs/student-guide.md` with token setup, AI client configuration, and 10 example prompts
- Add `docs/educator-guide.md` with grading workflows, write operations reference, and privacy/FERPA considerations
- Add `docs/integration-guide.md` with three integration patterns: stdio, HTTP multi-tenant, and library import

## Test plan

- [ ] Verify all tool names in README table match actual registered tools
- [ ] Verify config JSON examples are valid
- [ ] Verify Docker instructions match existing Dockerfile/docker-compose.yml
- [ ] Review guides for accuracy of Canvas API token instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)