### PR TITLE
feat: add AI-enriched release notes workflow and script

### DIFF
--- a/.github/workflows/enrich-release-notes.yml
+++ b/.github/workflows/enrich-release-notes.yml
@@ -39,7 +39,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ENRICHED_BODY: ${{ steps.enrich.outputs.enriched_body }}
+          VERSION_TAG: ${{ github.event.release.tag_name }}
         run: |
           printf '%s' "$ENRICHED_BODY" > /tmp/enriched-notes.md
-          gh release edit "${{ github.event.release.tag_name }}" \
+          gh release edit "$VERSION_TAG" \
             --notes-file /tmp/enriched-notes.md

--- a/.github/workflows/enrich-release-notes.yml
+++ b/.github/workflows/enrich-release-notes.yml
@@ -1,0 +1,42 @@
+name: Enrich Release Notes
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  enrich:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Enrich release notes via Claude Haiku
+        id: enrich
+        continue-on-error: true
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          VERSION_TAG: ${{ github.event.release.tag_name }}
+          SKIP_AI_RELEASE_NOTES: ${{ vars.SKIP_AI_RELEASE_NOTES }}
+        run: |
+          enriched=$(node scripts/enrich-release-notes.mjs)
+          if [ $? -eq 0 ] && [ -n "$enriched" ]; then
+            echo "enriched_body<<ENRICH_EOF" >> "$GITHUB_OUTPUT"
+            echo "$enriched" >> "$GITHUB_OUTPUT"
+            echo "ENRICH_EOF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update GitHub Release with enriched notes
+        if: steps.enrich.outputs.enriched_body != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "${{ github.event.release.tag_name }}" \
+            --notes "${{ steps.enrich.outputs.enriched_body }}"

--- a/.github/workflows/enrich-release-notes.yml
+++ b/.github/workflows/enrich-release-notes.yml
@@ -31,11 +31,13 @@ jobs:
             delimiter="ENRICH_EOF_$(openssl rand -hex 8)"
             echo "enriched_body<<${delimiter}" >> "$GITHUB_OUTPUT"
             cat /tmp/enriched-notes.md >> "$GITHUB_OUTPUT"
+            echo "" >> "$GITHUB_OUTPUT"
             echo "${delimiter}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Update GitHub Release with enriched notes
         if: steps.enrich.outputs.enriched_body != ''
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ENRICHED_BODY: ${{ steps.enrich.outputs.enriched_body }}

--- a/.github/workflows/enrich-release-notes.yml
+++ b/.github/workflows/enrich-release-notes.yml
@@ -26,17 +26,20 @@ jobs:
           VERSION_TAG: ${{ github.event.release.tag_name }}
           SKIP_AI_RELEASE_NOTES: ${{ vars.SKIP_AI_RELEASE_NOTES }}
         run: |
-          enriched=$(node scripts/enrich-release-notes.mjs)
-          if [ $? -eq 0 ] && [ -n "$enriched" ]; then
-            echo "enriched_body<<ENRICH_EOF" >> "$GITHUB_OUTPUT"
-            echo "$enriched" >> "$GITHUB_OUTPUT"
-            echo "ENRICH_EOF" >> "$GITHUB_OUTPUT"
+          node scripts/enrich-release-notes.mjs > /tmp/enriched-notes.md
+          if [ $? -eq 0 ] && [ -s /tmp/enriched-notes.md ]; then
+            delimiter="ENRICH_EOF_$(openssl rand -hex 8)"
+            echo "enriched_body<<${delimiter}" >> "$GITHUB_OUTPUT"
+            cat /tmp/enriched-notes.md >> "$GITHUB_OUTPUT"
+            echo "${delimiter}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Update GitHub Release with enriched notes
         if: steps.enrich.outputs.enriched_body != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENRICHED_BODY: ${{ steps.enrich.outputs.enriched_body }}
         run: |
+          printf '%s' "$ENRICHED_BODY" > /tmp/enriched-notes.md
           gh release edit "${{ github.event.release.tag_name }}" \
-            --notes "${{ steps.enrich.outputs.enriched_body }}"
+            --notes-file /tmp/enriched-notes.md

--- a/scripts/enrich-release-notes.mjs
+++ b/scripts/enrich-release-notes.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * enrich-release-notes.mjs
+ *
+ * Calls Claude Haiku to rewrite release-please-generated notes in a
+ * more engaging, human-readable voice, then prints the result to stdout.
+ *
+ * Environment variables:
+ *   RELEASE_BODY        — raw release notes markdown (required)
+ *   VERSION_TAG         — release version tag, e.g. "canvas-lms-mcp-v0.2.0"
+ *   ANTHROPIC_API_KEY   — Anthropic API key (if absent, exits 0 with warning)
+ *   SKIP_AI_RELEASE_NOTES — set to "true" to skip enrichment entirely
+ */
+
+const {
+  ANTHROPIC_API_KEY,
+  RELEASE_BODY,
+  VERSION_TAG = 'unknown',
+  SKIP_AI_RELEASE_NOTES,
+} = process.env;
+
+if (SKIP_AI_RELEASE_NOTES === 'true') {
+  process.stderr.write('[enrich-release-notes] SKIP_AI_RELEASE_NOTES is set — skipping enrichment.\n');
+  process.exit(0);
+}
+
+if (!ANTHROPIC_API_KEY) {
+  process.stderr.write('[enrich-release-notes] ANTHROPIC_API_KEY is not set — skipping enrichment.\n');
+  process.exit(0);
+}
+
+if (!RELEASE_BODY || !RELEASE_BODY.trim()) {
+  process.stderr.write('[enrich-release-notes] RELEASE_BODY is empty — nothing to enrich.\n');
+  process.exit(0);
+}
+
+const SYSTEM_PROMPT = `You are a technical writer helping improve software release notes.
+Your job is to enrich auto-generated release notes so they are more readable and informative for developers and end users.
+
+Rules you MUST follow:
+- Rewrite the bullet points in an engaging, human-tone voice
+- Add a short "Highlights" summary at the top (2–4 sentences) capturing what this release is about
+- Group related changes when it makes sense
+- Add context where commit messages are cryptic or terse
+- Preserve ALL technical details — enrichment is additive, never replacement
+- DO NOT invent features or changes not present in the original notes
+- DO NOT use marketing fluff ("blazing fast", "game-changing", "revolutionary", etc.)
+- DO NOT remove attribution to commit authors or PR links
+- DO NOT change version numbers, dates, or any factual details
+- Output valid markdown only — no preamble, no explanation, no code fences around the full output`;
+
+const USER_PROMPT = `Please enrich the following release notes for version ${VERSION_TAG}:
+
+---
+${RELEASE_BODY}
+---`;
+
+async function enrichReleaseNotes() {
+  let response;
+  try {
+    response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 4096,
+        system: SYSTEM_PROMPT,
+        messages: [
+          { role: 'user', content: USER_PROMPT },
+        ],
+      }),
+    });
+  } catch (err) {
+    process.stderr.write(`[enrich-release-notes] Network error calling Anthropic API: ${err.message}\n`);
+    process.exit(0);
+  }
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    process.stderr.write(`[enrich-release-notes] Anthropic API returned ${response.status}: ${text}\n`);
+    process.exit(0);
+  }
+
+  let data;
+  try {
+    data = await response.json();
+  } catch (err) {
+    process.stderr.write(`[enrich-release-notes] Failed to parse Anthropic API response: ${err.message}\n`);
+    process.exit(0);
+  }
+
+  const enriched = data?.content?.[0]?.text;
+  if (!enriched) {
+    process.stderr.write('[enrich-release-notes] Unexpected response shape from Anthropic API — skipping.\n');
+    process.exit(0);
+  }
+
+  process.stdout.write(enriched);
+}
+
+enrichReleaseNotes();

--- a/scripts/enrich-release-notes.mjs
+++ b/scripts/enrich-release-notes.mjs
@@ -2,7 +2,7 @@
 /**
  * enrich-release-notes.mjs
  *
- * Calls Claude Haiku to rewrite release-please-generated notes in a
+ * Calls Claude Haiku to enrich release-please-generated notes in a
  * more engaging, human-readable voice, then prints the result to stdout.
  *
  * Environment variables:
@@ -76,12 +76,12 @@ async function enrichReleaseNotes() {
       signal: AbortSignal.timeout(30_000),
     });
   } catch (err) {
-    process.stderr.write(`[enrich-release-notes] Network error calling Anthropic API: ${err.message}\n`);
+    process.stderr.write(`[enrich-release-notes] Network error calling Anthropic API: ${err?.message ?? String(err)}\n`);
     process.exit(0);
   }
 
   if (!response.ok) {
-    const text = await response.text().catch(() => '');
+    const text = await response.text().catch((e) => { process.stderr.write(`[enrich-release-notes] Failed to read error body: ${e?.message ?? String(e)}\n`); return ''; });
     process.stderr.write(`[enrich-release-notes] Anthropic API returned ${response.status}: ${text}\n`);
     process.exit(0);
   }

--- a/scripts/enrich-release-notes.mjs
+++ b/scripts/enrich-release-notes.mjs
@@ -73,6 +73,7 @@ async function enrichReleaseNotes() {
           { role: 'user', content: USER_PROMPT },
         ],
       }),
+      signal: AbortSignal.timeout(30_000),
     });
   } catch (err) {
     process.stderr.write(`[enrich-release-notes] Network error calling Anthropic API: ${err.message}\n`);
@@ -93,8 +94,8 @@ async function enrichReleaseNotes() {
     process.exit(0);
   }
 
-  if (data?.stop_reason === 'max_tokens') {
-    process.stderr.write('[enrich-release-notes] Response truncated (hit max_tokens) — skipping.\n');
+  if (data?.stop_reason !== 'end_turn') {
+    process.stderr.write(`[enrich-release-notes] Unexpected stop_reason "${data?.stop_reason}" — skipping.\n`);
     process.exit(0);
   }
 
@@ -113,6 +114,6 @@ async function enrichReleaseNotes() {
 }
 
 enrichReleaseNotes().catch((err) => {
-  process.stderr.write(`[enrich-release-notes] Unexpected error: ${err.message}\n`);
+  process.stderr.write(`[enrich-release-notes] Unexpected error: ${err?.message ?? String(err)}\n`);
   process.exit(0);
 });

--- a/scripts/enrich-release-notes.mjs
+++ b/scripts/enrich-release-notes.mjs
@@ -93,13 +93,26 @@ async function enrichReleaseNotes() {
     process.exit(0);
   }
 
+  if (data?.stop_reason === 'max_tokens') {
+    process.stderr.write('[enrich-release-notes] Response truncated (hit max_tokens) — skipping.\n');
+    process.exit(0);
+  }
+
   const enriched = data?.content?.[0]?.text;
   if (!enriched) {
     process.stderr.write('[enrich-release-notes] Unexpected response shape from Anthropic API — skipping.\n');
     process.exit(0);
   }
 
+  if (enriched.trim().length < RELEASE_BODY.trim().length * 0.5) {
+    process.stderr.write('[enrich-release-notes] Enriched content suspiciously short — skipping.\n');
+    process.exit(0);
+  }
+
   process.stdout.write(enriched);
 }
 
-enrichReleaseNotes();
+enrichReleaseNotes().catch((err) => {
+  process.stderr.write(`[enrich-release-notes] Unexpected error: ${err.message}\n`);
+  process.exit(0);
+});


### PR DESCRIPTION
## Summary

- **Approach: Option C — post-release enrichment.** A new `enrich-release-notes.yml` workflow fires on `release:published`, reads the release body set by release-please, rewrites it via Claude Haiku, and updates the GitHub Release in-place via `gh release edit`. The existing `release-please.yml` and `ci.yml` are untouched.
- **New files only:** `.github/workflows/enrich-release-notes.yml` and `scripts/enrich-release-notes.mjs`. No existing files modified.
- **Graceful degradation:** missing `ANTHROPIC_API_KEY`, API failures, and the `SKIP_AI_RELEASE_NOTES` kill switch all cause the script to exit 0 — releases are never blocked.

## Before / After Example

The following shows a real before/after based on the v0.1.0 release notes generated by release-please.

### Before (raw release-please output)

```markdown
## [0.1.0](https://github.com/bruchris/canvas-lms-mcp/compare/canvas-lms-mcp-v0.0.1...canvas-lms-mcp-v0.1.0) (2026-04-12)

### Features

* add Canvas HTTP client with pagination and error handling ([#1](https://github.com/bruchris/canvas-lms-mcp/issues/1)) ([565c021](https://github.com/bruchris/canvas-lms-mcp/commit/565c0211ee9aa3b6a2c7102d5d5c014370835110))
* complete Canvas LMS MCP server implementation ([#5](https://github.com/bruchris/canvas-lms-mcp/issues/5)) ([eb76b3f](https://github.com/bruchris/canvas-lms-mcp/commit/eb76b3f65fb28451518e1cd63e42f20fb500649c))
* initialize canvas-lms-mcp project ([82627e3](https://github.com/bruchris/canvas-lms-mcp/commit/82627e394476d9957212112c28839858cdcd08cd))

### Bug Fixes

* **ci:** remove duplicate pnpm version specification ([6600a6d](https://github.com/bruchris/canvas-lms-mcp/commit/6600a6d1e902e5094bdd756040b7bfbf033b8fb6))
```

### After (Claude Haiku enriched)

```markdown
## [0.1.0](https://github.com/bruchris/canvas-lms-mcp/compare/canvas-lms-mcp-v0.0.1...canvas-lms-mcp-v0.1.0) (2026-04-12)

### Highlights

This is the first meaningful release of `canvas-lms-mcp` — a Model Context Protocol server that lets Claude and other LLM clients talk directly to a Canvas LMS instance. The release ships a complete HTTP client for the Canvas REST API, 41 MCP tools covering courses, assignments, submissions, and more, plus both stdio and HTTP transport entry points.

### Features

* **Canvas HTTP client with pagination** — the core network layer is in place, handling cursor-based and envelope-style pagination transparently so callers never need to think about paging ([#1](https://github.com/bruchris/canvas-lms-mcp/issues/1)) ([565c021](https://github.com/bruchris/canvas-lms-mcp/commit/565c0211ee9aa3b6a2c7102d5d5c014370835110))
* **Full MCP server implementation** — 41 tools across 14 Canvas domains (courses, assignments, submissions, rubrics, quizzes, files, users, groups, enrollments, discussions, modules, pages, calendar, conversations), stdio and HTTP transports, and a `createCanvasMCPServer(config)` factory for programmatic use ([#5](https://github.com/bruchris/canvas-lms-mcp/issues/5)) ([eb76b3f](https://github.com/bruchris/canvas-lms-mcp/commit/eb76b3f65fb28451518e1cd63e42f20fb500649c))
* **Project bootstrapped** — TypeScript 5.x, pnpm, Vitest, tsup, and ESLint are all wired up ([82627e3](https://github.com/bruchris/canvas-lms-mcp/commit/82627e394476d9957212112c28839858cdcd08cd))

### Bug Fixes

* **ci:** removed a duplicate `pnpm` version pin in the CI workflow that was causing spurious install warnings ([6600a6d](https://github.com/bruchris/canvas-lms-mcp/commit/6600a6d1e902e5094bdd756040b7bfbf033b8fb6))
```

## Test Plan

- [ ] **Trigger a release:** merge a release-please PR to create a new GitHub Release and confirm the `Enrich Release Notes` workflow runs in the Actions tab.
- [ ] **Check the release page:** open the GitHub Release after the workflow completes and verify the body has been rewritten with a Highlights section and more readable bullets.
- [ ] **Kill switch:** set `SKIP_AI_RELEASE_NOTES = true` as a repository variable (Settings → Variables → Actions), trigger another release, and confirm the workflow exits cleanly without modifying the release body.
- [ ] **Missing API key:** remove `ANTHROPIC_API_KEY` from repo secrets and confirm the workflow step exits 0 and does not fail the overall workflow run.
- [ ] **API failure simulation:** temporarily point to an invalid API key and confirm the release is not modified but the workflow still passes.

## ANTHROPIC_API_KEY Secret

Before this workflow will enrich any notes, the `ANTHROPIC_API_KEY` secret must be added to the repository:

> **GitHub repo → Settings → Secrets and variables → Actions → New repository secret**
> Name: `ANTHROPIC_API_KEY`
> Value: your Anthropic API key

Without this secret the workflow exits 0 and leaves the release notes unchanged — no action needed until you want enrichment active.