### PR TITLE
fix(ci): restore npm token for release publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -22,7 +23,7 @@ jobs:
 
   npm-publish:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    if: ${{ needs.release-please.outputs.release_created || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -38,3 +39,5 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm publish --access public --no-git-checks --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Restore `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` on the npm publish step while keeping provenance enabled.
- Add `workflow_dispatch` so the fixed workflow can publish the already-created `0.5.0` release from `main` without local manual publishing.

## Root Cause

`0.4.0` published successfully with `NODE_AUTH_TOKEN` set on the publish step. The following release workflow change added `--provenance` but removed the token env block. The `0.4.1` and `0.5.0` publishes then reached npm, generated provenance, and failed the package PUT with npm `E404`, which is npm's hidden unauthorized/not-found response for a publish token that is not available to the command.

## Rerun Path For 0.5.0

After this PR merges to `main`, run the `Release` workflow manually from the `main` branch. That will execute the fixed `npm-publish` job against the current `package.json` version `0.5.0`. Do not publish locally.

## Validation

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- Confirmed `npm view @bruchris/canvas-lms-mcp@0.5.0 version --json` still returns npm `E404`, so `0.5.0` remains unpublished.