### PR TITLE
feat(discussions): add create/update/delete CRUD tools

### DIFF
--- a/src/canvas/discussions.ts
+++ b/src/canvas/discussions.ts
@@ -1,6 +1,21 @@
 import type { CanvasHttpClient } from './client'
 import type { CanvasDiscussionTopic, CanvasDiscussionEntry, CanvasAnnouncement } from './types'
 
+export interface CreateDiscussionParams {
+  title: string
+  message?: string
+  discussion_type?: 'side_comment' | 'threaded'
+  published?: boolean
+  require_initial_post?: boolean
+}
+
+export interface UpdateDiscussionParams {
+  title?: string
+  message?: string
+  published?: boolean
+  require_initial_post?: boolean
+}
+
 export class DiscussionsModule {
   constructor(private client: CanvasHttpClient) {}
 
@@ -34,6 +49,37 @@ export class DiscussionsModule {
         method: 'POST',
         body: JSON.stringify({ message }),
       },
+    )
+  }
+
+  async create(courseId: number, params: CreateDiscussionParams): Promise<CanvasDiscussionTopic> {
+    return this.client.request<CanvasDiscussionTopic>(
+      `/api/v1/courses/${courseId}/discussion_topics`,
+      {
+        method: 'POST',
+        body: JSON.stringify(params),
+      },
+    )
+  }
+
+  async update(
+    courseId: number,
+    topicId: number,
+    params: UpdateDiscussionParams,
+  ): Promise<CanvasDiscussionTopic> {
+    return this.client.request<CanvasDiscussionTopic>(
+      `/api/v1/courses/${courseId}/discussion_topics/${topicId}`,
+      {
+        method: 'PUT',
+        body: JSON.stringify(params),
+      },
+    )
+  }
+
+  async delete(courseId: number, topicId: number): Promise<void> {
+    await this.client.request<void>(
+      `/api/v1/courses/${courseId}/discussion_topics/${topicId}`,
+      { method: 'DELETE' },
     )
   }
 }

--- a/src/canvas/discussions.ts
+++ b/src/canvas/discussions.ts
@@ -77,9 +77,8 @@ export class DiscussionsModule {
   }
 
   async delete(courseId: number, topicId: number): Promise<void> {
-    await this.client.request<void>(
-      `/api/v1/courses/${courseId}/discussion_topics/${topicId}`,
-      { method: 'DELETE' },
-    )
+    await this.client.request<void>(`/api/v1/courses/${courseId}/discussion_topics/${topicId}`, {
+      method: 'DELETE',
+    })
   }
 }

--- a/src/canvas/discussions.ts
+++ b/src/canvas/discussions.ts
@@ -1,20 +1,11 @@
 import type { CanvasHttpClient } from './client'
-import type { CanvasDiscussionTopic, CanvasDiscussionEntry, CanvasAnnouncement } from './types'
-
-export interface CreateDiscussionParams {
-  title: string
-  message?: string
-  discussion_type?: 'side_comment' | 'threaded'
-  published?: boolean
-  require_initial_post?: boolean
-}
-
-export interface UpdateDiscussionParams {
-  title?: string
-  message?: string
-  published?: boolean
-  require_initial_post?: boolean
-}
+import type {
+  CanvasDiscussionTopic,
+  CanvasDiscussionEntry,
+  CanvasAnnouncement,
+  CreateDiscussionParams,
+  UpdateDiscussionParams,
+} from './types'
 
 export class DiscussionsModule {
   constructor(private client: CanvasHttpClient) {}

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -287,6 +287,21 @@ export interface CanvasAnnouncement {
   posted_at: string
 }
 
+export interface CreateDiscussionParams {
+  title: string
+  message?: string
+  discussion_type?: 'side_comment' | 'threaded'
+  published?: boolean
+  require_initial_post?: boolean
+}
+
+export interface UpdateDiscussionParams {
+  title?: string
+  message?: string
+  published?: boolean
+  require_initial_post?: boolean
+}
+
 // --- Calendar ---
 
 export interface CanvasCalendarEvent {

--- a/src/tools/discussions.ts
+++ b/src/tools/discussions.ts
@@ -70,5 +70,84 @@ export function discussionTools(canvas: CanvasClient): ToolDefinition[] {
         return canvas.discussions.postEntry(course_id, topic_id, message)
       },
     },
+    {
+      name: 'create_discussion',
+      description: 'Create a new discussion topic in a course.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        title: z.string().describe('Title of the discussion topic'),
+        message: z.string().optional().describe('Body text of the discussion (supports HTML)'),
+        discussion_type: z
+          .enum(['side_comment', 'threaded'])
+          .optional()
+          .describe('Discussion type: side_comment (flat) or threaded'),
+        published: z.boolean().optional().describe('Whether the topic is published'),
+        require_initial_post: z
+          .boolean()
+          .optional()
+          .describe('Require students to post before seeing replies'),
+      },
+      annotations: {
+        destructiveHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const course_id = params.course_id as number
+        return canvas.discussions.create(course_id, {
+          title: params.title as string,
+          message: params.message as string | undefined,
+          discussion_type: params.discussion_type as 'side_comment' | 'threaded' | undefined,
+          published: params.published as boolean | undefined,
+          require_initial_post: params.require_initial_post as boolean | undefined,
+        })
+      },
+    },
+    {
+      name: 'update_discussion',
+      description: 'Update an existing discussion topic.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        topic_id: z.number().describe('The Canvas discussion topic ID'),
+        title: z.string().optional().describe('New title for the discussion topic'),
+        message: z.string().optional().describe('New body text (supports HTML)'),
+        published: z.boolean().optional().describe('Publish or unpublish the topic'),
+        require_initial_post: z
+          .boolean()
+          .optional()
+          .describe('Require students to post before seeing replies'),
+      },
+      annotations: {
+        destructiveHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const course_id = params.course_id as number
+        const topic_id = params.topic_id as number
+        return canvas.discussions.update(course_id, topic_id, {
+          title: params.title as string | undefined,
+          message: params.message as string | undefined,
+          published: params.published as boolean | undefined,
+          require_initial_post: params.require_initial_post as boolean | undefined,
+        })
+      },
+    },
+    {
+      name: 'delete_discussion',
+      description: 'Delete a discussion topic from a course.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        topic_id: z.number().describe('The Canvas discussion topic ID to delete'),
+      },
+      annotations: {
+        destructiveHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const course_id = params.course_id as number
+        const topic_id = params.topic_id as number
+        await canvas.discussions.delete(course_id, topic_id)
+        return { deleted: true, topic_id }
+      },
+    },
   ]
 }

--- a/src/tools/discussions.ts
+++ b/src/tools/discussions.ts
@@ -75,7 +75,7 @@ export function discussionTools(canvas: CanvasClient): ToolDefinition[] {
       description: 'Create a new discussion topic in a course.',
       inputSchema: {
         course_id: z.number().describe('The Canvas course ID'),
-        title: z.string().describe('Title of the discussion topic'),
+        title: z.string().min(1).describe('Title of the discussion topic'),
         message: z.string().optional().describe('Body text of the discussion (supports HTML)'),
         discussion_type: z
           .enum(['side_comment', 'threaded'])
@@ -123,12 +123,16 @@ export function discussionTools(canvas: CanvasClient): ToolDefinition[] {
       handler: async (params) => {
         const course_id = params.course_id as number
         const topic_id = params.topic_id as number
-        return canvas.discussions.update(course_id, topic_id, {
+        const updateParams = {
           title: params.title as string | undefined,
           message: params.message as string | undefined,
           published: params.published as boolean | undefined,
           require_initial_post: params.require_initial_post as boolean | undefined,
-        })
+        }
+        if (Object.values(updateParams).every((v) => v === undefined)) {
+          throw new Error('At least one field must be provided to update a discussion topic')
+        }
+        return canvas.discussions.update(course_id, topic_id, updateParams)
       },
     },
     {

--- a/src/tools/modules.ts
+++ b/src/tools/modules.ts
@@ -107,7 +107,7 @@ export function moduleTools(canvas: CanvasClient): ToolDefinition[] {
     {
       name: 'create_module_item',
       description:
-        'Add an item (Assignment, Page, Quiz, File, Discussion, ExternalUrl, ExternalTool, SubHeader, Text) to a module.',
+        'Add an item (Assignment, Page, Quiz, File, Discussion, ExternalUrl, ExternalTool, SubHeader) to a module.',
       inputSchema: {
         course_id: z.number().describe('The Canvas course ID'),
         module_id: z.number().describe('The Canvas module ID'),
@@ -122,7 +122,6 @@ export function moduleTools(canvas: CanvasClient): ToolDefinition[] {
             'ExternalUrl',
             'ExternalTool',
             'SubHeader',
-            'Text',
           ])
           .describe('Type of content to add'),
         content_id: z

--- a/tests/canvas/discussions.test.ts
+++ b/tests/canvas/discussions.test.ts
@@ -75,4 +75,49 @@ describe('DiscussionsModule', () => {
       body: JSON.stringify({ message: 'My response' }),
     })
   })
+
+  it('creates a discussion topic via POST', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce({
+      id: 20,
+      title: 'New Discussion',
+      message: 'Welcome!',
+      discussion_type: 'threaded',
+      published: false,
+    })
+    const params = {
+      title: 'New Discussion',
+      message: 'Welcome!',
+      discussion_type: 'threaded' as const,
+      published: false,
+    }
+    const result = await discussions.create(100, params)
+    expect(result).toMatchObject({ id: 20, title: 'New Discussion' })
+    expect(client.request).toHaveBeenCalledWith('/api/v1/courses/100/discussion_topics', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    })
+  })
+
+  it('updates a discussion topic via PUT', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce({
+      id: 20,
+      title: 'Updated Title',
+      published: true,
+    })
+    const params = { title: 'Updated Title', published: true }
+    const result = await discussions.update(100, 20, params)
+    expect(result).toMatchObject({ id: 20, title: 'Updated Title' })
+    expect(client.request).toHaveBeenCalledWith('/api/v1/courses/100/discussion_topics/20', {
+      method: 'PUT',
+      body: JSON.stringify(params),
+    })
+  })
+
+  it('deletes a discussion topic via DELETE', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce(undefined)
+    await discussions.delete(100, 20)
+    expect(client.request).toHaveBeenCalledWith('/api/v1/courses/100/discussion_topics/20', {
+      method: 'DELETE',
+    })
+  })
 })

--- a/tests/tools/discussions.test.ts
+++ b/tests/tools/discussions.test.ts
@@ -41,12 +41,15 @@ describe('discussionTools', () => {
         get: vi.fn().mockResolvedValue(mockTopic),
         listAnnouncements: vi.fn().mockResolvedValue([mockAnnouncement]),
         postEntry: vi.fn().mockResolvedValue(mockEntry),
+        create: vi.fn().mockResolvedValue(mockTopic),
+        update: vi.fn().mockResolvedValue(mockTopic),
+        delete: vi.fn().mockResolvedValue(undefined),
       },
     } as unknown as CanvasClient
   }
 
-  it('returns an array with 4 tool definitions', () => {
-    expect(discussionTools(buildMockCanvas())).toHaveLength(4)
+  it('returns an array with 7 tool definitions', () => {
+    expect(discussionTools(buildMockCanvas())).toHaveLength(7)
   })
 
   it('exports tools with correct names', () => {
@@ -56,6 +59,9 @@ describe('discussionTools', () => {
       'get_discussion',
       'list_announcements',
       'post_discussion_entry',
+      'create_discussion',
+      'update_discussion',
+      'delete_discussion',
     ])
   })
 
@@ -114,6 +120,80 @@ describe('discussionTools', () => {
       const tool = discussionTools(canvas).find((t) => t.name === 'post_discussion_entry')!
       await tool.handler({ course_id: 1, topic_id: 1, message: 'Hello!' })
       expect(canvas.discussions.postEntry).toHaveBeenCalledWith(1, 1, 'Hello!')
+    })
+  })
+
+  describe('create_discussion', () => {
+    it('has destructive and openWorld annotations', () => {
+      const tool = discussionTools(buildMockCanvas()).find((t) => t.name === 'create_discussion')!
+      expect(tool.annotations).toEqual({ destructiveHint: true, openWorldHint: true })
+    })
+
+    it('delegates to canvas.discussions.create with required params', async () => {
+      const canvas = buildMockCanvas()
+      const tool = discussionTools(canvas).find((t) => t.name === 'create_discussion')!
+      await tool.handler({ course_id: 1, title: 'New Topic' })
+      expect(canvas.discussions.create).toHaveBeenCalledWith(1, {
+        title: 'New Topic',
+        message: undefined,
+        discussion_type: undefined,
+        published: undefined,
+        require_initial_post: undefined,
+      })
+    })
+
+    it('passes optional params to canvas.discussions.create', async () => {
+      const canvas = buildMockCanvas()
+      const tool = discussionTools(canvas).find((t) => t.name === 'create_discussion')!
+      await tool.handler({
+        course_id: 1,
+        title: 'New Topic',
+        message: '<p>Hello</p>',
+        discussion_type: 'threaded',
+        published: true,
+        require_initial_post: true,
+      })
+      expect(canvas.discussions.create).toHaveBeenCalledWith(1, {
+        title: 'New Topic',
+        message: '<p>Hello</p>',
+        discussion_type: 'threaded',
+        published: true,
+        require_initial_post: true,
+      })
+    })
+  })
+
+  describe('update_discussion', () => {
+    it('has destructive and openWorld annotations', () => {
+      const tool = discussionTools(buildMockCanvas()).find((t) => t.name === 'update_discussion')!
+      expect(tool.annotations).toEqual({ destructiveHint: true, openWorldHint: true })
+    })
+
+    it('delegates to canvas.discussions.update', async () => {
+      const canvas = buildMockCanvas()
+      const tool = discussionTools(canvas).find((t) => t.name === 'update_discussion')!
+      await tool.handler({ course_id: 1, topic_id: 1, title: 'Updated', published: false })
+      expect(canvas.discussions.update).toHaveBeenCalledWith(1, 1, {
+        title: 'Updated',
+        message: undefined,
+        published: false,
+        require_initial_post: undefined,
+      })
+    })
+  })
+
+  describe('delete_discussion', () => {
+    it('has destructive and openWorld annotations', () => {
+      const tool = discussionTools(buildMockCanvas()).find((t) => t.name === 'delete_discussion')!
+      expect(tool.annotations).toEqual({ destructiveHint: true, openWorldHint: true })
+    })
+
+    it('delegates to canvas.discussions.delete and returns confirmation', async () => {
+      const canvas = buildMockCanvas()
+      const tool = discussionTools(canvas).find((t) => t.name === 'delete_discussion')!
+      const result = await tool.handler({ course_id: 1, topic_id: 5 })
+      expect(canvas.discussions.delete).toHaveBeenCalledWith(1, 5)
+      expect(result).toEqual({ deleted: true, topic_id: 5 })
     })
   })
 })

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -42,6 +42,9 @@ function buildFullMockCanvas(): CanvasClient {
       get: async () => ({}),
       listAnnouncements: async () => [],
       postEntry: async () => ({}),
+      create: async () => ({}),
+      update: async () => ({}),
+      delete: async () => undefined,
     },
     modules: {
       list: async () => [],
@@ -83,7 +86,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 62 tools across all domains', () => {
+  it('returns all 65 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 
@@ -131,11 +134,14 @@ describe('getAllTools', () => {
     expect(names).toContain('list_enrollments')
     expect(names).toContain('enroll_user')
     expect(names).toContain('remove_enrollment')
-    // Discussions (4)
+    // Discussions (7)
     expect(names).toContain('list_discussions')
     expect(names).toContain('get_discussion')
     expect(names).toContain('list_announcements')
     expect(names).toContain('post_discussion_entry')
+    expect(names).toContain('create_discussion')
+    expect(names).toContain('update_discussion')
+    expect(names).toContain('delete_discussion')
     // Modules (6)
     expect(names).toContain('list_modules')
     expect(names).toContain('get_module')
@@ -167,7 +173,7 @@ describe('getAllTools', () => {
     expect(names).toContain('list_account_users')
     expect(names).toContain('get_account_reports')
 
-    expect(tools).toHaveLength(62)
+    expect(tools).toHaveLength(65)
   })
 
   it('all tools have openWorldHint: true', () => {
@@ -184,6 +190,9 @@ describe('getAllTools', () => {
       'submit_rubric_assessment',
       'score_quiz_question',
       'post_discussion_entry',
+      'create_discussion',
+      'update_discussion',
+      'delete_discussion',
       'send_conversation',
       'create_peer_review',
       'delete_peer_review',
@@ -210,6 +219,9 @@ describe('getAllTools', () => {
       'submit_rubric_assessment',
       'score_quiz_question',
       'post_discussion_entry',
+      'create_discussion',
+      'update_discussion',
+      'delete_discussion',
       'send_conversation',
       'create_peer_review',
       'delete_peer_review',


### PR DESCRIPTION
## Summary

- Adds `create_discussion` MCP tool — POST new discussion topic with title, message, type, publish state, and require_initial_post
- Adds `update_discussion` MCP tool — PUT updates to title, message, published, require_initial_post
- Adds `delete_discussion` MCP tool — DELETE a topic, returns `{ deleted: true, topic_id }`
- Exports `CreateDiscussionParams` and `UpdateDiscussionParams` interfaces from the canvas module

All new tools carry `destructiveHint: true, openWorldHint: true` annotations following the established write-tool pattern.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes (321 tests, 42 files)
- [ ] `pnpm build` succeeds
- [ ] Registry test updated: count 46 → 49, new tools in write/read annotation sets
- [ ] New tool-level tests cover annotations, delegation, and optional params

Closes BRU-258

🤖 Generated with [Claude Code](https://claude.com/claude-code)