### PR TITLE
chore: improve npm and GitHub discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![npm](https://img.shields.io/npm/v/%40bruchris%2Fcanvas-lms-mcp)](https://www.npmjs.com/package/@bruchris/canvas-lms-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org)
+[![npm downloads](https://img.shields.io/npm/dw/@bruchris/canvas-lms-mcp)](https://www.npmjs.com/package/@bruchris/canvas-lms-mcp)
 
 MCP server for [Canvas LMS](https://www.instructure.com/canvas). Read courses, assignments, submissions, rubrics, quizzes; grade and comment from any AI agent.
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,17 @@
     "mcp",
     "model-context-protocol",
     "education",
-    "grading"
+    "grading",
+    "ai-agent",
+    "claude-desktop",
+    "cursor",
+    "vscode",
+    "instructure",
+    "education-technology",
+    "edtech",
+    "teacher",
+    "student",
+    "grading-automation"
   ],
   "author": "Christian Bru",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Expanded `package.json` keywords from 6 to 16 (added: `ai-agent`, `claude-desktop`, `cursor`, `vscode`, `instructure`, `education-technology`, `edtech`, `teacher`, `student`, `grading-automation`)
- Added npm weekly downloads badge to README (5 badges total)

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (314 tests)
- [x] `pnpm build` passes
- [x] 16 keywords in package.json
- [x] 5 badges in README (CI, npm version, License, Node, npm downloads)

Closes [BRU-225](/BRU/issues/BRU-225)

🤖 Generated with [Claude Code](https://claude.com/claude-code)