### PR TITLE
chore: add Smithery marketplace listing metadata

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,5 +1,13 @@
 # Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
 
+name: Canvas LMS MCP
+description: >
+  The TypeScript MCP 1.x server for Canvas LMS. Connect Claude Desktop, Cursor,
+  VS Code, or any MCP-compatible AI agent to your Canvas instance with 46 tools
+  across 16 domains: courses, assignments, submissions, rubrics, quizzes, grades,
+  discussions, modules, pages, files, users, enrollments, groups, calendar,
+  conversations, and accounts. Three deployment modes: stdio, HTTP, and library import.
+
 startCommand:
   type: stdio
 


### PR DESCRIPTION
## Summary

- Adds `name` and `description` fields to `smithery.yaml` for the Smithery.ai marketplace listing
- Description leads with TypeScript MCP 1.x, 46 tools, 16 domains, lists supported AI clients
- Tagline follows approved branding: *The TypeScript MCP server for Canvas LMS.*

## Test plan

- [ ] Verify `smithery.yaml` parses cleanly (no YAML syntax errors)
- [ ] Confirm Smithery listing updates on next npm publish (auto-crawl)

Related: [BRU-235](/BRU/issues/BRU-235)

🤖 Generated with [Claude Code](https://claude.com/claude-code)