### PR TITLE
ci: add trusted publishing release mode

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      publish_auth:
+        description: 'npm publish auth mode. Use trusted-publisher only after npm Trusted Publisher is configured.'
+        required: true
+        default: token
+        type: choice
+        options:
+          - token
+          - trusted-publisher
 
 permissions:
   contents: write
@@ -23,21 +32,36 @@ jobs:
 
   npm-publish:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created || github.event_name == 'workflow_dispatch' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
+    env:
+      USE_TRUSTED_PUBLISHING: ${{ ((github.event_name == 'workflow_dispatch' && inputs.publish_auth == 'trusted-publisher') || (github.event_name != 'workflow_dispatch' && vars.NPM_PUBLISH_AUTH == 'trusted-publisher')) && 'true' || 'false' }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
-      - run: pnpm publish --access public --no-git-checks --provenance
+
+      # Default to the proven token path until the npm package Trusted Publisher
+      # has been configured and one release has verified OIDC end-to-end.
+      - name: Publish to npm with token fallback
+        if: ${{ env.USE_TRUSTED_PUBLISHING != 'true' }}
+        run: pnpm publish --access public --no-git-checks --provenance --registry https://registry.npmjs.org/
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Use npm CLI with trusted publishing support
+        if: ${{ env.USE_TRUSTED_PUBLISHING == 'true' }}
+        run: npm install --global npm@^11.5.1
+
+      - name: Publish to npm with Trusted Publisher OIDC
+        if: ${{ env.USE_TRUSTED_PUBLISHING == 'true' }}
+        run: npm publish --access public --no-git-checks --provenance --registry https://registry.npmjs.org/


### PR DESCRIPTION
## Summary

- Adds an explicit `publish_auth` workflow_dispatch input for choosing `token` or `trusted-publisher` publish mode.
- Keeps the existing `NPM_TOKEN` + `pnpm publish` path as the default fallback for normal releases.
- Adds a Trusted Publisher path that installs npm CLI `^11.5.1`, uses Node 24, keeps explicit npm registry targeting and `--provenance`, and publishes without `NODE_AUTH_TOKEN`.
- Tightens the release job condition to `release_created == 'true'` so normal pushes do not publish on a falsey release-please output string.

## Trusted Publisher settings required on npm

Configure `@bruchris/canvas-lms-mcp` on npm with:

- Publisher: GitHub Actions
- Organization/user: `bruchris`
- Repository: `canvas-lms-mcp`
- Workflow filename: `release-please.yml`
- Environment: leave unset unless this workflow later adds a GitHub environment

Docs checked:

- npm Trusted Publishers: https://docs.npmjs.com/trusted-publishers
- GitHub OIDC permissions: https://docs.github.com/en/actions/reference/security/oidc

## Validation

- `pnpm typecheck`
- `pnpm test` (49 files, 507 tests)
- `pnpm build`
- `pnpm lint`
- `npx --yes js-yaml .github/workflows/release-please.yml`

`actionlint` was not available through the attempted npm package names in this environment, so the local workflow validation is YAML parsing plus manual GitHub Actions expression review.

## End-to-end test plan

1. Configure the npm Trusted Publisher settings above.
2. Set repository variable `NPM_PUBLISH_AUTH=trusted-publisher` before merging the next release PR, or manually dispatch `Release` with `publish_auth=trusted-publisher` for an unpublished package version.
3. Confirm the `Publish to npm with Trusted Publisher OIDC` step succeeds and that `npm view @bruchris/canvas-lms-mcp@<version> version --json` returns the published version.

## Rollback / rerun plan

- If Trusted Publishing fails, unset `NPM_PUBLISH_AUTH` and rerun the `Release` workflow manually with `publish_auth=token`.
- The fallback path still uses `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` and `pnpm publish --provenance`, matching the v0.5.0 path that succeeded in https://github.com/bruchris/canvas-lms-mcp/actions/runs/24572746068.