### PR TITLE
feat!: rename package to unscoped canvas-lms-mcp

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,15 +4,6 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-    inputs:
-      publish_auth:
-        description: 'npm publish auth mode. Use trusted-publisher only after npm Trusted Publisher is configured.'
-        required: true
-        default: token
-        type: choice
-        options:
-          - token
-          - trusted-publisher
 
 permissions:
   contents: write
@@ -37,8 +28,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    env:
-      USE_TRUSTED_PUBLISHING: ${{ ((github.event_name == 'workflow_dispatch' && inputs.publish_auth == 'trusted-publisher') || (github.event_name != 'workflow_dispatch' && vars.NPM_PUBLISH_AUTH == 'trusted-publisher')) && 'true' || 'false' }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -50,18 +39,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
 
-      # Default to the proven token path until the npm package Trusted Publisher
-      # has been configured and one release has verified OIDC end-to-end.
-      - name: Publish to npm with token fallback
-        if: ${{ env.USE_TRUSTED_PUBLISHING != 'true' }}
-        run: pnpm publish --access public --no-git-checks --provenance --registry https://registry.npmjs.org/
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Use npm CLI with trusted publishing support
-        if: ${{ env.USE_TRUSTED_PUBLISHING == 'true' }}
         run: npm install --global npm@^11.5.1
 
       - name: Publish to npm with Trusted Publisher OIDC
-        if: ${{ env.USE_TRUSTED_PUBLISHING == 'true' }}
         run: npm publish --access public --no-git-checks --provenance --registry https://registry.npmjs.org/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,10 @@ Guide for AI agents consuming or contributing to `canvas-lms-mcp`.
 
 ```bash
 # Run with npx (no install needed)
-npx @bruchris/canvas-lms-mcp --token $CANVAS_API_TOKEN --base-url https://school.instructure.com/api/v1
+npx canvas-lms-mcp --token $CANVAS_API_TOKEN --base-url https://school.instructure.com/api/v1
 
 # Or install globally
-npm install -g @bruchris/canvas-lms-mcp
+npm install -g canvas-lms-mcp
 canvas-lms-mcp --token $CANVAS_API_TOKEN --base-url $CANVAS_BASE_URL
 ```
 
@@ -18,7 +18,7 @@ Environment variables are also supported:
 ```bash
 export CANVAS_API_TOKEN=your_token_here
 export CANVAS_BASE_URL=https://school.instructure.com/api/v1
-npx @bruchris/canvas-lms-mcp
+npx canvas-lms-mcp
 ```
 
 ## Architecture
@@ -151,7 +151,7 @@ ci: add Node 24 to CI matrix
 The Canvas client can be used independently of MCP:
 
 ```typescript
-import { CanvasClient } from '@bruchris/canvas-lms-mcp/canvas'
+import { CanvasClient } from 'canvas-lms-mcp/canvas'
 
 const canvas = new CanvasClient({
   token: process.env.CANVAS_API_TOKEN!,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,11 +62,11 @@
 
 ### ⚠ BREAKING CHANGES
 
-* package install path is now @bruchris/canvas-lms-mcp
+* package install path temporarily moved to the scoped package
 
 ### Features
 
-* rename package to @bruchris/canvas-lms-mcp ([#20](https://github.com/bruchris/canvas-lms-mcp/issues/20)) ([1dede1d](https://github.com/bruchris/canvas-lms-mcp/commit/1dede1d4fc59d0e2fc24b7301a8cd1d020e699c3))
+* rename package to scoped package ([#20](https://github.com/bruchris/canvas-lms-mcp/issues/20)) ([1dede1d](https://github.com/bruchris/canvas-lms-mcp/commit/1dede1d4fc59d0e2fc24b7301a8cd1d020e699c3))
 
 ## [0.3.0](https://github.com/bruchris/canvas-lms-mcp/compare/canvas-lms-mcp-v0.2.0...canvas-lms-mcp-v0.3.0) (2026-04-15)
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 > The TypeScript MCP server for Canvas LMS.
 
 [![CI](https://github.com/bruchris/canvas-lms-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/bruchris/canvas-lms-mcp/actions/workflows/ci.yml)
-[![npm](https://img.shields.io/npm/v/%40bruchris%2Fcanvas-lms-mcp)](https://www.npmjs.com/package/@bruchris/canvas-lms-mcp)
+[![npm](https://img.shields.io/npm/v/canvas-lms-mcp)](https://www.npmjs.com/package/canvas-lms-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org)
-[![npm downloads](https://img.shields.io/npm/dw/@bruchris/canvas-lms-mcp)](https://www.npmjs.com/package/@bruchris/canvas-lms-mcp)
+[![npm downloads](https://img.shields.io/npm/dw/canvas-lms-mcp)](https://www.npmjs.com/package/canvas-lms-mcp)
 
 MCP server for [Canvas LMS](https://www.instructure.com/canvas). Read courses, assignments, submissions, rubrics, quizzes; grade, comment, manage course content, and handle Canvas admin workflows from any AI agent.
 
@@ -14,7 +14,7 @@ MCP server for [Canvas LMS](https://www.instructure.com/canvas). Read courses, a
 
 ## Comparison
 
-| | @bruchris/canvas-lms-mcp | [vishalsachdev/canvas-mcp](https://github.com/vishalsachdev/canvas-mcp) | [DMontgomery40/mcp-canvas-lms](https://github.com/DMontgomery40/mcp-canvas-lms) |
+| | canvas-lms-mcp | [vishalsachdev/canvas-mcp](https://github.com/vishalsachdev/canvas-mcp) | [DMontgomery40/mcp-canvas-lms](https://github.com/DMontgomery40/mcp-canvas-lms) |
 |---|---|---|---|
 | Language | TypeScript | Python | TypeScript |
 | Tools | 88 | 80+ | 54 |
@@ -34,7 +34,7 @@ MCP server for [Canvas LMS](https://www.instructure.com/canvas). Read courses, a
 ### 2. One Command Setup
 
 ```bash
-npx add-mcp @bruchris/canvas-lms-mcp
+npx add-mcp canvas-lms-mcp
 ```
 
 This auto-detects your installed AI clients (Claude Code, Cursor, VS Code, etc.) and configures them. You will be prompted for your Canvas API token and base URL.
@@ -44,25 +44,25 @@ This auto-detects your installed AI clients (Claude Code, Cursor, VS Code, etc.)
 **Claude Code**
 
 ```bash
-claude mcp add canvas-lms --env CANVAS_API_TOKEN=your-token --env CANVAS_BASE_URL=https://school.instructure.com -- npx -y @bruchris/canvas-lms-mcp
+claude mcp add canvas-lms --env CANVAS_API_TOKEN=your-token --env CANVAS_BASE_URL=https://school.instructure.com -- npx -y canvas-lms-mcp
 ```
 
 **VS Code**
 
 ```bash
-code --add-mcp '{"name":"canvas-lms","command":"npx","args":["-y","@bruchris/canvas-lms-mcp"],"env":{"CANVAS_API_TOKEN":"your-token","CANVAS_BASE_URL":"https://school.instructure.com"}}'
+code --add-mcp '{"name":"canvas-lms","command":"npx","args":["-y","canvas-lms-mcp"],"env":{"CANVAS_API_TOKEN":"your-token","CANVAS_BASE_URL":"https://school.instructure.com"}}'
 ```
 
 **Gemini CLI**
 
 ```bash
-gemini mcp add canvas-lms npx @bruchris/canvas-lms-mcp
+gemini mcp add canvas-lms npx canvas-lms-mcp
 ```
 
 **Codex CLI**
 
 ```bash
-codex mcp add canvas-lms -- npx @bruchris/canvas-lms-mcp
+codex mcp add canvas-lms -- npx canvas-lms-mcp
 ```
 
 <details>
@@ -77,7 +77,7 @@ Add to your `claude_desktop_config.json`:
   "mcpServers": {
     "canvas-lms": {
       "command": "npx",
-      "args": ["-y", "@bruchris/canvas-lms-mcp"],
+      "args": ["-y", "canvas-lms-mcp"],
       "env": {
         "CANVAS_API_TOKEN": "your-token-here",
         "CANVAS_BASE_URL": "https://your-institution.instructure.com"
@@ -96,7 +96,7 @@ Add to `.cursor/mcp.json` in your project:
   "mcpServers": {
     "canvas-lms": {
       "command": "npx",
-      "args": ["-y", "@bruchris/canvas-lms-mcp"],
+      "args": ["-y", "canvas-lms-mcp"],
       "env": {
         "CANVAS_API_TOKEN": "your-token-here",
         "CANVAS_BASE_URL": "https://your-institution.instructure.com"
@@ -115,7 +115,7 @@ Add to your VS Code settings (`settings.json`):
   "mcp.servers": {
     "canvas-lms": {
       "command": "npx",
-      "args": ["-y", "@bruchris/canvas-lms-mcp"],
+      "args": ["-y", "canvas-lms-mcp"],
       "env": {
         "CANVAS_API_TOKEN": "your-token-here",
         "CANVAS_BASE_URL": "https://your-institution.instructure.com"
@@ -134,7 +134,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
   "mcpServers": {
     "canvas-lms": {
       "command": "npx",
-      "args": ["-y", "@bruchris/canvas-lms-mcp"],
+      "args": ["-y", "canvas-lms-mcp"],
       "env": {
         "CANVAS_API_TOKEN": "your-token-here",
         "CANVAS_BASE_URL": "https://your-institution.instructure.com"
@@ -149,7 +149,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 Run the server in HTTP mode, then point your client at the endpoint:
 
 ```bash
-npx @bruchris/canvas-lms-mcp serve --port 3001 \
+npx canvas-lms-mcp serve --port 3001 \
   --token your-token-here \
   --base-url https://your-institution.instructure.com
 ```
@@ -216,7 +216,7 @@ All write tools require appropriate Canvas permissions. Canvas enforces its own 
 For local AI clients like Claude Desktop, Cursor, and VS Code. The server communicates over stdin/stdout.
 
 ```bash
-npx @bruchris/canvas-lms-mcp --token $CANVAS_API_TOKEN --base-url $CANVAS_BASE_URL
+npx canvas-lms-mcp --token $CANVAS_API_TOKEN --base-url $CANVAS_BASE_URL
 ```
 
 ### HTTP
@@ -224,7 +224,7 @@ npx @bruchris/canvas-lms-mcp --token $CANVAS_API_TOKEN --base-url $CANVAS_BASE_U
 For web-based clients or hosted services. Starts an HTTP server with Streamable HTTP transport.
 
 ```bash
-npx @bruchris/canvas-lms-mcp serve \
+npx canvas-lms-mcp serve \
   --token $CANVAS_API_TOKEN \
   --base-url $CANVAS_BASE_URL \
   --port 3001 \
@@ -259,7 +259,7 @@ services:
 Use the server factory directly in your own Node.js application:
 
 ```typescript
-import { createCanvasMCPServer } from '@bruchris/canvas-lms-mcp'
+import { createCanvasMCPServer } from 'canvas-lms-mcp'
 
 const { server, canvas } = createCanvasMCPServer({
   token: userToken,
@@ -270,7 +270,7 @@ const { server, canvas } = createCanvasMCPServer({
 Or use the Canvas client standalone (no MCP dependency):
 
 ```typescript
-import { CanvasClient } from '@bruchris/canvas-lms-mcp/canvas'
+import { CanvasClient } from 'canvas-lms-mcp/canvas'
 
 const canvas = new CanvasClient({
   token: userToken,

--- a/docs/dispute/evidence/squatter-package-contents.md
+++ b/docs/dispute/evidence/squatter-package-contents.md
@@ -45,4 +45,4 @@ package/package.json
 
 ## Summary
 
-The squatter package (`canvas-lms-mcp@1.0.0`, published 2026-04-13T12:43:07Z by user `clm808`) contains only 11 pre-built JavaScript files with no TypeScript source, no tests, no documentation, and no README. It consists of thin wrapper stubs for a subset of Canvas LMS operations with no configuration schema, no published source repository, and no licence file. The package has no functional parity with `@bruchris/canvas-lms-mcp` and appears to have been registered opportunistically to capture the npm namespace.
+The squatter package (`canvas-lms-mcp@1.0.0`, published 2026-04-13T12:43:07Z by user `clm808`) contains only 11 pre-built JavaScript files with no TypeScript source, no tests, no documentation, and no README. It consists of thin wrapper stubs for a subset of Canvas LMS operations with no configuration schema, no published source repository, and no licence file. The package had no functional parity with the official implementation and appears to have been registered opportunistically to capture the npm namespace.

--- a/docs/dispute/evidence/timeline.md
+++ b/docs/dispute/evidence/timeline.md
@@ -5,7 +5,7 @@
 | 2026-04-10 | `bruchris` published the initial Canvas LMS MCP implementation to GitHub (`bruchris/canvas-lms-mcp`, PR #5) | https://github.com/bruchris/canvas-lms-mcp/pull/5 |
 | 2026-04-13T12:43:07Z | `clm808` registered the unscoped npm name `canvas-lms-mcp` (v1.0.0) | `docs/dispute/evidence/npm-registration-timestamp.json` |
 | 2026-04-13T15:02:34Z | `bruchris` published the official v0.1.0 GitHub Release for `canvas-lms-mcp` via release-please | https://github.com/bruchris/canvas-lms-mcp/releases/tag/canvas-lms-mcp-v0.1.0 |
-| 2026-04-16 | `bruchris` renamed package to `@bruchris/canvas-lms-mcp`; npm dispute filed | This commit |
+| 2026-04-16 | `bruchris` temporarily renamed package to a scoped fallback package; npm dispute filed | This commit |
 
 ## Notes
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ Choose the AI client you installed:
   "mcpServers": {
     "canvas-lms": {
       "command": "npx",
-      "args": ["-y", "@bruchris/canvas-lms-mcp"],
+      "args": ["-y", "canvas-lms-mcp"],
       "env": {
         "CANVAS_API_TOKEN": "paste-your-token-here",
         "CANVAS_BASE_URL": "https://your-school.instructure.com"
@@ -77,7 +77,7 @@ You should see a hammer icon (🔨) in the bottom-left of the chat input — cli
   "mcpServers": {
     "canvas-lms": {
       "command": "npx",
-      "args": ["-y", "@bruchris/canvas-lms-mcp"],
+      "args": ["-y", "canvas-lms-mcp"],
       "env": {
         "CANVAS_API_TOKEN": "paste-your-token-here",
         "CANVAS_BASE_URL": "https://your-school.instructure.com"
@@ -94,7 +94,7 @@ You should see a hammer icon (🔨) in the bottom-left of the chat input — cli
 Run this command in your terminal (replace the values in quotes):
 
 ```bash
-code --add-mcp '{"name":"canvas-lms","command":"npx","args":["-y","@bruchris/canvas-lms-mcp"],"env":{"CANVAS_API_TOKEN":"your-token","CANVAS_BASE_URL":"https://your-school.instructure.com"}}'
+code --add-mcp '{"name":"canvas-lms","command":"npx","args":["-y","canvas-lms-mcp"],"env":{"CANVAS_API_TOKEN":"your-token","CANVAS_BASE_URL":"https://your-school.instructure.com"}}'
 ```
 
 > **Windows users:** The single quotes above don't work in PowerShell or Command Prompt. Use the manual JSON method below instead.
@@ -106,7 +106,7 @@ Or add it manually to VS Code settings (`settings.json`):
   "mcp.servers": {
     "canvas-lms": {
       "command": "npx",
-      "args": ["-y", "@bruchris/canvas-lms-mcp"],
+      "args": ["-y", "canvas-lms-mcp"],
       "env": {
         "CANVAS_API_TOKEN": "paste-your-token-here",
         "CANVAS_BASE_URL": "https://your-school.instructure.com"

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -21,7 +21,7 @@ The AI client spawns `canvas-lms-mcp` as a subprocess. The MCP protocol messages
   "mcpServers": {
     "canvas-lms": {
       "command": "npx",
-      "args": ["-y", "@bruchris/canvas-lms-mcp"],
+      "args": ["-y", "canvas-lms-mcp"],
       "env": {
         "CANVAS_API_TOKEN": "token",
         "CANVAS_BASE_URL": "https://school.instructure.com"
@@ -61,7 +61,7 @@ Each `POST /mcp` request creates a fresh MCP server instance with the credential
 
 ```bash
 # CLI
-npx @bruchris/canvas-lms-mcp serve \
+npx canvas-lms-mcp serve \
   --port 3001 \
   --allowed-origin https://your-app.example.com
 
@@ -135,7 +135,7 @@ Import the server factory or the standalone Canvas client directly into your Nod
 Create an MCP server instance and connect it to your own transport:
 
 ```typescript
-import { createCanvasMCPServer } from '@bruchris/canvas-lms-mcp'
+import { createCanvasMCPServer } from 'canvas-lms-mcp'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 
 const { server, canvas } = createCanvasMCPServer({
@@ -155,7 +155,7 @@ The `server` is a standard `McpServer` instance with all 88 tools and 2 resource
 Use the Canvas client without MCP for direct API access:
 
 ```typescript
-import { CanvasClient } from '@bruchris/canvas-lms-mcp/canvas'
+import { CanvasClient } from 'canvas-lms-mcp/canvas'
 
 const canvas = new CanvasClient({
   token: process.env.CANVAS_API_TOKEN!,
@@ -198,7 +198,7 @@ The `CanvasClient` facade exposes 14 domain modules:
 All Canvas client methods throw `CanvasApiError` on failure:
 
 ```typescript
-import { CanvasApiError } from '@bruchris/canvas-lms-mcp/canvas'
+import { CanvasApiError } from 'canvas-lms-mcp/canvas'
 
 try {
   const course = await canvas.courses.get(99999)

--- a/docs/student-guide.md
+++ b/docs/student-guide.md
@@ -32,7 +32,7 @@ Keep this token private. It grants the same access as your Canvas login. If you 
   "mcpServers": {
     "canvas-lms": {
       "command": "npx",
-      "args": ["-y", "@bruchris/canvas-lms-mcp"],
+      "args": ["-y", "canvas-lms-mcp"],
       "env": {
         "CANVAS_API_TOKEN": "paste-your-token-here",
         "CANVAS_BASE_URL": "https://your-school.instructure.com"

--- a/docs/superpowers/plans/2026-04-12-canvas-lms-mcp.md
+++ b/docs/superpowers/plans/2026-04-12-canvas-lms-mcp.md
@@ -768,9 +768,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
-      - run: pnpm publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm install --global npm@^11.5.1
+      - run: npm publish --access public --no-git-checks --provenance --registry https://registry.npmjs.org/
 ```
 
 - [ ] **Step 3: Create `release-please-config.json`**

--- a/docs/superpowers/specs/2026-04-12-canvas-lms-mcp-design.md
+++ b/docs/superpowers/specs/2026-04-12-canvas-lms-mcp-design.md
@@ -570,7 +570,7 @@ Automated release management via [release-please](https://github.com/googleapis/
 **npm-publish.yml** — runs when release-please creates a release:
 - Builds the package
 - Publishes to npm as `canvas-lms-mcp`
-- Uses `NPM_TOKEN` secret for authentication
+- Uses npm Trusted Publishing (OIDC) for authentication
 
 ## Agent Team
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@bruchris/canvas-lms-mcp",
+  "name": "canvas-lms-mcp",
   "version": "0.5.1",
   "description": "TypeScript MCP 1.x server for Canvas LMS — 88 tools across Canvas courses, assignments, grades, quizzes, discussions, admin workflows, and more.",
   "type": "module",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -31,7 +31,7 @@ configSchema:
 commandFunction: |-
   (config) => ({
     command: 'npx',
-    args: ['-y', '@bruchris/canvas-lms-mcp'],
+    args: ['-y', 'canvas-lms-mcp'],
     env: {
       CANVAS_API_TOKEN: config.canvasApiToken,
       CANVAS_BASE_URL: config.canvasBaseUrl


### PR DESCRIPTION
## Summary

- Rename npm package metadata and user-facing install/import examples to `canvas-lms-mcp`
- Remove the release workflow token fallback and publish only through npm Trusted Publishing OIDC
- Update stale planning/spec references so no scoped package or npm token publish references remain

## Verification

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm lint`
- `npx --yes js-yaml .github/workflows/release-please.yml`

## Follow-up

After this publishes successfully under `canvas-lms-mcp`, deprecate the old scoped package manually:

```bash
npm deprecate @bruchris/canvas-lms-mcp "Package moved to canvas-lms-mcp (unscoped)"
```

PR #46 was already merged/closed before this branch, so no close action was needed.