### PR TITLE
feat: add Account & Admin domain with 6 tools

### DIFF
--- a/src/canvas/accounts.ts
+++ b/src/canvas/accounts.ts
@@ -1,0 +1,34 @@
+import type { CanvasHttpClient } from './client'
+import type { CanvasAccount, CanvasAccountReport, CanvasCourse, CanvasUser } from './types'
+
+export class AccountsModule {
+  constructor(private client: CanvasHttpClient) {}
+
+  async get(accountId: number): Promise<CanvasAccount> {
+    return this.client.request<CanvasAccount>(`/api/v1/accounts/${accountId}`)
+  }
+
+  async list(): Promise<CanvasAccount[]> {
+    return this.client.paginate<CanvasAccount>('/api/v1/accounts')
+  }
+
+  async listSubAccounts(accountId: number): Promise<CanvasAccount[]> {
+    return this.client.paginate<CanvasAccount>(`/api/v1/accounts/${accountId}/sub_accounts`)
+  }
+
+  async listCourses(accountId: number, params?: { search_term?: string }): Promise<CanvasCourse[]> {
+    const query: Record<string, string> = {}
+    if (params?.search_term) query.search_term = params.search_term
+    return this.client.paginate<CanvasCourse>(`/api/v1/accounts/${accountId}/courses`, Object.keys(query).length ? query : undefined)
+  }
+
+  async listUsers(accountId: number, params?: { search_term?: string }): Promise<CanvasUser[]> {
+    const query: Record<string, string> = {}
+    if (params?.search_term) query.search_term = params.search_term
+    return this.client.paginate<CanvasUser>(`/api/v1/accounts/${accountId}/users`, Object.keys(query).length ? query : undefined)
+  }
+
+  async getReports(accountId: number): Promise<CanvasAccountReport[]> {
+    return this.client.request<CanvasAccountReport[]>(`/api/v1/accounts/${accountId}/reports`)
+  }
+}

--- a/src/canvas/accounts.ts
+++ b/src/canvas/accounts.ts
@@ -19,13 +19,19 @@ export class AccountsModule {
   async listCourses(accountId: number, params?: { search_term?: string }): Promise<CanvasCourse[]> {
     const query: Record<string, string> = {}
     if (params?.search_term) query.search_term = params.search_term
-    return this.client.paginate<CanvasCourse>(`/api/v1/accounts/${accountId}/courses`, Object.keys(query).length ? query : undefined)
+    return this.client.paginate<CanvasCourse>(
+      `/api/v1/accounts/${accountId}/courses`,
+      Object.keys(query).length ? query : undefined,
+    )
   }
 
   async listUsers(accountId: number, params?: { search_term?: string }): Promise<CanvasUser[]> {
     const query: Record<string, string> = {}
     if (params?.search_term) query.search_term = params.search_term
-    return this.client.paginate<CanvasUser>(`/api/v1/accounts/${accountId}/users`, Object.keys(query).length ? query : undefined)
+    return this.client.paginate<CanvasUser>(
+      `/api/v1/accounts/${accountId}/users`,
+      Object.keys(query).length ? query : undefined,
+    )
   }
 
   async getReports(accountId: number): Promise<CanvasAccountReport[]> {

--- a/src/canvas/index.ts
+++ b/src/canvas/index.ts
@@ -15,6 +15,7 @@ import { PagesModule } from './pages'
 import { CalendarModule } from './calendar'
 import { ConversationsModule } from './conversations'
 import { PeerReviewsModule } from './peer-reviews'
+import { AccountsModule } from './accounts'
 
 export class CanvasClient {
   private client: CanvasHttpClient
@@ -33,6 +34,7 @@ export class CanvasClient {
   calendar: CalendarModule
   conversations: ConversationsModule
   peerReviews: PeerReviewsModule
+  accounts: AccountsModule
 
   constructor(config: CanvasClientConfig) {
     this.client = new CanvasHttpClient(config)
@@ -51,6 +53,7 @@ export class CanvasClient {
     this.calendar = new CalendarModule(this.client)
     this.conversations = new ConversationsModule(this.client)
     this.peerReviews = new PeerReviewsModule(this.client)
+    this.accounts = new AccountsModule(this.client)
   }
 }
 

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -302,6 +302,35 @@ export interface CanvasConversation {
   participants: Array<{ id: number; name: string }>
 }
 
+// --- Accounts ---
+
+export interface CanvasAccount {
+  id: number
+  name: string
+  parent_account_id: number | null
+  root_account_id: number | null
+  uuid: string
+  default_storage_quota_mb: number
+  default_user_storage_quota_mb: number
+  default_group_storage_quota_mb: number
+  workflow_state: 'active' | 'deleted'
+}
+
+export interface CanvasAccountReport {
+  report: string
+  title: string
+  parameters_schema: Record<string, unknown>[] | null
+  last_run: {
+    id: number
+    report: string
+    status: string
+    created_at: string
+    started_at: string | null
+    ended_at: string | null
+    attachment: CanvasFile | null
+  } | null
+}
+
 // --- Peer Reviews ---
 
 export interface CanvasPeerReview {

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -319,11 +319,11 @@ export interface CanvasAccount {
 export interface CanvasAccountReport {
   report: string
   title: string
-  parameters_schema: Record<string, unknown>[] | null
+  parameters: Record<string, { required?: boolean; description?: string }> | null
   last_run: {
     id: number
     report: string
-    status: string
+    status: 'created' | 'running' | 'complete' | 'error'
     created_at: string
     started_at: string | null
     ended_at: string | null

--- a/src/tools/accounts.ts
+++ b/src/tools/accounts.ts
@@ -1,0 +1,96 @@
+import { z } from 'zod'
+import type { CanvasClient } from '../canvas'
+import type { ToolDefinition } from './types'
+
+export function accountTools(canvas: CanvasClient): ToolDefinition[] {
+  return [
+    {
+      name: 'get_account',
+      description: 'Get details for a Canvas account by ID.',
+      inputSchema: {
+        account_id: z.number().describe('The Canvas account ID'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        return canvas.accounts.get(params.account_id as number)
+      },
+    },
+    {
+      name: 'list_accounts',
+      description: 'List all accounts accessible to the authenticated user.',
+      inputSchema: {},
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async () => {
+        return canvas.accounts.list()
+      },
+    },
+    {
+      name: 'list_sub_accounts',
+      description: 'List sub-accounts under a given Canvas account.',
+      inputSchema: {
+        account_id: z.number().describe('The parent Canvas account ID'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        return canvas.accounts.listSubAccounts(params.account_id as number)
+      },
+    },
+    {
+      name: 'list_account_courses',
+      description: 'List courses under a given Canvas account.',
+      inputSchema: {
+        account_id: z.number().describe('The Canvas account ID'),
+        search_term: z.string().optional().describe('Search courses by name or course code'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        return canvas.accounts.listCourses(params.account_id as number, {
+          search_term: params.search_term as string | undefined,
+        })
+      },
+    },
+    {
+      name: 'list_account_users',
+      description: 'List users in a Canvas account.',
+      inputSchema: {
+        account_id: z.number().describe('The Canvas account ID'),
+        search_term: z.string().optional().describe('Search users by name, email, or login'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        return canvas.accounts.listUsers(params.account_id as number, {
+          search_term: params.search_term as string | undefined,
+        })
+      },
+    },
+    {
+      name: 'get_account_reports',
+      description: 'List available report types for a Canvas account.',
+      inputSchema: {
+        account_id: z.number().describe('The Canvas account ID'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        return canvas.accounts.getReports(params.account_id as number)
+      },
+    },
+  ]
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -18,6 +18,7 @@ import { pageTools } from './pages'
 import { calendarTools } from './calendar'
 import { conversationTools } from './conversations'
 import { peerReviewTools } from './peer-reviews'
+import { accountTools } from './accounts'
 
 export function getAllTools(canvas: CanvasClient): ToolDefinition[] {
   return [
@@ -37,6 +38,7 @@ export function getAllTools(canvas: CanvasClient): ToolDefinition[] {
     ...calendarTools(canvas),
     ...conversationTools(canvas),
     ...peerReviewTools(canvas),
+    ...accountTools(canvas),
   ]
 }
 

--- a/tests/canvas/accounts.test.ts
+++ b/tests/canvas/accounts.test.ts
@@ -45,7 +45,9 @@ describe('AccountsModule', () => {
   it('lists courses with a search term', async () => {
     vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
     await accounts.listCourses(1, { search_term: 'math' })
-    expect(client.paginate).toHaveBeenCalledWith('/api/v1/accounts/1/courses', { search_term: 'math' })
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/accounts/1/courses', {
+      search_term: 'math',
+    })
   })
 
   it('lists users under an account without filter', async () => {
@@ -56,7 +58,9 @@ describe('AccountsModule', () => {
   })
 
   it('gets available report types for an account', async () => {
-    vi.spyOn(client, 'request').mockResolvedValueOnce([{ report: 'grade_export_csv', title: 'Grade Export' }])
+    vi.spyOn(client, 'request').mockResolvedValueOnce([
+      { report: 'grade_export_csv', title: 'Grade Export' },
+    ])
     const result = await accounts.getReports(1)
     expect(result).toHaveLength(1)
     expect(client.request).toHaveBeenCalledWith('/api/v1/accounts/1/reports')

--- a/tests/canvas/accounts.test.ts
+++ b/tests/canvas/accounts.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { AccountsModule } from '../../src/canvas/accounts'
+import { CanvasHttpClient } from '../../src/canvas/client'
+
+describe('AccountsModule', () => {
+  let client: CanvasHttpClient
+  let accounts: AccountsModule
+
+  beforeEach(() => {
+    client = new CanvasHttpClient({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+    })
+    accounts = new AccountsModule(client)
+  })
+
+  it('gets a single account', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce({ id: 1, name: 'Default' })
+    const result = await accounts.get(1)
+    expect(result).toMatchObject({ id: 1, name: 'Default' })
+    expect(client.request).toHaveBeenCalledWith('/api/v1/accounts/1')
+  })
+
+  it('lists all accessible accounts', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([{ id: 1, name: 'Default' }])
+    const result = await accounts.list()
+    expect(result).toHaveLength(1)
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/accounts')
+  })
+
+  it('lists sub-accounts', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([{ id: 2, name: 'Sub' }])
+    const result = await accounts.listSubAccounts(1)
+    expect(result).toHaveLength(1)
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/accounts/1/sub_accounts')
+  })
+
+  it('lists courses under an account without filter', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([{ id: 10, name: 'Course A' }])
+    const result = await accounts.listCourses(1)
+    expect(result).toHaveLength(1)
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/accounts/1/courses', undefined)
+  })
+
+  it('lists courses with a search term', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+    await accounts.listCourses(1, { search_term: 'math' })
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/accounts/1/courses', { search_term: 'math' })
+  })
+
+  it('lists users under an account without filter', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([{ id: 5, name: 'Alice' }])
+    const result = await accounts.listUsers(1)
+    expect(result).toHaveLength(1)
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/accounts/1/users', undefined)
+  })
+
+  it('gets available report types for an account', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce([{ report: 'grade_export_csv', title: 'Grade Export' }])
+    const result = await accounts.getReports(1)
+    expect(result).toHaveLength(1)
+    expect(client.request).toHaveBeenCalledWith('/api/v1/accounts/1/reports')
+  })
+})

--- a/tests/tools/accounts.test.ts
+++ b/tests/tools/accounts.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { CanvasClient } from '../../src/canvas'
+import type { CanvasAccount, CanvasAccountReport, CanvasCourse, CanvasUser } from '../../src/canvas/types'
+import { accountTools } from '../../src/tools/accounts'
+
+describe('accountTools', () => {
+  const mockAccount: CanvasAccount = {
+    id: 1,
+    name: 'Default Account',
+    parent_account_id: null,
+    root_account_id: null,
+    uuid: 'abc-123',
+    default_storage_quota_mb: 500,
+    default_user_storage_quota_mb: 50,
+    default_group_storage_quota_mb: 50,
+    workflow_state: 'active',
+  }
+
+  const mockCourse: CanvasCourse = {
+    id: 10,
+    name: 'Intro to Math',
+    course_code: 'MATH101',
+    workflow_state: 'available',
+  }
+
+  const mockUser: CanvasUser = {
+    id: 5,
+    name: 'Alice',
+    sortable_name: 'Alice',
+    short_name: 'Alice',
+    login_id: 'alice@example.com',
+    email: 'alice@example.com',
+    created_at: '2026-01-01T00:00:00Z',
+  }
+
+  const mockReport: CanvasAccountReport = {
+    report: 'grade_export_csv',
+    title: 'Grade Export',
+    parameters_schema: null,
+    last_run: null,
+  }
+
+  function buildMockCanvas(): CanvasClient {
+    return {
+      accounts: {
+        get: vi.fn().mockResolvedValue(mockAccount),
+        list: vi.fn().mockResolvedValue([mockAccount]),
+        listSubAccounts: vi.fn().mockResolvedValue([mockAccount]),
+        listCourses: vi.fn().mockResolvedValue([mockCourse]),
+        listUsers: vi.fn().mockResolvedValue([mockUser]),
+        getReports: vi.fn().mockResolvedValue([mockReport]),
+      },
+    } as unknown as CanvasClient
+  }
+
+  it('returns 6 tool definitions', () => {
+    expect(accountTools(buildMockCanvas())).toHaveLength(6)
+  })
+
+  it('exports tools with correct names', () => {
+    const names = accountTools(buildMockCanvas()).map((t) => t.name)
+    expect(names).toEqual([
+      'get_account',
+      'list_accounts',
+      'list_sub_accounts',
+      'list_account_courses',
+      'list_account_users',
+      'get_account_reports',
+    ])
+  })
+
+  describe('get_account', () => {
+    it('has read-only annotations', () => {
+      const tool = accountTools(buildMockCanvas()).find((t) => t.name === 'get_account')!
+      expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+    })
+
+    it('delegates to canvas.accounts.get', async () => {
+      const canvas = buildMockCanvas()
+      const tool = accountTools(canvas).find((t) => t.name === 'get_account')!
+      await tool.handler({ account_id: 1 })
+      expect(canvas.accounts.get).toHaveBeenCalledWith(1)
+    })
+  })
+
+  describe('list_accounts', () => {
+    it('has read-only annotations', () => {
+      const tool = accountTools(buildMockCanvas()).find((t) => t.name === 'list_accounts')!
+      expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+    })
+
+    it('delegates to canvas.accounts.list', async () => {
+      const canvas = buildMockCanvas()
+      const tool = accountTools(canvas).find((t) => t.name === 'list_accounts')!
+      await tool.handler({})
+      expect(canvas.accounts.list).toHaveBeenCalled()
+    })
+  })
+
+  describe('list_sub_accounts', () => {
+    it('delegates to canvas.accounts.listSubAccounts', async () => {
+      const canvas = buildMockCanvas()
+      const tool = accountTools(canvas).find((t) => t.name === 'list_sub_accounts')!
+      await tool.handler({ account_id: 1 })
+      expect(canvas.accounts.listSubAccounts).toHaveBeenCalledWith(1)
+    })
+  })
+
+  describe('list_account_courses', () => {
+    it('delegates to canvas.accounts.listCourses without search_term', async () => {
+      const canvas = buildMockCanvas()
+      const tool = accountTools(canvas).find((t) => t.name === 'list_account_courses')!
+      await tool.handler({ account_id: 1 })
+      expect(canvas.accounts.listCourses).toHaveBeenCalledWith(1, { search_term: undefined })
+    })
+
+    it('delegates to canvas.accounts.listCourses with search_term', async () => {
+      const canvas = buildMockCanvas()
+      const tool = accountTools(canvas).find((t) => t.name === 'list_account_courses')!
+      await tool.handler({ account_id: 1, search_term: 'math' })
+      expect(canvas.accounts.listCourses).toHaveBeenCalledWith(1, { search_term: 'math' })
+    })
+  })
+
+  describe('list_account_users', () => {
+    it('delegates to canvas.accounts.listUsers', async () => {
+      const canvas = buildMockCanvas()
+      const tool = accountTools(canvas).find((t) => t.name === 'list_account_users')!
+      await tool.handler({ account_id: 1 })
+      expect(canvas.accounts.listUsers).toHaveBeenCalledWith(1, { search_term: undefined })
+    })
+  })
+
+  describe('get_account_reports', () => {
+    it('delegates to canvas.accounts.getReports', async () => {
+      const canvas = buildMockCanvas()
+      const tool = accountTools(canvas).find((t) => t.name === 'get_account_reports')!
+      await tool.handler({ account_id: 1 })
+      expect(canvas.accounts.getReports).toHaveBeenCalledWith(1)
+    })
+  })
+})

--- a/tests/tools/accounts.test.ts
+++ b/tests/tools/accounts.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi } from 'vitest'
 import type { CanvasClient } from '../../src/canvas'
-import type { CanvasAccount, CanvasAccountReport, CanvasCourse, CanvasUser } from '../../src/canvas/types'
+import type {
+  CanvasAccount,
+  CanvasAccountReport,
+  CanvasCourse,
+  CanvasUser,
+} from '../../src/canvas/types'
 import { accountTools } from '../../src/tools/accounts'
 
 describe('accountTools', () => {
@@ -36,7 +41,7 @@ describe('accountTools', () => {
   const mockReport: CanvasAccountReport = {
     report: 'grade_export_csv',
     title: 'Grade Export',
-    parameters_schema: null,
+    parameters: null,
     last_run: null,
   }
 

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -47,6 +47,14 @@ function buildFullMockCanvas(): CanvasClient {
       create: async () => ({}),
       delete: async () => undefined,
     },
+    accounts: {
+      get: async () => ({}),
+      list: async () => [],
+      listSubAccounts: async () => [],
+      listCourses: async () => [],
+      listUsers: async () => [],
+      getReports: async () => [],
+    },
   } as unknown as CanvasClient
 }
 
@@ -56,7 +64,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 42 tools across all domains', () => {
+  it('returns all 52 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 
@@ -122,8 +130,15 @@ describe('getAllTools', () => {
     expect(names).toContain('get_submission_peer_reviews')
     expect(names).toContain('create_peer_review')
     expect(names).toContain('delete_peer_review')
+    // Accounts (6)
+    expect(names).toContain('get_account')
+    expect(names).toContain('list_accounts')
+    expect(names).toContain('list_sub_accounts')
+    expect(names).toContain('list_account_courses')
+    expect(names).toContain('list_account_users')
+    expect(names).toContain('get_account_reports')
 
-    expect(tools).toHaveLength(46)
+    expect(tools).toHaveLength(52)
   })
 
   it('all tools have openWorldHint: true', () => {


### PR DESCRIPTION
## Summary

- Adds `AccountsModule` canvas client class (`src/canvas/accounts.ts`) with 6 methods: `get`, `list`, `listSubAccounts`, `listCourses`, `listUsers`, `getReports`
- Adds `CanvasAccount` and `CanvasAccountReport` types to `src/canvas/types.ts`
- Wires `AccountsModule` into the `CanvasClient` facade
- Adds `accountTools` in `src/tools/accounts.ts` (6 read-only MCP tools with Zod schemas)
- Registers account tools in `getAllTools()` — total tool count: 46 → 52
- Full test coverage: `tests/canvas/accounts.test.ts` and `tests/tools/accounts.test.ts`
- Updates `tests/tools/registry.test.ts` with account tool names and updated count

Closes BRU-254.

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 332/332 tests pass
- [x] `pnpm build` — builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)