### PR TITLE
docs: reconcile Canvas MCP tool inventory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,118 +57,30 @@ AI Agent  -->  MCP Transport (stdio/HTTP)
 
 ## Tool Inventory
 
-41 tools total: 33 read-only, 8 write operations.
+88 tools total: 60 read-only, 28 write operations.
 
-### Courses (3 tools)
-
-| Tool | Type | Description |
-| --- | --- | --- |
-| `list_courses` | read | List courses for the authenticated user |
-| `get_course` | read | Get a single course by ID |
-| `list_course_students` | read | List students enrolled in a course |
-
-### Assignments (3 tools)
-
-| Tool | Type | Description |
-| --- | --- | --- |
-| `list_assignments` | read | List all assignments in a course |
-| `get_assignment` | read | Get a single assignment by ID |
-| `create_assignment` | write | Create a new assignment in a course |
-
-### Submissions (5 tools)
-
-| Tool | Type | Description |
-| --- | --- | --- |
-| `list_submissions` | read | List submissions for an assignment |
-| `get_submission` | read | Get a single submission by user and assignment |
-| `get_submission_comments` | read | Get comments on a submission |
-| `grade_submission` | write | Post a grade for a submission |
-| `comment_on_submission` | write | Add a comment to a submission |
-
-### Rubrics (3 tools)
-
-| Tool | Type | Description |
-| --- | --- | --- |
-| `list_rubrics` | read | List rubrics in a course |
-| `get_rubric` | read | Get a single rubric with full criteria |
-| `assess_with_rubric` | write | Submit a rubric assessment for a submission |
-
-### Quizzes (3 tools)
-
-| Tool | Type | Description |
-| --- | --- | --- |
-| `list_quizzes` | read | List quizzes in a course |
-| `get_quiz` | read | Get a single quiz by ID |
-| `get_quiz_submissions` | read | List submissions for a quiz |
-
-### Files (3 tools)
-
-| Tool | Type | Description |
-| --- | --- | --- |
-| `list_files` | read | List files in a course or folder |
-| `get_file` | read | Get file metadata and download URL |
-| `list_folders` | read | List folders in a course |
-
-### Users (3 tools)
-
-| Tool | Type | Description |
-| --- | --- | --- |
-| `get_user` | read | Get a user profile by ID |
-| `get_user_profile` | read | Get detailed profile for a user |
-| `list_user_courses` | read | List courses a user is enrolled in |
-
-### Groups (2 tools)
-
-| Tool | Type | Description |
-| --- | --- | --- |
-| `list_groups` | read | List groups in a course |
-| `get_group_members` | read | List members of a group |
-
-### Enrollments (2 tools)
-
-| Tool | Type | Description |
-| --- | --- | --- |
-| `list_enrollments` | read | List enrollments in a course |
-| `enroll_user` | write | Enroll a user in a course |
-
-### Discussions (3 tools)
-
-| Tool | Type | Description |
-| --- | --- | --- |
-| `list_discussions` | read | List discussion topics in a course |
-| `get_discussion` | read | Get a discussion topic with entries |
-| `post_discussion_entry` | write | Post a reply to a discussion topic |
-
-### Modules (3 tools)
-
-| Tool | Type | Description |
-| --- | --- | --- |
-| `list_modules` | read | List modules in a course |
-| `get_module` | read | Get a single module by ID |
-| `list_module_items` | read | List items within a module |
-
-### Pages (3 tools)
-
-| Tool | Type | Description |
-| --- | --- | --- |
-| `list_pages` | read | List wiki pages in a course |
-| `get_page` | read | Get a single wiki page by URL slug |
-| `update_page` | write | Update a wiki page's content |
-
-### Calendar (2 tools)
-
-| Tool | Type | Description |
-| --- | --- | --- |
-| `list_calendar_events` | read | List calendar events for a course or user |
-| `create_calendar_event` | write | Create a new calendar event |
-
-### Conversations (3 tools)
-
-| Tool | Type | Description |
-| --- | --- | --- |
-| `list_conversations` | read | List inbox conversations |
-| `get_conversation` | read | Get a single conversation with messages |
-| `send_message` | read | Get message details (read-only preview) |
+| Domain | Tools |
+| --- | --- |
+| Health | `health_check` |
+| Courses | `list_courses`, `get_course`, `get_syllabus`, `create_course`, `update_course` |
+| Assignments | `list_assignments`, `get_assignment`, `list_assignment_groups`, `create_assignment`, `update_assignment`, `delete_assignment` |
+| Submissions | `list_submissions`, `get_submission`, `grade_submission`, `comment_on_submission` |
+| Rubrics | `list_rubrics`, `get_rubric`, `get_rubric_assessment`, `submit_rubric_assessment` |
+| Quizzes | `list_quizzes`, `get_quiz`, `list_quiz_submissions`, `list_quiz_questions`, `get_quiz_submission_answers`, `score_quiz_question` |
+| Files | `list_files`, `list_folders`, `get_file`, `upload_file`, `delete_file` |
+| Users | `list_students`, `get_user`, `get_profile`, `search_users`, `list_course_users` |
+| Groups | `list_groups`, `list_group_members` |
+| Enrollments | `list_enrollments`, `enroll_user`, `remove_enrollment` |
+| Discussions | `list_discussions`, `get_discussion`, `list_announcements`, `post_discussion_entry`, `create_discussion`, `update_discussion`, `delete_discussion` |
+| Modules | `list_modules`, `get_module`, `list_module_items`, `create_module`, `update_module`, `create_module_item` |
+| Pages | `list_pages`, `get_page`, `create_page`, `update_page`, `delete_page` |
+| Calendar | `list_calendar_events`, `create_calendar_event`, `update_calendar_event` |
+| Conversations | `list_conversations`, `get_conversation`, `get_conversation_unread_count`, `send_conversation` |
+| Peer Reviews | `list_peer_reviews`, `get_submission_peer_reviews`, `create_peer_review`, `delete_peer_review` |
+| Accounts | `get_account`, `list_accounts`, `list_sub_accounts`, `list_account_courses`, `list_account_users`, `get_account_reports` |
+| Analytics | `search_course_content`, `get_course_analytics`, `get_student_analytics`, `get_course_activity_stream` |
+| Student | `get_my_courses`, `get_my_grades`, `get_my_submissions`, `get_my_upcoming_assignments` |
+| Dashboard | `get_dashboard_cards`, `get_todo_items`, `get_upcoming_events`, `get_missing_submissions` |
 
 ## Tool Annotations
 

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@
 [![Node](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org)
 [![npm downloads](https://img.shields.io/npm/dw/@bruchris/canvas-lms-mcp)](https://www.npmjs.com/package/@bruchris/canvas-lms-mcp)
 
-MCP server for [Canvas LMS](https://www.instructure.com/canvas). Read courses, assignments, submissions, rubrics, quizzes; grade and comment from any AI agent.
+MCP server for [Canvas LMS](https://www.instructure.com/canvas). Read courses, assignments, submissions, rubrics, quizzes; grade, comment, manage course content, and handle Canvas admin workflows from any AI agent.
 
-46 tools across 16 Canvas domains. Three deployment modes: stdio, HTTP, and library import.
+88 tools across Canvas courses, assignments, submissions, rubrics, quizzes, files, users, groups, enrollments, discussions, modules, pages, calendar, conversations, peer reviews, accounts, analytics, student workflows, dashboard, and health checks. Three deployment modes: stdio, HTTP, and library import.
 
 ## Comparison
 
 | | @bruchris/canvas-lms-mcp | [vishalsachdev/canvas-mcp](https://github.com/vishalsachdev/canvas-mcp) | [DMontgomery40/mcp-canvas-lms](https://github.com/DMontgomery40/mcp-canvas-lms) |
 |---|---|---|---|
 | Language | TypeScript | Python | TypeScript |
-| Tools | 46 | 80+ | 54 |
+| Tools | 88 | 80+ | 54 |
 | License | [![License: MIT](https://img.shields.io/github/license/bruchris/canvas-lms-mcp)](https://github.com/bruchris/canvas-lms-mcp/blob/main/LICENSE) | [![License](https://img.shields.io/github/license/vishalsachdev/canvas-mcp)](https://github.com/vishalsachdev/canvas-mcp/blob/main/LICENSE) | [![License](https://img.shields.io/github/license/DMontgomery40/mcp-canvas-lms)](https://github.com/DMontgomery40/mcp-canvas-lms/blob/main/LICENSE) |
 | Last commit | [![Last commit](https://img.shields.io/github/last-commit/bruchris/canvas-lms-mcp)](https://github.com/bruchris/canvas-lms-mcp) | [![Last commit](https://img.shields.io/github/last-commit/vishalsachdev/canvas-mcp)](https://github.com/vishalsachdev/canvas-mcp) | [![Last commit](https://img.shields.io/github/last-commit/DMontgomery40/mcp-canvas-lms)](https://github.com/DMontgomery40/mcp-canvas-lms) |
 
@@ -173,61 +173,32 @@ Once configured, try these prompts with your AI client:
 
 ## Tool Inventory
 
-### Read-Only Tools (38)
+### All Registered Tools (88)
 
-| Category | Tool | Description |
-|----------|------|-------------|
-| Health | `health_check` | Check if the Canvas API is reachable and token is valid |
-| Courses | `list_courses` | List courses (optionally filter by enrollment state) |
-| Courses | `get_course` | Get course details including term and student count |
-| Courses | `get_syllabus` | Get the syllabus HTML for a course |
-| Assignments | `list_assignments` | List all assignments in a course |
-| Assignments | `get_assignment` | Get details for a single assignment |
-| Assignments | `list_assignment_groups` | List assignment groups (Homework, Exams, etc.) |
-| Submissions | `list_submissions` | List all submissions for an assignment |
-| Submissions | `get_submission` | Get a specific student's submission with comments |
-| Rubrics | `list_rubrics` | List all rubrics in a course |
-| Rubrics | `get_rubric` | Get rubric details including criteria |
-| Rubrics | `get_rubric_assessment` | Get rubric assessment for a student submission |
-| Quizzes | `list_quizzes` | List all quizzes in a course |
-| Quizzes | `get_quiz` | Get details for a single quiz |
-| Quizzes | `list_quiz_submissions` | List all submissions for a quiz |
-| Quizzes | `list_quiz_questions` | List all questions in a quiz |
-| Quizzes | `get_quiz_submission_answers` | Get a student's quiz answers |
-| Files | `list_files` | List all files in a course |
-| Files | `list_folders` | List all folders in a course |
-| Files | `get_file` | Get file metadata including download URL |
-| Users | `list_students` | List all students enrolled in a course |
-| Users | `get_user` | Get details for a single user |
-| Users | `get_profile` | Get the authenticated user's profile |
-| Groups | `list_groups` | List all groups in a course |
-| Groups | `list_group_members` | List all members of a group |
-| Enrollments | `list_enrollments` | List enrollments for the authenticated user |
-| Discussions | `list_discussions` | List all discussion topics in a course |
-| Discussions | `get_discussion` | Get details for a discussion topic |
-| Discussions | `list_announcements` | List all announcements in a course |
-| Modules | `list_modules` | List all modules in a course |
-| Modules | `get_module` | Get details for a single module |
-| Modules | `list_module_items` | List all items within a module |
-| Pages | `list_pages` | List all wiki pages in a course |
-| Pages | `get_page` | Get a wiki page by its URL slug |
-| Calendar | `list_calendar_events` | List calendar events for a course |
-| Conversations | `list_conversations` | List inbox messages for the authenticated user |
-| Peer Reviews | `list_peer_reviews` | List all peer reviews for an assignment in a course |
-| Peer Reviews | `get_submission_peer_reviews` | List peer reviews assigned to a specific submission |
+| Category | Tools |
+|----------|-------|
+| Health | `health_check` |
+| Courses | `list_courses`, `get_course`, `get_syllabus`, `create_course`, `update_course` |
+| Assignments | `list_assignments`, `get_assignment`, `list_assignment_groups`, `create_assignment`, `update_assignment`, `delete_assignment` |
+| Submissions | `list_submissions`, `get_submission`, `grade_submission`, `comment_on_submission` |
+| Rubrics | `list_rubrics`, `get_rubric`, `get_rubric_assessment`, `submit_rubric_assessment` |
+| Quizzes | `list_quizzes`, `get_quiz`, `list_quiz_submissions`, `list_quiz_questions`, `get_quiz_submission_answers`, `score_quiz_question` |
+| Files | `list_files`, `list_folders`, `get_file`, `upload_file`, `delete_file` |
+| Users | `list_students`, `get_user`, `get_profile`, `search_users`, `list_course_users` |
+| Groups | `list_groups`, `list_group_members` |
+| Enrollments | `list_enrollments`, `enroll_user`, `remove_enrollment` |
+| Discussions | `list_discussions`, `get_discussion`, `list_announcements`, `post_discussion_entry`, `create_discussion`, `update_discussion`, `delete_discussion` |
+| Modules | `list_modules`, `get_module`, `list_module_items`, `create_module`, `update_module`, `create_module_item` |
+| Pages | `list_pages`, `get_page`, `create_page`, `update_page`, `delete_page` |
+| Calendar | `list_calendar_events`, `create_calendar_event`, `update_calendar_event` |
+| Conversations | `list_conversations`, `get_conversation`, `get_conversation_unread_count`, `send_conversation` |
+| Peer Reviews | `list_peer_reviews`, `get_submission_peer_reviews`, `create_peer_review`, `delete_peer_review` |
+| Accounts | `get_account`, `list_accounts`, `list_sub_accounts`, `list_account_courses`, `list_account_users`, `get_account_reports` |
+| Analytics | `search_course_content`, `get_course_analytics`, `get_student_analytics`, `get_course_activity_stream` |
+| Student | `get_my_courses`, `get_my_grades`, `get_my_submissions`, `get_my_upcoming_assignments` |
+| Dashboard | `get_dashboard_cards`, `get_todo_items`, `get_upcoming_events`, `get_missing_submissions` |
 
-### Write Tools (8)
-
-| Tool | Description | Idempotent |
-|------|-------------|------------|
-| `grade_submission` | Post or update a grade for a submission | Yes |
-| `comment_on_submission` | Add a text comment to a submission | No |
-| `submit_rubric_assessment` | Submit rubric scores and comments per criterion | Yes |
-| `score_quiz_question` | Score a specific quiz question | Yes |
-| `post_discussion_entry` | Post a reply to a discussion topic | No |
-| `send_conversation` | Send a message to one or more recipients | No |
-| `create_peer_review` | Assign a user to peer-review a submission | No |
-| `delete_peer_review` | Remove a peer review assignment from a submission | No |
+60 tools are read-only and 28 tools perform Canvas write operations.
 
 All write tools require appropriate Canvas permissions. Canvas enforces its own permission model -- the MCP server does not bypass it.
 

--- a/docs/educator-guide.md
+++ b/docs/educator-guide.md
@@ -66,7 +66,7 @@ Posts a reply to a discussion topic. Supports HTML formatting.
 
 ## Write Operations Reference
 
-The server includes 6 write tools. All require appropriate Canvas permissions.
+The server includes 28 write tools. All require appropriate Canvas permissions.
 
 | Operation | Tool | What It Does | Reversible? |
 |-----------|------|--------------|-------------|

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -148,7 +148,7 @@ const transport = new StdioServerTransport()
 await server.connect(transport)
 ```
 
-The `server` is a standard `McpServer` instance with all 42 tools and 2 resources registered. The `canvas` is the underlying `CanvasClient` instance if you need direct API access.
+The `server` is a standard `McpServer` instance with all 88 tools and 2 resources registered. The `canvas` is the underlying `CanvasClient` instance if you need direct API access.
 
 ### Standalone Canvas Client
 

--- a/docs/superpowers/plans/2026-04-12-canvas-lms-mcp.md
+++ b/docs/superpowers/plans/2026-04-12-canvas-lms-mcp.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Build an open-source MCP server (`bruchris/canvas-lms-mcp`) that exposes the Canvas LMS REST API as 41 MCP tools across 15 domains, with stdio and HTTP transports, publishable to npm as `canvas-lms-mcp`.
+**Goal:** Build an open-source MCP server (`bruchris/canvas-lms-mcp`) that exposes the Canvas LMS REST API as 88 MCP tools across Canvas courses, assignments, grading, content, communication, admin, analytics, student, and dashboard workflows, with stdio and HTTP transports, publishable to npm as `canvas-lms-mcp`.
 
 **Architecture:** Three layers — standalone Canvas API client (`src/canvas/`), MCP tool definitions with Zod schemas (`src/tools/`), and thin transport entry points. A `createCanvasMCPServer()` factory wires everything together. The Canvas client is independently usable as a library via the `canvas-lms-mcp/canvas` export.
 
@@ -396,7 +396,7 @@ You are the project coordinator for the canvas-lms-mcp project.
 - `docs/` — user guides
 
 ## Project Context
-This is an open-source MCP server exposing Canvas LMS API as 41 tools. Three deployment modes: stdio, HTTP, npm library. Read-heavy with selective writes for grading.
+This is an open-source MCP server exposing Canvas LMS API as 88 tools. Three deployment modes: stdio, HTTP, npm library. Read-heavy with selective writes for grading, content management, course administration, and messaging.
 ```
 
 - [ ] **Step 4: Create `.claude/agents/architect.md`**
@@ -620,56 +620,30 @@ Three layers:
 - `src/tools/` — MCP tool definitions with Zod schemas
 - `src/server.ts` — Factory wiring tools + resources
 
-## Tools (41 total — 33 read, 8 write)
+## Tools (88 total — 60 read, 28 write)
 
-### Read Tools
-| Tool | Domain | Description |
-|------|--------|-------------|
-| `health_check` | health | Verify Canvas API connectivity |
-| `list_courses` | courses | User's courses |
-| `get_course` | courses | Single course details |
-| `get_syllabus` | courses | Course syllabus content |
-| `list_assignments` | assignments | Assignments for a course |
-| `get_assignment` | assignments | Single assignment details |
-| `list_assignment_groups` | assignments | Grouped assignments |
-| `list_submissions` | submissions | Submissions for an assignment |
-| `get_submission` | submissions | Single submission detail |
-| `list_rubrics` | rubrics | All rubrics in a course |
-| `get_rubric` | rubrics | Full rubric with criteria |
-| `get_rubric_assessment` | rubrics | Existing assessment |
-| `get_quiz` | quizzes | Quiz metadata |
-| `list_quiz_submissions` | quizzes | Quiz submissions |
-| `get_quiz_questions` | quizzes | Question definitions |
-| `get_quiz_submission_answers` | quizzes | Student's answers |
-| `list_files` | files | Files in a course |
-| `list_folders` | files | Folder structure |
-| `get_file` | files | File metadata + URL |
-| `list_students` | users | Students in a course |
-| `get_user` | users | User profile |
-| `get_user_profile` | users | Own profile |
-| `list_groups` | groups | Course groups |
-| `list_group_members` | groups | Group members |
-| `list_enrollments` | enrollments | User's enrollments |
-| `list_modules` | modules | Course modules |
-| `get_module` | modules | Module details |
-| `list_module_items` | modules | Module items |
-| `list_pages` | pages | Course pages |
-| `get_page` | pages | Page content |
-| `list_discussions` | discussions | Discussion topics |
-| `get_discussion` | discussions | Discussion with entries |
-| `list_announcements` | discussions | Announcements |
-| `list_calendar_events` | calendar | Calendar events |
-| `list_conversations` | conversations | Inbox messages |
-
-### Write Tools
-| Tool | Domain | Description |
-|------|--------|-------------|
-| `grade_submission` | submissions | Post a grade |
-| `comment_on_submission` | submissions | Post a comment with optional file |
-| `submit_rubric_assessment` | rubrics | Grade via rubric |
-| `score_quiz_question` | quizzes | Score open-ended question |
-| `post_discussion_entry` | discussions | Post to discussion |
-| `send_conversation` | conversations | Send message |
+| Domain | Tools |
+|--------|-------|
+| health | `health_check` |
+| courses | `list_courses`, `get_course`, `get_syllabus`, `create_course`, `update_course` |
+| assignments | `list_assignments`, `get_assignment`, `list_assignment_groups`, `create_assignment`, `update_assignment`, `delete_assignment` |
+| submissions | `list_submissions`, `get_submission`, `grade_submission`, `comment_on_submission` |
+| rubrics | `list_rubrics`, `get_rubric`, `get_rubric_assessment`, `submit_rubric_assessment` |
+| quizzes | `list_quizzes`, `get_quiz`, `list_quiz_submissions`, `list_quiz_questions`, `get_quiz_submission_answers`, `score_quiz_question` |
+| files | `list_files`, `list_folders`, `get_file`, `upload_file`, `delete_file` |
+| users | `list_students`, `get_user`, `get_profile`, `search_users`, `list_course_users` |
+| groups | `list_groups`, `list_group_members` |
+| enrollments | `list_enrollments`, `enroll_user`, `remove_enrollment` |
+| discussions | `list_discussions`, `get_discussion`, `list_announcements`, `post_discussion_entry`, `create_discussion`, `update_discussion`, `delete_discussion` |
+| modules | `list_modules`, `get_module`, `list_module_items`, `create_module`, `update_module`, `create_module_item` |
+| pages | `list_pages`, `get_page`, `create_page`, `update_page`, `delete_page` |
+| calendar | `list_calendar_events`, `create_calendar_event`, `update_calendar_event` |
+| conversations | `list_conversations`, `get_conversation`, `get_conversation_unread_count`, `send_conversation` |
+| peer-reviews | `list_peer_reviews`, `get_submission_peer_reviews`, `create_peer_review`, `delete_peer_review` |
+| accounts | `get_account`, `list_accounts`, `list_sub_accounts`, `list_account_courses`, `list_account_users`, `get_account_reports` |
+| analytics | `search_course_content`, `get_course_analytics`, `get_student_analytics`, `get_course_activity_stream` |
+| student | `get_my_courses`, `get_my_grades`, `get_my_submissions`, `get_my_upcoming_assignments` |
+| dashboard | `get_dashboard_cards`, `get_todo_items`, `get_upcoming_events`, `get_missing_submissions` |
 
 ## Development
 
@@ -2682,17 +2656,17 @@ pnpm vitest run
 Add a test in `tests/server.test.ts`:
 
 ```typescript
-it('registers all 41 tools', () => {
+it('registers all 88 tools', () => {
   const { canvas } = createCanvasMCPServer({
     token: 'test',
     baseUrl: 'https://canvas.example.com',
   })
   const tools = getAllTools(canvas)
-  expect(tools).toHaveLength(41)
+  expect(tools).toHaveLength(88)
 })
 ```
 
-Expected: All PASS, 41 tools registered
+Expected: All PASS, 88 tools registered
 
 - [ ] **Step 5: Commit**
 
@@ -3140,7 +3114,7 @@ Expected: All entry points present in dist/
 pnpm vitest run tests/server.test.ts
 ```
 
-Expected: 41 tools registered
+Expected: 88 tools registered
 
 - [ ] **Step 4: Push to GitHub**
 
@@ -3171,11 +3145,11 @@ git push origin v0.1.0-rc.1
 | 4 | Canvas HTTP client + types | — |
 | 5 | Courses module + facade | — |
 | 6 | MCP server factory + tool types | — |
-| 7 | Health + course tools | 4 tools |
+| 7 | Health + course tools | 6 tools |
 | 8 | Assignments + submissions modules | — |
-| 9 | Assignment + submission tools | 7 tools |
+| 9 | Assignment + submission tools | 10 tools |
 | 10 | All remaining canvas modules | — |
-| 11 | All remaining MCP tools | 30 tools |
+| 11 | All remaining MCP tools | 72 tools |
 | 12 | MCP resources | 2 resources |
 | 13 | CLI + stdio transport | — |
 | 14 | HTTP transport | — |
@@ -3183,4 +3157,4 @@ git push origin v0.1.0-rc.1
 | 16 | Documentation | — |
 | 17 | Final verification | — |
 
-**Total: 41 tools, 2 resources, 3 transports, 17 tasks**
+**Total: 88 tools, 2 resources, 3 transports, 17 tasks**

--- a/docs/superpowers/specs/2026-04-12-canvas-lms-mcp-design.md
+++ b/docs/superpowers/specs/2026-04-12-canvas-lms-mcp-design.md
@@ -253,7 +253,7 @@ Built fresh referencing the Fjordbyte Canvas Integration's `src/types/canvas.ts`
 
 ## MCP Tool Inventory
 
-42 tools across 15 domains.
+88 tools across Canvas courses, assignments, submissions, rubrics, quizzes, files, users, groups, enrollments, discussions, modules, pages, calendar, conversations, peer reviews, accounts, analytics, student workflows, dashboard, and health checks.
 
 ### Tool Pattern
 
@@ -302,21 +302,26 @@ All errors returned as structured MCP content, never thrown:
 |------|------|-------------|
 | `health_check` | read | Verify Canvas API connectivity and token validity |
 
-#### Courses (3 tools)
+#### Courses (5 tools)
 
 | Tool | Type | Description |
 |------|------|-------------|
 | `list_courses` | read | User's courses with optional term/enrollment filtering |
 | `get_course` | read | Single course details |
 | `get_syllabus` | read | Course syllabus content |
+| `create_course` | write | Create a course in a Canvas account |
+| `update_course` | write | Update an existing course |
 
-#### Assignments (3 tools)
+#### Assignments (6 tools)
 
 | Tool | Type | Description |
 |------|------|-------------|
 | `list_assignments` | read | Assignments for a course |
 | `get_assignment` | read | Single assignment with rubric settings |
 | `list_assignment_groups` | read | Grouped assignments with weights/rules |
+| `create_assignment` | write | Create a new assignment |
+| `update_assignment` | write | Update an existing assignment |
+| `delete_assignment` | write | Delete an assignment |
 
 #### Submissions (4 tools)
 
@@ -343,25 +348,29 @@ All errors returned as structured MCP content, never thrown:
 | `list_quizzes` | read | List quizzes in a course |
 | `get_quiz` | read | Quiz metadata |
 | `list_quiz_submissions` | read | Submissions for a quiz |
-| `get_quiz_questions` | read | Question definitions |
+| `list_quiz_questions` | read | Question definitions |
 | `get_quiz_submission_answers` | read | Student's answered questions |
 | `score_quiz_question` | write | Score an essay/open-ended question |
 
-#### Files (3 tools)
+#### Files (5 tools)
 
 | Tool | Type | Description |
 |------|------|-------------|
 | `list_files` | read | Files in a course |
 | `list_folders` | read | Folder structure |
 | `get_file` | read | File metadata + download URL |
+| `upload_file` | write | Upload a file to a course folder |
+| `delete_file` | write | Delete a file |
 
-#### Users (3 tools)
+#### Users (5 tools)
 
 | Tool | Type | Description |
 |------|------|-------------|
 | `list_students` | read | Students enrolled in a course |
 | `get_user` | read | User profile details |
-| `get_user_profile` | read | Authenticated user's own profile |
+| `get_profile` | read | Authenticated user's own profile |
+| `search_users` | read | Search users in an account |
+| `list_course_users` | read | List users in a course, optionally filtered by enrollment type |
 
 #### Groups (2 tools)
 
@@ -370,26 +379,34 @@ All errors returned as structured MCP content, never thrown:
 | `list_groups` | read | Course groups |
 | `list_group_members` | read | Members of a group |
 
-#### Enrollments (1 tool)
+#### Enrollments (3 tools)
 
 | Tool | Type | Description |
 |------|------|-------------|
 | `list_enrollments` | read | User's enrollments across courses |
+| `enroll_user` | write | Enroll a user in a course |
+| `remove_enrollment` | write | Remove or conclude an enrollment |
 
-#### Modules (3 tools)
+#### Modules (6 tools)
 
 | Tool | Type | Description |
 |------|------|-------------|
 | `list_modules` | read | Course modules |
 | `get_module` | read | Single module details |
 | `list_module_items` | read | Items within a module |
+| `create_module` | write | Create a module |
+| `update_module` | write | Update an existing module |
+| `create_module_item` | write | Add an item to a module |
 
-#### Pages (2 tools)
+#### Pages (5 tools)
 
 | Tool | Type | Description |
 |------|------|-------------|
 | `list_pages` | read | Course pages |
 | `get_page` | read | Page content |
+| `create_page` | write | Create a wiki page |
+| `update_page` | write | Update a wiki page |
+| `delete_page` | write | Delete a wiki page |
 
 #### Discussions (4 tools)
 
@@ -399,21 +416,75 @@ All errors returned as structured MCP content, never thrown:
 | `get_discussion` | read | Discussion topic with entries |
 | `list_announcements` | read | Course announcements |
 | `post_discussion_entry` | write | Post to a discussion topic |
+| `create_discussion` | write | Create a discussion topic |
+| `update_discussion` | write | Update a discussion topic |
+| `delete_discussion` | write | Delete a discussion topic |
 
-#### Calendar (1 tool)
+#### Calendar (3 tools)
 
 | Tool | Type | Description |
 |------|------|-------------|
 | `list_calendar_events` | read | Calendar events and due dates |
+| `create_calendar_event` | write | Create a calendar event |
+| `update_calendar_event` | write | Update a calendar event |
 
-#### Conversations (2 tools)
+#### Conversations (4 tools)
 
 | Tool | Type | Description |
 |------|------|-------------|
 | `list_conversations` | read | Inbox messages |
+| `get_conversation` | read | Conversation message thread |
+| `get_conversation_unread_count` | read | Count unread conversations |
 | `send_conversation` | write | Send a message to students |
 
-**Totals: 42 tools (36 read, 6 write)**
+#### Peer Reviews (4 tools)
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `list_peer_reviews` | read | Peer reviews for an assignment |
+| `get_submission_peer_reviews` | read | Peer reviews assigned to a submission |
+| `create_peer_review` | write | Assign a peer review |
+| `delete_peer_review` | write | Remove a peer review assignment |
+
+#### Accounts (6 tools)
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `get_account` | read | Canvas account details |
+| `list_accounts` | read | Accounts accessible to the authenticated user |
+| `list_sub_accounts` | read | Sub-accounts under an account |
+| `list_account_courses` | read | Courses in an account |
+| `list_account_users` | read | Users in an account |
+| `get_account_reports` | read | Available account report types |
+
+#### Analytics (4 tools)
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `search_course_content` | read | Search Canvas course content |
+| `get_course_analytics` | read | Course analytics activity |
+| `get_student_analytics` | read | Student analytics in a course |
+| `get_course_activity_stream` | read | Course activity stream |
+
+#### Student (4 tools)
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `get_my_courses` | read | Authenticated student's courses |
+| `get_my_grades` | read | Authenticated student's grades |
+| `get_my_submissions` | read | Authenticated student's submissions |
+| `get_my_upcoming_assignments` | read | Authenticated student's upcoming assignments |
+
+#### Dashboard (4 tools)
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `get_dashboard_cards` | read | Current user's dashboard course cards |
+| `get_todo_items` | read | Current user's Canvas todo items |
+| `get_upcoming_events` | read | Current user's upcoming events |
+| `get_missing_submissions` | read | Current user's missing submissions |
+
+**Totals: 88 tools (60 read, 28 write)**
 
 ## MCP Resources
 
@@ -547,8 +618,8 @@ All tools include MCP tool annotations to help clients (Claude, ChatGPT) make sa
 
 | Annotation | Applied to | Effect |
 |------------|-----------|--------|
-| `readOnlyHint: true` | All 33 read tools | Clients may auto-execute without confirmation |
-| `destructiveHint: true` | All 8 write tools | Clients should ask for user confirmation before executing |
+| `readOnlyHint: true` | All 60 read tools | Clients may auto-execute without confirmation |
+| `destructiveHint: true` | All 28 write tools | Clients should ask for user confirmation before executing |
 | `idempotentHint: true` | `grade_submission`, `submit_rubric_assessment`, `score_quiz_question` | Safe to retry — re-grading with same value is a no-op |
 | `openWorldHint: true` | All tools | Tools interact with external Canvas API |
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bruchris/canvas-lms-mcp",
   "version": "0.4.1",
-  "description": "TypeScript MCP 1.x server for Canvas LMS — 46 tools across 16 domains. Connect Claude Desktop, Cursor, or VS Code to your Canvas courses, assignments, grades, quizzes, discussions, and more.",
+  "description": "TypeScript MCP 1.x server for Canvas LMS — 88 tools across Canvas courses, assignments, grades, quizzes, discussions, admin workflows, and more.",
   "type": "module",
   "exports": {
     ".": {

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -133,7 +133,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 84 tools across all domains', () => {
+  it('returns all 88 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 


### PR DESCRIPTION
## Summary

- Update public and planning docs from stale 41/42/46-tool references to the actual 88 registered tools
- Reconcile read/write totals to 60 read-only and 28 write operations
- Fix the stale registry test title so it matches the existing 88-tool assertion

## Validation

- pnpm typecheck
- pnpm test
- pnpm build

Closes BRU-343.