### PR TITLE
feat: add custom_grade_status_id to CanvasSubmission type

### DIFF
--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -81,6 +81,7 @@ export interface CanvasSubmission {
   url: string | null
   attempt: number | null
   workflow_state: string
+  custom_grade_status_id?: number | null
   attachments?: CanvasAttachment[]
   submission_comments?: CanvasSubmissionComment[]
 }


### PR DESCRIPTION
## Summary

- Adds `custom_grade_status_id?: number | null` to the `CanvasSubmission` interface in `src/canvas/types.ts`
- Field tracks excused, custom, late, extended, and missing submission statuses (Canvas API April 2026 addition)
- Field is optional so existing tests pass without modification

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (294 tests)
- [x] `pnpm build` passes

Closes BRU-147

🤖 Generated with [Claude Code](https://claude.com/claude-code)