### PR TITLE
chore: resolve hono audit advisory

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,13 @@ pnpm lint:fix      # Auto-fix lint issues
 pnpm typecheck     # TypeScript strict type check
 ```
 
+### Dependency audit
+
+The `pnpm.overrides.hono` entry pins `hono` to `4.12.14` because
+`@modelcontextprotocol/sdk@1.29.0` allows vulnerable `hono <4.12.14`
+versions. Remove the override when the MCP SDK publishes a release that
+depends on a patched `hono` range.
+
 ### Architecture
 
 ```

--- a/package.json
+++ b/package.json
@@ -70,6 +70,11 @@
     "node": ">=22"
   },
   "packageManager": "pnpm@10.11.0",
+  "pnpm": {
+    "overrides": {
+      "hono": "4.12.14"
+    }
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  hono: 4.12.14
+
 importers:
 
   .:
@@ -262,7 +265,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.14
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -995,8 +998,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.12:
-    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -1770,9 +1773,9 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@hono/node-server@1.19.13(hono@4.12.12)':
+  '@hono/node-server@1.19.13(hono@4.12.14)':
     dependencies:
-      hono: 4.12.12
+      hono: 4.12.14
 
   '@humanfs/core@0.19.1': {}
 
@@ -1801,7 +1804,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.12)
+      '@hono/node-server': 1.19.13(hono@4.12.14)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -1811,7 +1814,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.12
+      hono: 4.12.14
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -2497,7 +2500,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.12: {}
+  hono@4.12.14: {}
 
   http-errors@2.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Add a narrow pnpm override to resolve GHSA-458j-xx4x-4375 by pinning transitive `hono` to patched `4.12.14`
- Document why the override exists and when to remove it
- Regenerate `pnpm-lock.yaml` so `@modelcontextprotocol/sdk@1.29.0` resolves to patched `hono`

## Notes
The latest published `@modelcontextprotocol/sdk` is still `1.29.0`, and its dependency range currently permits vulnerable `hono <4.12.14`, so a direct SDK bump is not available yet.

## Validation
- `pnpm audit --audit-level=moderate`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm lint`

Resolves [BRU-341](/BRU/issues/BRU-341).