### PR TITLE
docs: add one-liner MCP setup commands to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,42 @@ MCP server for [Canvas LMS](https://www.instructure.com/canvas). Read courses, a
 4. Give it a name (e.g., "MCP Server") and click **Generate Token**
 5. Copy the token immediately -- you won't see it again
 
-### 2. Configure Your AI Client
+### 2. One Command Setup
+
+```bash
+npx add-mcp canvas-lms-mcp
+```
+
+This auto-detects your installed AI clients (Claude Code, Cursor, VS Code, etc.) and configures them. You will be prompted for your Canvas API token and base URL.
+
+### Client-Specific Commands
+
+**Claude Code**
+
+```bash
+claude mcp add canvas-lms --env CANVAS_API_TOKEN=your-token --env CANVAS_BASE_URL=https://school.instructure.com -- npx -y canvas-lms-mcp
+```
+
+**VS Code**
+
+```bash
+code --add-mcp '{"name":"canvas-lms","command":"npx","args":["-y","canvas-lms-mcp"],"env":{"CANVAS_API_TOKEN":"your-token","CANVAS_BASE_URL":"https://school.instructure.com"}}'
+```
+
+**Gemini CLI**
+
+```bash
+gemini mcp add canvas-lms npx canvas-lms-mcp
+```
+
+**Codex CLI**
+
+```bash
+codex mcp add canvas-lms -- npx canvas-lms-mcp
+```
+
+<details>
+<summary>Manual Configuration</summary>
 
 #### Claude Desktop
 
@@ -77,6 +112,25 @@ Add to your VS Code settings (`settings.json`):
 }
 ```
 
+#### Windsurf
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "canvas-lms": {
+      "command": "npx",
+      "args": ["-y", "canvas-lms-mcp"],
+      "env": {
+        "CANVAS_API_TOKEN": "your-token-here",
+        "CANVAS_BASE_URL": "https://your-institution.instructure.com"
+      }
+    }
+  }
+}
+```
+
 #### ChatGPT / HTTP Clients
 
 Run the server in HTTP mode, then point your client at the endpoint:
@@ -88,6 +142,8 @@ npx canvas-lms-mcp serve --port 3001 \
 ```
 
 The MCP endpoint is `http://localhost:3001/mcp`. Per-request credentials can be passed via `X-Canvas-Token` and `X-Canvas-Base-URL` headers.
+
+</details>
 
 ## Example Prompts
 


### PR DESCRIPTION
## Summary

- Adds `npx add-mcp canvas-lms-mcp` as the primary "one command" setup option (auto-detects installed AI clients)
- Adds client-specific one-liners for Claude Code, VS Code, Gemini CLI, and Codex CLI
- Moves existing manual JSON config blocks (Claude Desktop, Cursor, VS Code, ChatGPT) into a collapsible `<details>` block
- Adds Windsurf manual config (`~/.codeium/windsurf/mcp_config.json`)

Closes BRU-156.

## Test plan

- [ ] Verify "2. One Command Setup" section appears immediately after "Get a Canvas API Token"
- [ ] Verify all four client-specific one-liner commands are present
- [ ] Verify manual configs are inside collapsible `<details>` block and still complete
- [ ] Verify Windsurf config is included in the manual section

🤖 Generated with [Claude Code](https://claude.com/claude-code)