### PR TITLE
feat: add mcpName for Official MCP Registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "canvas-lms-mcp",
   "version": "1.1.1",
+  "mcpName": "io.github.bruchris/canvas-lms-mcp",
   "description": "TypeScript MCP 1.x server for Canvas LMS — 88 tools across Canvas courses, assignments, grades, quizzes, discussions, admin workflows, and more.",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- Adds `mcpName: "io.github.bruchris/canvas-lms-mcp"` to package.json
- Required by the `mcp-publisher` CLI to publish to the [Official MCP Registry](https://github.com/modelcontextprotocol/registry)
- PulseMCP and other directories ingest from this registry automatically

## Context

Part of [BRU-223] community engagement strategy. The Official MCP Registry is the upstream source that PulseMCP (and others) pull from. Without `mcpName`, we can't use `mcp-publisher` to register.

After this merges and a new version is published to npm, the board can run:
```bash
mcp-publisher publish --github
```

## Test plan

- [x] `pnpm test` — 507/507 passing
- [x] No functional change — metadata field only

🤖 Generated with [Claude Code](https://claude.com/claude-code)