### PR TITLE
feat: add Peer Reviews domain

### DIFF
--- a/src/canvas/client.ts
+++ b/src/canvas/client.ts
@@ -26,6 +26,11 @@ export class CanvasHttpClient {
     this.maxPaginationPages = config.maxPaginationPages ?? DEFAULT_MAX_PAGINATION_PAGES
   }
 
+  /**
+   * Makes a single authenticated request to the Canvas API.
+   * Returns `undefined` (typed as `T`) when Canvas responds with 204 No Content,
+   * which is the expected response for DELETE operations.
+   */
   async request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
     const url = endpoint.startsWith('http') ? endpoint : `${this.baseUrl}${endpoint}`
 

--- a/src/canvas/client.ts
+++ b/src/canvas/client.ts
@@ -59,7 +59,7 @@ export class CanvasHttpClient {
       throw new CanvasApiError(message, response.status, endpoint)
     }
 
-    if (response.status === 204 || response.headers.get('content-length') === '0') {
+    if (response.status === 204) {
       return undefined as T
     }
 

--- a/src/canvas/client.ts
+++ b/src/canvas/client.ts
@@ -59,6 +59,10 @@ export class CanvasHttpClient {
       throw new CanvasApiError(message, response.status, endpoint)
     }
 
+    if (response.status === 204 || response.headers.get('content-length') === '0') {
+      return undefined as T
+    }
+
     return response.json() as Promise<T>
   }
 

--- a/src/canvas/index.ts
+++ b/src/canvas/index.ts
@@ -14,6 +14,7 @@ import { ModulesModule } from './modules'
 import { PagesModule } from './pages'
 import { CalendarModule } from './calendar'
 import { ConversationsModule } from './conversations'
+import { PeerReviewsModule } from './peer-reviews'
 
 export class CanvasClient {
   private client: CanvasHttpClient
@@ -31,6 +32,7 @@ export class CanvasClient {
   pages: PagesModule
   calendar: CalendarModule
   conversations: ConversationsModule
+  peerReviews: PeerReviewsModule
 
   constructor(config: CanvasClientConfig) {
     this.client = new CanvasHttpClient(config)
@@ -48,6 +50,7 @@ export class CanvasClient {
     this.pages = new PagesModule(this.client)
     this.calendar = new CalendarModule(this.client)
     this.conversations = new ConversationsModule(this.client)
+    this.peerReviews = new PeerReviewsModule(this.client)
   }
 }
 

--- a/src/canvas/peer-reviews.ts
+++ b/src/canvas/peer-reviews.ts
@@ -1,0 +1,49 @@
+import type { CanvasHttpClient } from './client'
+import type { CanvasPeerReview } from './types'
+
+export class PeerReviewsModule {
+  constructor(private client: CanvasHttpClient) {}
+
+  async listForAssignment(courseId: number, assignmentId: number): Promise<CanvasPeerReview[]> {
+    return this.client.paginate<CanvasPeerReview>(
+      `/api/v1/courses/${courseId}/assignments/${assignmentId}/peer_reviews`,
+    )
+  }
+
+  async listForSubmission(
+    courseId: number,
+    assignmentId: number,
+    submissionId: number,
+  ): Promise<CanvasPeerReview[]> {
+    return this.client.paginate<CanvasPeerReview>(
+      `/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions/${submissionId}/peer_reviews`,
+    )
+  }
+
+  async create(
+    courseId: number,
+    assignmentId: number,
+    submissionId: number,
+    userId: number,
+  ): Promise<CanvasPeerReview> {
+    return this.client.request<CanvasPeerReview>(
+      `/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions/${submissionId}/peer_reviews`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ user_id: userId }),
+      },
+    )
+  }
+
+  async delete(
+    courseId: number,
+    assignmentId: number,
+    submissionId: number,
+    userId: number,
+  ): Promise<CanvasPeerReview> {
+    return this.client.request<CanvasPeerReview>(
+      `/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions/${submissionId}/peer_reviews?user_id=${userId}`,
+      { method: 'DELETE' },
+    )
+  }
+}

--- a/src/canvas/peer-reviews.ts
+++ b/src/canvas/peer-reviews.ts
@@ -40,8 +40,8 @@ export class PeerReviewsModule {
     assignmentId: number,
     submissionId: number,
     userId: number,
-  ): Promise<CanvasPeerReview> {
-    return this.client.request<CanvasPeerReview>(
+  ): Promise<void> {
+    await this.client.request<void>(
       `/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions/${submissionId}/peer_reviews?user_id=${userId}`,
       { method: 'DELETE' },
     )

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -301,3 +301,14 @@ export interface CanvasConversation {
   message_count: number
   participants: Array<{ id: number; name: string }>
 }
+
+// --- Peer Reviews ---
+
+export interface CanvasPeerReview {
+  id: number
+  assessor_id: number
+  user_id: number
+  asset_id: number
+  asset_type: string
+  workflow_state: string
+}

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -306,9 +306,11 @@ export interface CanvasConversation {
 
 export interface CanvasPeerReview {
   id: number
+  /** The user ID of the reviewer (the person doing the reviewing). */
   assessor_id: number
+  /** The user ID of the reviewee (the student whose submission is being reviewed). */
   user_id: number
   asset_id: number
-  asset_type: string
-  workflow_state: string
+  asset_type: 'Submission'
+  workflow_state: 'assigned' | 'completed'
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -47,7 +47,7 @@ export function registerAllTools(server: McpServer, canvas: CanvasClient): void 
       try {
         const result = await tool.handler(params as Record<string, unknown>)
         const text =
-          result === undefined || result === null
+          result === undefined
             ? 'Operation completed successfully.'
             : JSON.stringify(result, null, 2)
         return {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -17,6 +17,7 @@ import { moduleTools } from './modules'
 import { pageTools } from './pages'
 import { calendarTools } from './calendar'
 import { conversationTools } from './conversations'
+import { peerReviewTools } from './peer-reviews'
 
 export function getAllTools(canvas: CanvasClient): ToolDefinition[] {
   return [
@@ -35,6 +36,7 @@ export function getAllTools(canvas: CanvasClient): ToolDefinition[] {
     ...pageTools(canvas),
     ...calendarTools(canvas),
     ...conversationTools(canvas),
+    ...peerReviewTools(canvas),
   ]
 }
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -46,8 +46,12 @@ export function registerAllTools(server: McpServer, canvas: CanvasClient): void 
     server.tool(tool.name, tool.description, tool.inputSchema, tool.annotations, async (params) => {
       try {
         const result = await tool.handler(params as Record<string, unknown>)
+        const text =
+          result === undefined || result === null
+            ? 'Operation completed successfully.'
+            : JSON.stringify(result, null, 2)
         return {
-          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          content: [{ type: 'text' as const, text }],
         }
       } catch (error) {
         if (error instanceof CanvasApiError) {

--- a/src/tools/peer-reviews.ts
+++ b/src/tools/peer-reviews.ts
@@ -1,0 +1,86 @@
+import { z } from 'zod'
+import type { CanvasClient } from '../canvas'
+import type { ToolDefinition } from './types'
+
+export function peerReviewTools(canvas: CanvasClient): ToolDefinition[] {
+  return [
+    {
+      name: 'list_peer_reviews',
+      description: 'List all peer reviews for an assignment in a course.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        assignment_id: z.number().describe('The Canvas assignment ID'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const course_id = params.course_id as number
+        const assignment_id = params.assignment_id as number
+        return canvas.peerReviews.listForAssignment(course_id, assignment_id)
+      },
+    },
+    {
+      name: 'get_submission_peer_reviews',
+      description: 'List peer reviews assigned to a specific submission.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        assignment_id: z.number().describe('The Canvas assignment ID'),
+        submission_id: z.number().describe('The Canvas submission ID'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const course_id = params.course_id as number
+        const assignment_id = params.assignment_id as number
+        const submission_id = params.submission_id as number
+        return canvas.peerReviews.listForSubmission(course_id, assignment_id, submission_id)
+      },
+    },
+    {
+      name: 'create_peer_review',
+      description: 'Assign a user to peer-review a submission.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        assignment_id: z.number().describe('The Canvas assignment ID'),
+        submission_id: z.number().describe('The Canvas submission ID'),
+        user_id: z.number().describe('The Canvas user ID of the reviewer to assign'),
+      },
+      annotations: {
+        destructiveHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const course_id = params.course_id as number
+        const assignment_id = params.assignment_id as number
+        const submission_id = params.submission_id as number
+        const user_id = params.user_id as number
+        return canvas.peerReviews.create(course_id, assignment_id, submission_id, user_id)
+      },
+    },
+    {
+      name: 'delete_peer_review',
+      description: 'Remove a peer review assignment from a submission.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        assignment_id: z.number().describe('The Canvas assignment ID'),
+        submission_id: z.number().describe('The Canvas submission ID'),
+        user_id: z.number().describe('The Canvas user ID of the reviewer to remove'),
+      },
+      annotations: {
+        destructiveHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const course_id = params.course_id as number
+        const assignment_id = params.assignment_id as number
+        const submission_id = params.submission_id as number
+        const user_id = params.user_id as number
+        return canvas.peerReviews.delete(course_id, assignment_id, submission_id, user_id)
+      },
+    },
+  ]
+}

--- a/src/tools/peer-reviews.ts
+++ b/src/tools/peer-reviews.ts
@@ -80,7 +80,6 @@ export function peerReviewTools(canvas: CanvasClient): ToolDefinition[] {
         const submission_id = params.submission_id as number
         const user_id = params.user_id as number
         await canvas.peerReviews.delete(course_id, assignment_id, submission_id, user_id)
-        return { success: true, message: 'Peer review deleted successfully' }
       },
     },
   ]

--- a/src/tools/peer-reviews.ts
+++ b/src/tools/peer-reviews.ts
@@ -79,7 +79,8 @@ export function peerReviewTools(canvas: CanvasClient): ToolDefinition[] {
         const assignment_id = params.assignment_id as number
         const submission_id = params.submission_id as number
         const user_id = params.user_id as number
-        return canvas.peerReviews.delete(course_id, assignment_id, submission_id, user_id)
+        await canvas.peerReviews.delete(course_id, assignment_id, submission_id, user_id)
+        return { success: true, message: 'Peer review deleted successfully' }
       },
     },
   ]

--- a/tests/canvas/client.test.ts
+++ b/tests/canvas/client.test.ts
@@ -156,6 +156,26 @@ describe('CanvasHttpClient', () => {
       expect(error.status).toBe(500)
       expect(error.message).toContain('500')
     })
+
+    it('returns undefined for 204 No Content without throwing', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(null, { status: 204 }),
+      )
+
+      const result = await client.request('/api/v1/courses/1/peer_reviews?user_id=5', {
+        method: 'DELETE',
+      })
+      expect(result).toBeUndefined()
+    })
+
+    it('returns undefined when content-length is 0', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response('', { status: 200, headers: { 'content-length': '0' } }),
+      )
+
+      const result = await client.request('/api/v1/courses/1/something', { method: 'DELETE' })
+      expect(result).toBeUndefined()
+    })
   })
 
   describe('paginate', () => {

--- a/tests/canvas/client.test.ts
+++ b/tests/canvas/client.test.ts
@@ -158,9 +158,7 @@ describe('CanvasHttpClient', () => {
     })
 
     it('returns undefined for 204 No Content without throwing', async () => {
-      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-        new Response(null, { status: 204 }),
-      )
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(null, { status: 204 }))
 
       const result = await client.request('/api/v1/courses/1/peer_reviews?user_id=5', {
         method: 'DELETE',

--- a/tests/canvas/client.test.ts
+++ b/tests/canvas/client.test.ts
@@ -168,7 +168,10 @@ describe('CanvasHttpClient', () => {
 
     it('attempts to parse body on 200 with content-length: 0', async () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-        new Response(JSON.stringify({ id: 1 }), { status: 200, headers: { 'content-length': '0' } }),
+        new Response(JSON.stringify({ id: 1 }), {
+          status: 200,
+          headers: { 'content-length': '0' },
+        }),
       )
 
       const result = await client.request('/api/v1/courses/1/something')

--- a/tests/canvas/client.test.ts
+++ b/tests/canvas/client.test.ts
@@ -166,13 +166,13 @@ describe('CanvasHttpClient', () => {
       expect(result).toBeUndefined()
     })
 
-    it('returns undefined when content-length is 0', async () => {
+    it('attempts to parse body on 200 with content-length: 0', async () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-        new Response('', { status: 200, headers: { 'content-length': '0' } }),
+        new Response(JSON.stringify({ id: 1 }), { status: 200, headers: { 'content-length': '0' } }),
       )
 
-      const result = await client.request('/api/v1/courses/1/something', { method: 'DELETE' })
-      expect(result).toBeUndefined()
+      const result = await client.request('/api/v1/courses/1/something')
+      expect(result).toEqual({ id: 1 })
     })
   })
 

--- a/tests/canvas/peer-reviews.test.ts
+++ b/tests/canvas/peer-reviews.test.ts
@@ -20,9 +20,7 @@ describe('PeerReviewsModule', () => {
     ])
     const result = await peerReviews.listForAssignment(1, 2)
     expect(result).toHaveLength(1)
-    expect(client.paginate).toHaveBeenCalledWith(
-      '/api/v1/courses/1/assignments/2/peer_reviews',
-    )
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/1/assignments/2/peer_reviews')
   })
 
   it('lists peer reviews for a submission', async () => {

--- a/tests/canvas/peer-reviews.test.ts
+++ b/tests/canvas/peer-reviews.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { PeerReviewsModule } from '../../src/canvas/peer-reviews'
+import { CanvasHttpClient } from '../../src/canvas/client'
+
+describe('PeerReviewsModule', () => {
+  let client: CanvasHttpClient
+  let peerReviews: PeerReviewsModule
+
+  beforeEach(() => {
+    client = new CanvasHttpClient({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+    })
+    peerReviews = new PeerReviewsModule(client)
+  })
+
+  it('lists peer reviews for an assignment', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([
+      { id: 1, assessor_id: 10, asset_id: 20, user_id: 10, workflow_state: 'assigned' },
+    ])
+    const result = await peerReviews.listForAssignment(1, 2)
+    expect(result).toHaveLength(1)
+    expect(client.paginate).toHaveBeenCalledWith(
+      '/api/v1/courses/1/assignments/2/peer_reviews',
+    )
+  })
+
+  it('lists peer reviews for a submission', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([
+      { id: 2, assessor_id: 11, asset_id: 30, user_id: 11, workflow_state: 'completed' },
+    ])
+    const result = await peerReviews.listForSubmission(1, 2, 3)
+    expect(result).toHaveLength(1)
+    expect(client.paginate).toHaveBeenCalledWith(
+      '/api/v1/courses/1/assignments/2/submissions/3/peer_reviews',
+    )
+  })
+
+  it('creates a peer review via POST with user_id in body', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce({
+      id: 3,
+      assessor_id: 42,
+      asset_id: 99,
+      user_id: 42,
+      workflow_state: 'assigned',
+    })
+    const result = await peerReviews.create(1, 2, 3, 42)
+    expect(result).toMatchObject({ id: 3, user_id: 42 })
+    expect(client.request).toHaveBeenCalledWith(
+      '/api/v1/courses/1/assignments/2/submissions/3/peer_reviews',
+      {
+        method: 'POST',
+        body: JSON.stringify({ user_id: 42 }),
+      },
+    )
+  })
+
+  it('deletes a peer review via DELETE with user_id as query param', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce(undefined)
+    await peerReviews.delete(1, 2, 3, 42)
+    expect(client.request).toHaveBeenCalledWith(
+      '/api/v1/courses/1/assignments/2/submissions/3/peer_reviews?user_id=42',
+      { method: 'DELETE' },
+    )
+  })
+})

--- a/tests/tools/peer-reviews.test.ts
+++ b/tests/tools/peer-reviews.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { CanvasClient } from '../../src/canvas'
+import type { CanvasPeerReview } from '../../src/canvas/types'
+import { peerReviewTools } from '../../src/tools/peer-reviews'
+
+describe('peerReviewTools', () => {
+  const mockPeerReview: CanvasPeerReview = {
+    id: 1,
+    assessor_id: 5,
+    user_id: 10,
+    asset_id: 100,
+    asset_type: 'Submission',
+    workflow_state: 'assigned',
+  }
+
+  function buildMockCanvas(): CanvasClient {
+    return {
+      peerReviews: {
+        listForAssignment: vi.fn().mockResolvedValue([mockPeerReview]),
+        listForSubmission: vi.fn().mockResolvedValue([mockPeerReview]),
+        create: vi.fn().mockResolvedValue(mockPeerReview),
+        delete: vi.fn().mockResolvedValue(mockPeerReview),
+      },
+    } as unknown as CanvasClient
+  }
+
+  it('returns an array with 4 tool definitions', () => {
+    expect(peerReviewTools(buildMockCanvas())).toHaveLength(4)
+  })
+
+  it('exports tools with correct names', () => {
+    const names = peerReviewTools(buildMockCanvas()).map((t) => t.name)
+    expect(names).toEqual([
+      'list_peer_reviews',
+      'get_submission_peer_reviews',
+      'create_peer_review',
+      'delete_peer_review',
+    ])
+  })
+
+  describe('list_peer_reviews', () => {
+    it('has read-only annotations', () => {
+      const tool = peerReviewTools(buildMockCanvas()).find((t) => t.name === 'list_peer_reviews')!
+      expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+    })
+
+    it('delegates to canvas.peerReviews.listForAssignment', async () => {
+      const canvas = buildMockCanvas()
+      const tool = peerReviewTools(canvas).find((t) => t.name === 'list_peer_reviews')!
+      await tool.handler({ course_id: 1, assignment_id: 2 })
+      expect(canvas.peerReviews.listForAssignment).toHaveBeenCalledWith(1, 2)
+    })
+  })
+
+  describe('get_submission_peer_reviews', () => {
+    it('has read-only annotations', () => {
+      const tool = peerReviewTools(buildMockCanvas()).find(
+        (t) => t.name === 'get_submission_peer_reviews',
+      )!
+      expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+    })
+
+    it('delegates to canvas.peerReviews.listForSubmission', async () => {
+      const canvas = buildMockCanvas()
+      const tool = peerReviewTools(canvas).find((t) => t.name === 'get_submission_peer_reviews')!
+      await tool.handler({ course_id: 1, assignment_id: 2, submission_id: 3 })
+      expect(canvas.peerReviews.listForSubmission).toHaveBeenCalledWith(1, 2, 3)
+    })
+  })
+
+  describe('create_peer_review', () => {
+    it('has destructive and openWorld annotations', () => {
+      const tool = peerReviewTools(buildMockCanvas()).find((t) => t.name === 'create_peer_review')!
+      expect(tool.annotations).toEqual({ destructiveHint: true, openWorldHint: true })
+    })
+
+    it('delegates to canvas.peerReviews.create', async () => {
+      const canvas = buildMockCanvas()
+      const tool = peerReviewTools(canvas).find((t) => t.name === 'create_peer_review')!
+      await tool.handler({ course_id: 1, assignment_id: 2, submission_id: 3, user_id: 5 })
+      expect(canvas.peerReviews.create).toHaveBeenCalledWith(1, 2, 3, 5)
+    })
+  })
+
+  describe('delete_peer_review', () => {
+    it('has destructive and openWorld annotations', () => {
+      const tool = peerReviewTools(buildMockCanvas()).find((t) => t.name === 'delete_peer_review')!
+      expect(tool.annotations).toEqual({ destructiveHint: true, openWorldHint: true })
+    })
+
+    it('delegates to canvas.peerReviews.delete', async () => {
+      const canvas = buildMockCanvas()
+      const tool = peerReviewTools(canvas).find((t) => t.name === 'delete_peer_review')!
+      await tool.handler({ course_id: 1, assignment_id: 2, submission_id: 3, user_id: 5 })
+      expect(canvas.peerReviews.delete).toHaveBeenCalledWith(1, 2, 3, 5)
+    })
+  })
+})

--- a/tests/tools/peer-reviews.test.ts
+++ b/tests/tools/peer-reviews.test.ts
@@ -19,7 +19,7 @@ describe('peerReviewTools', () => {
         listForAssignment: vi.fn().mockResolvedValue([mockPeerReview]),
         listForSubmission: vi.fn().mockResolvedValue([mockPeerReview]),
         create: vi.fn().mockResolvedValue(mockPeerReview),
-        delete: vi.fn().mockResolvedValue(mockPeerReview),
+        delete: vi.fn().mockResolvedValue(undefined),
       },
     } as unknown as CanvasClient
   }

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -45,7 +45,7 @@ function buildFullMockCanvas(): CanvasClient {
       listForAssignment: async () => [],
       listForSubmission: async () => [],
       create: async () => ({}),
-      delete: async () => ({}),
+      delete: async () => undefined,
     },
   } as unknown as CanvasClient
 }

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -41,6 +41,12 @@ function buildFullMockCanvas(): CanvasClient {
     pages: { list: async () => [], get: async () => ({}) },
     calendar: { list: async () => [] },
     conversations: { list: async () => [], send: async () => [] },
+    peerReviews: {
+      listForAssignment: async () => [],
+      listForSubmission: async () => [],
+      create: async () => ({}),
+      delete: async () => ({}),
+    },
   } as unknown as CanvasClient
 }
 
@@ -111,8 +117,13 @@ describe('getAllTools', () => {
     // Conversations (2)
     expect(names).toContain('list_conversations')
     expect(names).toContain('send_conversation')
+    // Peer Reviews (4)
+    expect(names).toContain('list_peer_reviews')
+    expect(names).toContain('get_submission_peer_reviews')
+    expect(names).toContain('create_peer_review')
+    expect(names).toContain('delete_peer_review')
 
-    expect(tools).toHaveLength(42)
+    expect(tools).toHaveLength(46)
   })
 
   it('all tools have openWorldHint: true', () => {
@@ -130,6 +141,8 @@ describe('getAllTools', () => {
       'score_quiz_question',
       'post_discussion_entry',
       'send_conversation',
+      'create_peer_review',
+      'delete_peer_review',
     ]
     const tools = getAllTools(buildFullMockCanvas())
     for (const name of writeToolNames) {
@@ -146,6 +159,8 @@ describe('getAllTools', () => {
       'score_quiz_question',
       'post_discussion_entry',
       'send_conversation',
+      'create_peer_review',
+      'delete_peer_review',
     ])
     const tools = getAllTools(buildFullMockCanvas())
     for (const tool of tools) {


### PR DESCRIPTION
## Summary

- Adds `PeerReviewsModule` (`src/canvas/peer-reviews.ts`) with `listForAssignment`, `listForSubmission`, `create`, `delete`
- Adds `CanvasPeerReview` interface to `src/canvas/types.ts`
- Registers `peerReviews` on `CanvasClient` facade in `src/canvas/index.ts`
- Adds 4 MCP tools in `src/tools/peer-reviews.ts`: `list_peer_reviews`, `get_submission_peer_reviews`, `create_peer_review`, `delete_peer_review`
- Registers tools in `src/tools/index.ts` via `getAllTools()`
- Tests in `tests/tools/peer-reviews.test.ts` covering happy paths for all 4 tools
- Updates registry test: tool count 42→46, adds peer review write tool names to write/read annotation sets

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 308 tests pass (41 files)
- [x] `pnpm build` — ESM + CJS build success

Closes BRU-152

🤖 Generated with [Claude Code](https://claude.com/claude-code)