### PR TITLE
fix: prevent GET requests with body payloads in CanvasHttpClient

### DIFF
--- a/src/canvas/client.ts
+++ b/src/canvas/client.ts
@@ -29,6 +29,13 @@ export class CanvasHttpClient {
   async request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
     const url = endpoint.startsWith('http') ? endpoint : `${this.baseUrl}${endpoint}`
 
+    const method = (options.method ?? 'GET').toUpperCase()
+    if (options.body != null && (method === 'GET' || method === 'HEAD')) {
+      throw new Error(
+        `GET requests must not include a body (Canvas CloudFront CDN rejects them with 403): ${endpoint}`,
+      )
+    }
+
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.token}`,
       'User-Agent': USER_AGENT,

--- a/tests/canvas/client.test.ts
+++ b/tests/canvas/client.test.ts
@@ -58,6 +58,36 @@ describe('CanvasHttpClient', () => {
       )
     })
 
+    it('throws if a body is passed with a GET request (no method specified)', async () => {
+      await expect(
+        client.request('/api/v1/courses', { body: JSON.stringify({ foo: 'bar' }) }),
+      ).rejects.toThrow('GET requests must not include a body')
+    })
+
+    it('throws if a body is passed with an explicit GET method', async () => {
+      await expect(
+        client.request('/api/v1/courses', { method: 'GET', body: JSON.stringify({ foo: 'bar' }) }),
+      ).rejects.toThrow('GET requests must not include a body')
+    })
+
+    it('throws if a body is passed with a HEAD request', async () => {
+      await expect(
+        client.request('/api/v1/courses', {
+          method: 'HEAD',
+          body: JSON.stringify({ foo: 'bar' }),
+        }),
+      ).rejects.toThrow('GET requests must not include a body')
+    })
+
+    it('does not throw when a body is passed with POST', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      )
+      await expect(
+        client.request('/api/v1/courses', { method: 'POST', body: JSON.stringify({ name: 'x' }) }),
+      ).resolves.toBeDefined()
+    })
+
     it('handles absolute URLs without prepending baseUrl', async () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
         new Response(JSON.stringify([]), { status: 200 }),


### PR DESCRIPTION
## Summary

- Audited all 14 Canvas domain modules — no existing violations found; all `body:` usages already pair with explicit POST/PUT methods
- Added guard in `CanvasHttpClient.request()` that throws immediately if a body is provided with GET or HEAD (Canvas CloudFront CDN migration on April 18, 2026 will return 403 for such requests)
- Added 4 regression tests: GET+body (no method), GET+body (explicit), HEAD+body, and POST+body (valid — no throw)

## Test plan

- [ ] `pnpm typecheck && pnpm test && pnpm build` all pass (298 tests)
- [ ] New tests cover the guard path and the valid POST path
- [ ] No existing tests broken

Closes [BRU-146](/BRU/issues/BRU-146)

🤖 Generated with [Claude Code](https://claude.com/claude-code)