### PR TITLE
feat: add read-only outcomes tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ AI Agent  -->  MCP Transport (stdio/HTTP)
 
 ## Tool Inventory
 
-88 tools total: 60 read-only, 28 write operations.
+100 tools total: 72 read-only, 28 write operations.
 
 | Domain | Tools |
 | --- | --- |
@@ -79,6 +79,7 @@ AI Agent  -->  MCP Transport (stdio/HTTP)
 | Peer Reviews | `list_peer_reviews`, `get_submission_peer_reviews`, `create_peer_review`, `delete_peer_review` |
 | Accounts | `get_account`, `list_accounts`, `list_sub_accounts`, `list_account_courses`, `list_account_users`, `get_account_reports` |
 | Analytics | `search_course_content`, `get_course_analytics`, `get_student_analytics`, `get_course_activity_stream` |
+| Outcomes | `get_root_outcome_group`, `list_outcome_groups`, `list_outcome_group_links`, `get_outcome_group`, `list_outcome_group_outcomes`, `list_outcome_group_subgroups`, `get_outcome`, `get_outcome_alignments`, `get_outcome_results`, `get_outcome_rollups`, `get_outcome_contributing_scores`, `get_outcome_mastery_distribution` |
 | Student | `get_my_courses`, `get_my_grades`, `get_my_submissions`, `get_my_upcoming_assignments` |
 | Dashboard | `get_dashboard_cards`, `get_todo_items`, `get_upcoming_events`, `get_missing_submissions` |
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 MCP server for [Canvas LMS](https://www.instructure.com/canvas). Read courses, assignments, submissions, rubrics, quizzes; grade, comment, manage course content, and handle Canvas admin workflows from any AI agent.
 
-88 tools across Canvas courses, assignments, submissions, rubrics, quizzes, files, users, groups, enrollments, discussions, modules, pages, calendar, conversations, peer reviews, accounts, analytics, student workflows, dashboard, and health checks. Three deployment modes: stdio, HTTP, and library import.
+100 tools across Canvas courses, assignments, submissions, rubrics, quizzes, files, users, groups, enrollments, discussions, modules, pages, calendar, conversations, peer reviews, accounts, analytics, outcomes, student workflows, dashboard, and health checks. Three deployment modes: stdio, HTTP, and library import.
 
 ## Comparison
 
@@ -173,7 +173,7 @@ Once configured, try these prompts with your AI client:
 
 ## Tool Inventory
 
-### All Registered Tools (88)
+### All Registered Tools (100)
 
 | Category | Tools |
 |----------|-------|
@@ -195,10 +195,11 @@ Once configured, try these prompts with your AI client:
 | Peer Reviews | `list_peer_reviews`, `get_submission_peer_reviews`, `create_peer_review`, `delete_peer_review` |
 | Accounts | `get_account`, `list_accounts`, `list_sub_accounts`, `list_account_courses`, `list_account_users`, `get_account_reports` |
 | Analytics | `search_course_content`, `get_course_analytics`, `get_student_analytics`, `get_course_activity_stream` |
+| Outcomes | `get_root_outcome_group`, `list_outcome_groups`, `list_outcome_group_links`, `get_outcome_group`, `list_outcome_group_outcomes`, `list_outcome_group_subgroups`, `get_outcome`, `get_outcome_alignments`, `get_outcome_results`, `get_outcome_rollups`, `get_outcome_contributing_scores`, `get_outcome_mastery_distribution` |
 | Student | `get_my_courses`, `get_my_grades`, `get_my_submissions`, `get_my_upcoming_assignments` |
 | Dashboard | `get_dashboard_cards`, `get_todo_items`, `get_upcoming_events`, `get_missing_submissions` |
 
-60 tools are read-only and 28 tools perform Canvas write operations.
+72 tools are read-only and 28 tools perform Canvas write operations.
 
 All write tools require appropriate Canvas permissions. Canvas enforces its own permission model -- the MCP server does not bypass it.
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -148,7 +148,7 @@ const transport = new StdioServerTransport()
 await server.connect(transport)
 ```
 
-The `server` is a standard `McpServer` instance with all 88 tools and 2 resources registered. The `canvas` is the underlying `CanvasClient` instance if you need direct API access.
+The `server` is a standard `McpServer` instance with all 100 tools and 2 resources registered. The `canvas` is the underlying `CanvasClient` instance if you need direct API access.
 
 ### Standalone Canvas Client
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "canvas-lms-mcp",
   "version": "1.2.2",
   "mcpName": "io.github.bruchris/canvas-lms-mcp",
-  "description": "TypeScript MCP 1.x server for Canvas LMS — 88 tools across Canvas courses, assignments, grades, quizzes, discussions, admin workflows, and more.",
+  "description": "TypeScript MCP 1.x server for Canvas LMS — 100 tools across Canvas courses, assignments, grades, quizzes, outcomes, discussions, admin workflows, and more.",
   "type": "module",
   "exports": {
     ".": {

--- a/src/canvas/index.ts
+++ b/src/canvas/index.ts
@@ -18,6 +18,7 @@ import { PeerReviewsModule } from './peer-reviews'
 import { AccountsModule } from './accounts'
 import { AnalyticsModule } from './analytics'
 import { DashboardModule } from './dashboard'
+import { OutcomesModule } from './outcomes'
 
 export class CanvasClient {
   private client: CanvasHttpClient
@@ -39,6 +40,7 @@ export class CanvasClient {
   accounts: AccountsModule
   analytics: AnalyticsModule
   dashboard: DashboardModule
+  outcomes: OutcomesModule
 
   constructor(config: CanvasClientConfig) {
     this.client = new CanvasHttpClient(config)
@@ -60,6 +62,7 @@ export class CanvasClient {
     this.accounts = new AccountsModule(this.client)
     this.analytics = new AnalyticsModule(this.client)
     this.dashboard = new DashboardModule(this.client)
+    this.outcomes = new OutcomesModule(this.client)
   }
 }
 

--- a/src/canvas/outcomes.ts
+++ b/src/canvas/outcomes.ts
@@ -16,10 +16,7 @@ export const OUTCOME_DETAIL_LEVELS = ['abbrev', 'full'] as const
 export const OUTCOME_ROLLUP_AGGREGATE_STATS = ['mean', 'median'] as const
 export const OUTCOME_ROLLUP_SORT_BY = ['student', 'outcome'] as const
 export const OUTCOME_SORT_ORDER = ['asc', 'desc'] as const
-export const OUTCOME_EXCLUDE_OPTIONS = [
-  'missing_user_rollups',
-  'missing_outcome_results',
-] as const
+export const OUTCOME_EXCLUDE_OPTIONS = ['missing_user_rollups', 'missing_outcome_results'] as const
 
 type ContextPathSuffix = 'outcome_groups' | 'outcome_group_links' | 'root_outcome_group'
 
@@ -89,7 +86,10 @@ export class OutcomesModule {
     )
   }
 
-  async getOutcome(outcomeId: number, options?: { add_defaults?: boolean }): Promise<CanvasOutcome> {
+  async getOutcome(
+    outcomeId: number,
+    options?: { add_defaults?: boolean },
+  ): Promise<CanvasOutcome> {
     return this.client.request<CanvasOutcome>(
       this.withQuery(`/api/v1/outcomes/${outcomeId}`, {
         add_defaults: options?.add_defaults,

--- a/src/canvas/outcomes.ts
+++ b/src/canvas/outcomes.ts
@@ -1,0 +1,234 @@
+import type { CanvasHttpClient } from './client'
+import type {
+  CanvasOutcomeContextType,
+  CanvasOutcome,
+  CanvasOutcomeAlignment,
+  CanvasOutcomeContributingScoresResponse,
+  CanvasOutcomeGroup,
+  CanvasOutcomeLink,
+  CanvasOutcomeMasteryDistributionResponse,
+  CanvasOutcomeResultsResponse,
+  CanvasOutcomeRollupsResponse,
+} from './types'
+
+export const OUTCOME_CONTEXT_TYPES = ['account', 'course'] as const
+export const OUTCOME_DETAIL_LEVELS = ['abbrev', 'full'] as const
+export const OUTCOME_ROLLUP_AGGREGATE_STATS = ['mean', 'median'] as const
+export const OUTCOME_ROLLUP_SORT_BY = ['student', 'outcome'] as const
+export const OUTCOME_SORT_ORDER = ['asc', 'desc'] as const
+export const OUTCOME_EXCLUDE_OPTIONS = [
+  'missing_user_rollups',
+  'missing_outcome_results',
+] as const
+
+type ContextPathSuffix = 'outcome_groups' | 'outcome_group_links' | 'root_outcome_group'
+
+export class OutcomesModule {
+  constructor(private client: CanvasHttpClient) {}
+
+  async getRootOutcomeGroup(
+    contextType: CanvasOutcomeContextType,
+    contextId: number,
+  ): Promise<CanvasOutcomeGroup> {
+    return this.client.request<CanvasOutcomeGroup>(this.buildContextPath(contextType, contextId))
+  }
+
+  async listOutcomeGroups(
+    contextType: CanvasOutcomeContextType,
+    contextId: number,
+  ): Promise<CanvasOutcomeGroup[]> {
+    return this.client.paginate<CanvasOutcomeGroup>(
+      this.buildContextPath(contextType, contextId, 'outcome_groups'),
+    )
+  }
+
+  async listOutcomeGroupLinks(
+    contextType: CanvasOutcomeContextType,
+    contextId: number,
+    options?: { outcome_style?: 'abbrev' | 'full'; outcome_group_style?: 'abbrev' | 'full' },
+  ): Promise<CanvasOutcomeLink[]> {
+    return this.client.paginate<CanvasOutcomeLink>(
+      this.withQuery(this.buildContextPath(contextType, contextId, 'outcome_group_links'), {
+        outcome_style: options?.outcome_style,
+        outcome_group_style: options?.outcome_group_style,
+      }),
+    )
+  }
+
+  async getOutcomeGroup(
+    contextType: CanvasOutcomeContextType,
+    contextId: number,
+    groupId: number,
+  ): Promise<CanvasOutcomeGroup> {
+    return this.client.request<CanvasOutcomeGroup>(
+      `${this.buildContextPath(contextType, contextId, 'outcome_groups')}/${groupId}`,
+    )
+  }
+
+  async listGroupOutcomes(
+    contextType: CanvasOutcomeContextType,
+    contextId: number,
+    groupId: number,
+    options?: { outcome_style?: 'abbrev' | 'full' },
+  ): Promise<CanvasOutcomeLink[]> {
+    return this.client.paginate<CanvasOutcomeLink>(
+      this.withQuery(
+        `${this.buildContextPath(contextType, contextId, 'outcome_groups')}/${groupId}/outcomes`,
+        { outcome_style: options?.outcome_style },
+      ),
+    )
+  }
+
+  async listGroupSubgroups(
+    contextType: CanvasOutcomeContextType,
+    contextId: number,
+    groupId: number,
+  ): Promise<CanvasOutcomeGroup[]> {
+    return this.client.paginate<CanvasOutcomeGroup>(
+      `${this.buildContextPath(contextType, contextId, 'outcome_groups')}/${groupId}/subgroups`,
+    )
+  }
+
+  async getOutcome(outcomeId: number, options?: { add_defaults?: boolean }): Promise<CanvasOutcome> {
+    return this.client.request<CanvasOutcome>(
+      this.withQuery(`/api/v1/outcomes/${outcomeId}`, {
+        add_defaults: options?.add_defaults,
+      }),
+    )
+  }
+
+  async getOutcomeAlignments(
+    courseId: number,
+    options?: { student_id?: number; assignment_id?: number },
+  ): Promise<CanvasOutcomeAlignment[]> {
+    return this.client.request<CanvasOutcomeAlignment[]>(
+      this.withQuery(`/api/v1/courses/${courseId}/outcome_alignments`, {
+        student_id: options?.student_id,
+        assignment_id: options?.assignment_id,
+      }),
+    )
+  }
+
+  async getOutcomeResults(
+    courseId: number,
+    options?: {
+      user_ids?: Array<number | string>
+      outcome_ids?: number[]
+      include_alignments?: boolean
+      include_hidden?: boolean
+    },
+  ): Promise<CanvasOutcomeResultsResponse> {
+    return this.client.request<CanvasOutcomeResultsResponse>(
+      this.withQuery(`/api/v1/courses/${courseId}/outcome_results`, {
+        'user_ids[]': options?.user_ids,
+        'outcome_ids[]': options?.outcome_ids,
+        'include[]': options?.include_alignments ? ['alignments'] : undefined,
+        include_hidden: options?.include_hidden,
+      }),
+    )
+  }
+
+  async getOutcomeRollups(
+    courseId: number,
+    options?: {
+      aggregate?: 'course'
+      aggregate_stat?: 'mean' | 'median'
+      user_ids?: Array<number | string>
+      outcome_ids?: number[]
+      include_courses?: boolean
+      exclude?: Array<'missing_user_rollups' | 'missing_outcome_results'>
+      sort_by?: 'student' | 'outcome'
+      sort_outcome_id?: number
+      sort_order?: 'asc' | 'desc'
+      add_defaults?: boolean
+    },
+  ): Promise<CanvasOutcomeRollupsResponse> {
+    return this.client.request<CanvasOutcomeRollupsResponse>(
+      this.withQuery(`/api/v1/courses/${courseId}/outcome_rollups`, {
+        aggregate: options?.aggregate,
+        aggregate_stat: options?.aggregate_stat,
+        'user_ids[]': options?.user_ids,
+        'outcome_ids[]': options?.outcome_ids,
+        'include[]': options?.include_courses ? ['courses'] : undefined,
+        'exclude[]': options?.exclude,
+        sort_by: options?.sort_by,
+        sort_outcome_id: options?.sort_outcome_id,
+        sort_order: options?.sort_order,
+        add_defaults: options?.add_defaults,
+      }),
+    )
+  }
+
+  async getOutcomeContributingScores(
+    courseId: number,
+    outcomeId: number,
+    options?: {
+      user_ids?: Array<number | string>
+      only_assignment_alignments?: boolean
+      show_unpublished_assignments?: boolean
+    },
+  ): Promise<CanvasOutcomeContributingScoresResponse> {
+    return this.client.request<CanvasOutcomeContributingScoresResponse>(
+      this.withQuery(`/api/v1/courses/${courseId}/outcomes/${outcomeId}/contributing_scores`, {
+        'user_ids[]': options?.user_ids,
+        only_assignment_alignments: options?.only_assignment_alignments,
+        show_unpublished_assignments: options?.show_unpublished_assignments,
+      }),
+    )
+  }
+
+  async getOutcomeMasteryDistribution(
+    courseId: number,
+    options?: {
+      exclude?: Array<'missing_user_rollups' | 'missing_outcome_results'>
+      outcome_ids?: number[]
+      student_ids?: Array<number | string>
+      include_alignment_distributions?: boolean
+      only_assignment_alignments?: boolean
+      show_unpublished_assignments?: boolean
+      add_defaults?: boolean
+    },
+  ): Promise<CanvasOutcomeMasteryDistributionResponse> {
+    return this.client.request<CanvasOutcomeMasteryDistributionResponse>(
+      this.withQuery(`/api/v1/courses/${courseId}/outcome_mastery_distribution`, {
+        'exclude[]': options?.exclude,
+        'outcome_ids[]': options?.outcome_ids,
+        'student_ids[]': options?.student_ids,
+        'include[]': options?.include_alignment_distributions
+          ? ['alignment_distributions']
+          : undefined,
+        only_assignment_alignments: options?.only_assignment_alignments,
+        show_unpublished_assignments: options?.show_unpublished_assignments,
+        add_defaults: options?.add_defaults,
+      }),
+    )
+  }
+
+  private buildContextPath(
+    contextType: CanvasOutcomeContextType,
+    contextId: number,
+    suffix: ContextPathSuffix = 'root_outcome_group',
+  ): string {
+    const segment = contextType === 'account' ? 'accounts' : 'courses'
+    return `/api/v1/${segment}/${contextId}/${suffix}`
+  }
+
+  private withQuery(
+    endpoint: string,
+    params: Record<string, string | number | boolean | Array<string | number> | undefined>,
+  ): string {
+    const searchParams = new URLSearchParams()
+
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined) continue
+      if (Array.isArray(value)) {
+        for (const item of value) searchParams.append(key, String(item))
+        continue
+      }
+      searchParams.set(key, String(value))
+    }
+
+    const query = searchParams.toString()
+    return query ? `${endpoint}?${query}` : endpoint
+  }
+}

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -396,6 +396,135 @@ export interface CanvasConversationUnreadCount {
   unread_count: number
 }
 
+// --- Outcomes ---
+
+export type CanvasOutcomeContextType = 'account' | 'course'
+
+export interface CanvasOutcomeRating {
+  description: string
+  points: number
+  mastery?: boolean
+  color?: string | null
+}
+
+export interface CanvasOutcome {
+  id: number
+  url: string
+  context_id: number | null
+  context_type: 'Account' | 'Course' | 'Global' | (string & {})
+  title: string
+  display_name?: string | null
+  description?: string
+  vendor_guid?: string | null
+  points_possible?: number
+  mastery_points?: number | null
+  calculation_method?: string | null
+  calculation_int?: number | null
+  ratings?: CanvasOutcomeRating[]
+}
+
+export interface CanvasOutcomeGroup {
+  id: number
+  url: string
+  context_id: number | null
+  context_type: 'Account' | 'Course' | 'Global' | (string & {})
+  title: string
+  description?: string | null
+  vendor_guid?: string | null
+  subgroups_url?: string
+  outcomes_url?: string
+  can_edit?: boolean
+}
+
+export interface CanvasOutcomeLink {
+  id: number | string
+  url?: string
+  context_id?: number | null
+  context_type?: 'Account' | 'Course' | 'Global' | (string & {})
+  outcome_group?: CanvasOutcomeGroup | null
+  outcome?: CanvasOutcome | null
+  assessed?: boolean
+}
+
+export interface CanvasOutcomeAlignment {
+  id: number
+  assignment_id: number | null
+  assessment_id: number | null
+  submission_types?: string | null
+  url?: string | null
+  title: string
+}
+
+export interface CanvasOutcomeResult {
+  id: number
+  score: number | null
+  submitted_or_assessed_at: string | null
+  links: {
+    user: string | number
+    learning_outcome: string | number
+    alignment: string | number
+  }
+  percent: number | null
+}
+
+export interface CanvasOutcomeResultsResponse {
+  outcome_results: CanvasOutcomeResult[]
+  linked?: {
+    users?: CanvasUser[]
+    outcomes?: CanvasOutcome[]
+    outcome_groups?: CanvasOutcomeGroup[]
+    alignments?: CanvasOutcomeAlignment[]
+  }
+}
+
+export interface CanvasOutcomeRollupScore {
+  score: number | null
+  count: number
+  links: {
+    outcome: string | number
+  }
+}
+
+export interface CanvasOutcomeRollup {
+  scores: CanvasOutcomeRollupScore[] | null
+  name: string
+  links: {
+    course?: number
+    user?: number
+    section?: number
+  }
+}
+
+export interface CanvasOutcomeRollupsResponse {
+  rollups: CanvasOutcomeRollup[]
+  linked?: {
+    users?: CanvasUser[]
+    outcomes?: CanvasOutcome[]
+    outcome_groups?: CanvasOutcomeGroup[]
+    courses?: CanvasCourse[]
+    sections?: Array<{ id: number; name: string }>
+  }
+}
+
+export interface CanvasOutcomeContributingScoresResponse {
+  scores: Array<Record<string, unknown>>
+  linked?: {
+    users?: CanvasUser[]
+    outcomes?: CanvasOutcome[]
+    outcome_groups?: CanvasOutcomeGroup[]
+    alignments?: CanvasOutcomeAlignment[]
+  }
+}
+
+export interface CanvasOutcomeMasteryDistributionResponse {
+  linked?: {
+    outcomes?: CanvasOutcome[]
+    outcome_groups?: CanvasOutcomeGroup[]
+    alignments?: CanvasOutcomeAlignment[]
+  }
+  outcomes?: Array<Record<string, unknown>>
+}
+
 // --- Accounts ---
 
 export interface CanvasAccount {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -23,6 +23,7 @@ import { accountTools } from './accounts'
 import { analyticsTools } from './analytics'
 import { studentTools } from './student'
 import { dashboardTools } from './dashboard'
+import { outcomeTools } from './outcomes'
 
 export function getAllTools(canvas: CanvasClient): ToolDefinition[] {
   return [
@@ -44,6 +45,7 @@ export function getAllTools(canvas: CanvasClient): ToolDefinition[] {
     ...peerReviewTools(canvas),
     ...accountTools(canvas),
     ...analyticsTools(canvas),
+    ...outcomeTools(canvas),
     ...studentTools(canvas),
     ...dashboardTools(canvas),
   ]

--- a/src/tools/outcomes.ts
+++ b/src/tools/outcomes.ts
@@ -254,9 +254,9 @@ export function outcomeTools(canvas: CanvasClient): ToolDefinition[] {
           user_ids: params.user_ids as Array<number | string> | undefined,
           outcome_ids: params.outcome_ids as number[] | undefined,
           include_courses: params.include_courses as boolean | undefined,
-          exclude: params.exclude as Array<
-            'missing_user_rollups' | 'missing_outcome_results'
-          > | undefined,
+          exclude: params.exclude as
+            | Array<'missing_user_rollups' | 'missing_outcome_results'>
+            | undefined,
           sort_by: params.sort_by as 'student' | 'outcome' | undefined,
           sort_outcome_id: params.sort_outcome_id as number | undefined,
           sort_order: params.sort_order as 'asc' | 'desc' | undefined,
@@ -335,18 +335,16 @@ export function outcomeTools(canvas: CanvasClient): ToolDefinition[] {
       annotations: { readOnlyHint: true, openWorldHint: true },
       handler: async (params) =>
         canvas.outcomes.getOutcomeMasteryDistribution(params.course_id as number, {
-          exclude: params.exclude as Array<
-            'missing_user_rollups' | 'missing_outcome_results'
-          > | undefined,
+          exclude: params.exclude as
+            | Array<'missing_user_rollups' | 'missing_outcome_results'>
+            | undefined,
           outcome_ids: params.outcome_ids as number[] | undefined,
           student_ids: params.student_ids as Array<number | string> | undefined,
           include_alignment_distributions: params.include_alignment_distributions as
             | boolean
             | undefined,
           only_assignment_alignments: params.only_assignment_alignments as boolean | undefined,
-          show_unpublished_assignments: params.show_unpublished_assignments as
-            | boolean
-            | undefined,
+          show_unpublished_assignments: params.show_unpublished_assignments as boolean | undefined,
           add_defaults: params.add_defaults as boolean | undefined,
         }),
     },

--- a/src/tools/outcomes.ts
+++ b/src/tools/outcomes.ts
@@ -1,0 +1,354 @@
+import { z } from 'zod'
+import type { CanvasClient } from '../canvas'
+import type { ToolDefinition } from './types'
+import {
+  OUTCOME_CONTEXT_TYPES,
+  OUTCOME_DETAIL_LEVELS,
+  OUTCOME_EXCLUDE_OPTIONS,
+  OUTCOME_ROLLUP_AGGREGATE_STATS,
+  OUTCOME_ROLLUP_SORT_BY,
+  OUTCOME_SORT_ORDER,
+} from '../canvas/outcomes'
+
+export function outcomeTools(canvas: CanvasClient): ToolDefinition[] {
+  return [
+    {
+      name: 'get_root_outcome_group',
+      description: 'Get the root outcome group for an account or course context.',
+      inputSchema: {
+        context_type: z
+          .enum(OUTCOME_CONTEXT_TYPES)
+          .describe('Whether to read outcomes from an account or course context.'),
+        context_id: z.number().describe('The Canvas account ID or course ID for the context.'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      handler: async (params) =>
+        canvas.outcomes.getRootOutcomeGroup(
+          params.context_type as 'account' | 'course',
+          params.context_id as number,
+        ),
+    },
+    {
+      name: 'list_outcome_groups',
+      description: 'List all outcome groups for an account or course context.',
+      inputSchema: {
+        context_type: z
+          .enum(OUTCOME_CONTEXT_TYPES)
+          .describe('Whether to read outcome groups from an account or course context.'),
+        context_id: z.number().describe('The Canvas account ID or course ID for the context.'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      handler: async (params) =>
+        canvas.outcomes.listOutcomeGroups(
+          params.context_type as 'account' | 'course',
+          params.context_id as number,
+        ),
+    },
+    {
+      name: 'list_outcome_group_links',
+      description: 'List all outcome links in an account or course context.',
+      inputSchema: {
+        context_type: z
+          .enum(OUTCOME_CONTEXT_TYPES)
+          .describe('Whether to read outcome links from an account or course context.'),
+        context_id: z.number().describe('The Canvas account ID or course ID for the context.'),
+        outcome_style: z
+          .enum(OUTCOME_DETAIL_LEVELS)
+          .optional()
+          .describe('Outcome detail level. Use "full" to include expanded outcome fields.'),
+        outcome_group_style: z
+          .enum(OUTCOME_DETAIL_LEVELS)
+          .optional()
+          .describe(
+            'Outcome group detail level. Use "full" to include expanded outcome group fields.',
+          ),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      handler: async (params) =>
+        canvas.outcomes.listOutcomeGroupLinks(
+          params.context_type as 'account' | 'course',
+          params.context_id as number,
+          {
+            outcome_style: params.outcome_style as 'abbrev' | 'full' | undefined,
+            outcome_group_style: params.outcome_group_style as 'abbrev' | 'full' | undefined,
+          },
+        ),
+    },
+    {
+      name: 'get_outcome_group',
+      description: 'Get details for a specific outcome group in an account or course context.',
+      inputSchema: {
+        context_type: z.enum(OUTCOME_CONTEXT_TYPES).describe('The outcome group context type.'),
+        context_id: z.number().describe('The Canvas account ID or course ID for the context.'),
+        outcome_group_id: z.number().describe('The Canvas outcome group ID.'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      handler: async (params) =>
+        canvas.outcomes.getOutcomeGroup(
+          params.context_type as 'account' | 'course',
+          params.context_id as number,
+          params.outcome_group_id as number,
+        ),
+    },
+    {
+      name: 'list_outcome_group_outcomes',
+      description: 'List the linked outcomes directly under a specific outcome group.',
+      inputSchema: {
+        context_type: z.enum(OUTCOME_CONTEXT_TYPES).describe('The outcome group context type.'),
+        context_id: z.number().describe('The Canvas account ID or course ID for the context.'),
+        outcome_group_id: z.number().describe('The Canvas outcome group ID.'),
+        outcome_style: z
+          .enum(OUTCOME_DETAIL_LEVELS)
+          .optional()
+          .describe('Outcome detail level. Use "full" to include expanded outcome fields.'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      handler: async (params) =>
+        canvas.outcomes.listGroupOutcomes(
+          params.context_type as 'account' | 'course',
+          params.context_id as number,
+          params.outcome_group_id as number,
+          {
+            outcome_style: params.outcome_style as 'abbrev' | 'full' | undefined,
+          },
+        ),
+    },
+    {
+      name: 'list_outcome_group_subgroups',
+      description: 'List the immediate child outcome groups under a specific outcome group.',
+      inputSchema: {
+        context_type: z.enum(OUTCOME_CONTEXT_TYPES).describe('The outcome group context type.'),
+        context_id: z.number().describe('The Canvas account ID or course ID for the context.'),
+        outcome_group_id: z.number().describe('The Canvas outcome group ID.'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      handler: async (params) =>
+        canvas.outcomes.listGroupSubgroups(
+          params.context_type as 'account' | 'course',
+          params.context_id as number,
+          params.outcome_group_id as number,
+        ),
+    },
+    {
+      name: 'get_outcome',
+      description: 'Get the full details for a specific learning outcome by ID.',
+      inputSchema: {
+        outcome_id: z.number().describe('The Canvas outcome ID.'),
+        add_defaults: z
+          .boolean()
+          .optional()
+          .describe('Include default mastery colors and levels when Canvas supports it.'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      handler: async (params) =>
+        canvas.outcomes.getOutcome(params.outcome_id as number, {
+          add_defaults: params.add_defaults as boolean | undefined,
+        }),
+    },
+    {
+      name: 'get_outcome_alignments',
+      description:
+        'Get outcome alignments for a course, optionally filtered to a specific student or assignment.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID.'),
+        student_id: z
+          .number()
+          .optional()
+          .describe('Optional Canvas user ID of the student to filter alignments by.'),
+        assignment_id: z
+          .number()
+          .optional()
+          .describe('Optional Canvas assignment ID to filter alignments by.'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      handler: async (params) =>
+        canvas.outcomes.getOutcomeAlignments(params.course_id as number, {
+          student_id: params.student_id as number | undefined,
+          assignment_id: params.assignment_id as number | undefined,
+        }),
+    },
+    {
+      name: 'get_outcome_results',
+      description:
+        'Get per-student outcome results for a course, with optional outcome, student, and alignment filters.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID.'),
+        user_ids: z
+          .array(z.union([z.number(), z.string()]))
+          .optional()
+          .describe('Optional Canvas user IDs or SIS user IDs prefixed with "sis_user_id:".'),
+        outcome_ids: z
+          .array(z.number())
+          .optional()
+          .describe('Optional outcome IDs to restrict the results.'),
+        include_alignments: z
+          .boolean()
+          .optional()
+          .describe('Include linked alignment details in the response.'),
+        include_hidden: z
+          .boolean()
+          .optional()
+          .describe('Include hidden outcomes when Canvas supports it.'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      handler: async (params) =>
+        canvas.outcomes.getOutcomeResults(params.course_id as number, {
+          user_ids: params.user_ids as Array<number | string> | undefined,
+          outcome_ids: params.outcome_ids as number[] | undefined,
+          include_alignments: params.include_alignments as boolean | undefined,
+          include_hidden: params.include_hidden as boolean | undefined,
+        }),
+    },
+    {
+      name: 'get_outcome_rollups',
+      description:
+        'Get outcome rollups for a course, optionally aggregated or filtered by students, outcomes, and sort options.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID.'),
+        aggregate: z
+          .enum(['course'])
+          .optional()
+          .describe('Aggregate all student rollups into a single course-level rollup.'),
+        aggregate_stat: z
+          .enum(OUTCOME_ROLLUP_AGGREGATE_STATS)
+          .optional()
+          .describe('Statistic to use when aggregate="course".'),
+        user_ids: z
+          .array(z.union([z.number(), z.string()]))
+          .optional()
+          .describe('Optional Canvas user IDs or SIS user IDs prefixed with "sis_user_id:".'),
+        outcome_ids: z
+          .array(z.number())
+          .optional()
+          .describe('Optional outcome IDs to restrict the rollups.'),
+        include_courses: z
+          .boolean()
+          .optional()
+          .describe('Include linked course details in the response payload.'),
+        exclude: z
+          .array(z.enum(OUTCOME_EXCLUDE_OPTIONS))
+          .optional()
+          .describe('Optional rollup exclusions for missing users or missing outcome results.'),
+        sort_by: z
+          .enum(OUTCOME_ROLLUP_SORT_BY)
+          .optional()
+          .describe('Sort rollups by student name or by a specific outcome score.'),
+        sort_outcome_id: z
+          .number()
+          .optional()
+          .describe('Outcome ID to sort by when sort_by="outcome".'),
+        sort_order: z
+          .enum(OUTCOME_SORT_ORDER)
+          .optional()
+          .describe('Sort order to apply when sorting rollups.'),
+        add_defaults: z
+          .boolean()
+          .optional()
+          .describe('Include default mastery colors and levels when Canvas supports it.'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      handler: async (params) =>
+        canvas.outcomes.getOutcomeRollups(params.course_id as number, {
+          aggregate: params.aggregate as 'course' | undefined,
+          aggregate_stat: params.aggregate_stat as 'mean' | 'median' | undefined,
+          user_ids: params.user_ids as Array<number | string> | undefined,
+          outcome_ids: params.outcome_ids as number[] | undefined,
+          include_courses: params.include_courses as boolean | undefined,
+          exclude: params.exclude as Array<
+            'missing_user_rollups' | 'missing_outcome_results'
+          > | undefined,
+          sort_by: params.sort_by as 'student' | 'outcome' | undefined,
+          sort_outcome_id: params.sort_outcome_id as number | undefined,
+          sort_order: params.sort_order as 'asc' | 'desc' | undefined,
+          add_defaults: params.add_defaults as boolean | undefined,
+        }),
+    },
+    {
+      name: 'get_outcome_contributing_scores',
+      description:
+        'Get assignment or quiz scores that contributed to a specific outcome for one or more students in a course.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID.'),
+        outcome_id: z.number().describe('The Canvas outcome ID.'),
+        user_ids: z
+          .array(z.union([z.number(), z.string()]))
+          .optional()
+          .describe('Optional Canvas user IDs or SIS user IDs prefixed with "sis_user_id:".'),
+        only_assignment_alignments: z
+          .boolean()
+          .optional()
+          .describe('Limit results to assignment alignments only.'),
+        show_unpublished_assignments: z
+          .boolean()
+          .optional()
+          .describe('Include unpublished assignments in the contributing score results.'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      handler: async (params) =>
+        canvas.outcomes.getOutcomeContributingScores(
+          params.course_id as number,
+          params.outcome_id as number,
+          {
+            user_ids: params.user_ids as Array<number | string> | undefined,
+            only_assignment_alignments: params.only_assignment_alignments as boolean | undefined,
+            show_unpublished_assignments: params.show_unpublished_assignments as
+              | boolean
+              | undefined,
+          },
+        ),
+    },
+    {
+      name: 'get_outcome_mastery_distribution',
+      description:
+        'Get mastery distribution analytics for outcomes in a course, optionally filtered by students or outcomes.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID.'),
+        exclude: z
+          .array(z.enum(OUTCOME_EXCLUDE_OPTIONS))
+          .optional()
+          .describe('Optional exclusions for missing users or missing outcome results.'),
+        outcome_ids: z
+          .array(z.number())
+          .optional()
+          .describe('Optional outcome IDs to restrict the distribution results.'),
+        student_ids: z
+          .array(z.union([z.number(), z.string()]))
+          .optional()
+          .describe('Optional Canvas student IDs or SIS user IDs prefixed with "sis_user_id:".'),
+        include_alignment_distributions: z
+          .boolean()
+          .optional()
+          .describe('Include contributing score distributions for alignments.'),
+        only_assignment_alignments: z
+          .boolean()
+          .optional()
+          .describe('When including alignment distributions, limit them to assignments only.'),
+        show_unpublished_assignments: z
+          .boolean()
+          .optional()
+          .describe('Include unpublished assignments in alignment distributions.'),
+        add_defaults: z
+          .boolean()
+          .optional()
+          .describe('Include default mastery colors and levels when Canvas supports it.'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      handler: async (params) =>
+        canvas.outcomes.getOutcomeMasteryDistribution(params.course_id as number, {
+          exclude: params.exclude as Array<
+            'missing_user_rollups' | 'missing_outcome_results'
+          > | undefined,
+          outcome_ids: params.outcome_ids as number[] | undefined,
+          student_ids: params.student_ids as Array<number | string> | undefined,
+          include_alignment_distributions: params.include_alignment_distributions as
+            | boolean
+            | undefined,
+          only_assignment_alignments: params.only_assignment_alignments as boolean | undefined,
+          show_unpublished_assignments: params.show_unpublished_assignments as
+            | boolean
+            | undefined,
+          add_defaults: params.add_defaults as boolean | undefined,
+        }),
+    },
+  ]
+}

--- a/tests/canvas/outcomes.test.ts
+++ b/tests/canvas/outcomes.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CanvasHttpClient } from '../../src/canvas/client'
+import { OutcomesModule } from '../../src/canvas/outcomes'
+
+describe('OutcomesModule', () => {
+  let client: CanvasHttpClient
+  let outcomes: OutcomesModule
+
+  beforeEach(() => {
+    client = new CanvasHttpClient({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+    })
+    outcomes = new OutcomesModule(client)
+  })
+
+  it('gets the root outcome group for a course context', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce({ id: 7, title: 'Course Outcomes' })
+    const result = await outcomes.getRootOutcomeGroup('course', 42)
+    expect(result).toMatchObject({ id: 7, title: 'Course Outcomes' })
+    expect(client.request).toHaveBeenCalledWith('/api/v1/courses/42/root_outcome_group')
+  })
+
+  it('lists outcome groups for an account context', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([{ id: 1, title: 'Institution Outcomes' }])
+    const result = await outcomes.listOutcomeGroups('account', 9)
+    expect(result).toHaveLength(1)
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/accounts/9/outcome_groups')
+  })
+
+  it('lists outcome group links with detail params', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([{ id: 1 }])
+    await outcomes.listOutcomeGroupLinks('course', 42, {
+      outcome_style: 'full',
+      outcome_group_style: 'full',
+    })
+    expect(client.paginate).toHaveBeenCalledWith(
+      '/api/v1/courses/42/outcome_group_links?outcome_style=full&outcome_group_style=full',
+    )
+  })
+
+  it('gets a specific outcome group', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce({ id: 13, title: 'Writing Skills' })
+    const result = await outcomes.getOutcomeGroup('course', 42, 13)
+    expect(result).toMatchObject({ id: 13, title: 'Writing Skills' })
+    expect(client.request).toHaveBeenCalledWith('/api/v1/courses/42/outcome_groups/13')
+  })
+
+  it('lists outcomes in an outcome group with optional detail level', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([{ id: 2 }])
+    await outcomes.listGroupOutcomes('account', 9, 3, { outcome_style: 'full' })
+    expect(client.paginate).toHaveBeenCalledWith(
+      '/api/v1/accounts/9/outcome_groups/3/outcomes?outcome_style=full',
+    )
+  })
+
+  it('lists subgroups in an outcome group', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([{ id: 5, title: 'Subgroup' }])
+    const result = await outcomes.listGroupSubgroups('course', 42, 3)
+    expect(result).toHaveLength(1)
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/42/outcome_groups/3/subgroups')
+  })
+
+  it('gets an outcome with add_defaults enabled', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce({ id: 8, title: 'Critical Thinking' })
+    const result = await outcomes.getOutcome(8, { add_defaults: true })
+    expect(result).toMatchObject({ id: 8, title: 'Critical Thinking' })
+    expect(client.request).toHaveBeenCalledWith('/api/v1/outcomes/8?add_defaults=true')
+  })
+
+  it('gets outcome alignments for a student and assignment filter', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce([{ id: 9, title: 'Quiz 1' }])
+    const result = await outcomes.getOutcomeAlignments(42, {
+      student_id: 55,
+      assignment_id: 99,
+    })
+    expect(result).toHaveLength(1)
+    expect(client.request).toHaveBeenCalledWith(
+      '/api/v1/courses/42/outcome_alignments?student_id=55&assignment_id=99',
+    )
+  })
+
+  it('gets outcome results with repeated user and outcome filters', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce({ outcome_results: [] })
+    await outcomes.getOutcomeResults(42, {
+      user_ids: [10, 'sis_user_id:abc'],
+      outcome_ids: [1, 2],
+      include_alignments: true,
+      include_hidden: true,
+    })
+    expect(client.request).toHaveBeenCalledWith(
+      '/api/v1/courses/42/outcome_results?user_ids%5B%5D=10&user_ids%5B%5D=sis_user_id%3Aabc&outcome_ids%5B%5D=1&outcome_ids%5B%5D=2&include%5B%5D=alignments&include_hidden=true',
+    )
+  })
+
+  it('gets outcome rollups with aggregate, filters, and sorting options', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce({ rollups: [] })
+    await outcomes.getOutcomeRollups(42, {
+      aggregate: 'course',
+      aggregate_stat: 'median',
+      user_ids: [10],
+      outcome_ids: [3],
+      include_courses: true,
+      exclude: ['missing_user_rollups'],
+      sort_by: 'outcome',
+      sort_outcome_id: 3,
+      sort_order: 'desc',
+      add_defaults: true,
+    })
+    expect(client.request).toHaveBeenCalledWith(
+      '/api/v1/courses/42/outcome_rollups?aggregate=course&aggregate_stat=median&user_ids%5B%5D=10&outcome_ids%5B%5D=3&include%5B%5D=courses&exclude%5B%5D=missing_user_rollups&sort_by=outcome&sort_outcome_id=3&sort_order=desc&add_defaults=true',
+    )
+  })
+
+  it('gets contributing scores for a specific outcome', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce({ scores: [] })
+    await outcomes.getOutcomeContributingScores(42, 8, {
+      user_ids: [10],
+      only_assignment_alignments: true,
+      show_unpublished_assignments: true,
+    })
+    expect(client.request).toHaveBeenCalledWith(
+      '/api/v1/courses/42/outcomes/8/contributing_scores?user_ids%5B%5D=10&only_assignment_alignments=true&show_unpublished_assignments=true',
+    )
+  })
+
+  it('gets outcome mastery distribution with alignment distributions', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce({ outcomes: [] })
+    await outcomes.getOutcomeMasteryDistribution(42, {
+      exclude: ['missing_outcome_results'],
+      outcome_ids: [8],
+      student_ids: [10],
+      include_alignment_distributions: true,
+      only_assignment_alignments: true,
+      show_unpublished_assignments: true,
+      add_defaults: true,
+    })
+    expect(client.request).toHaveBeenCalledWith(
+      '/api/v1/courses/42/outcome_mastery_distribution?exclude%5B%5D=missing_outcome_results&outcome_ids%5B%5D=8&student_ids%5B%5D=10&include%5B%5D=alignment_distributions&only_assignment_alignments=true&show_unpublished_assignments=true&add_defaults=true',
+    )
+  })
+})

--- a/tests/tools/outcomes.test.ts
+++ b/tests/tools/outcomes.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { CanvasClient } from '../../src/canvas'
+import { outcomeTools } from '../../src/tools/outcomes'
+
+describe('outcomeTools', () => {
+  function buildMockCanvas(): CanvasClient {
+    return {
+      outcomes: {
+        getRootOutcomeGroup: vi.fn().mockResolvedValue({ id: 1 }),
+        listOutcomeGroups: vi.fn().mockResolvedValue([]),
+        listOutcomeGroupLinks: vi.fn().mockResolvedValue([]),
+        getOutcomeGroup: vi.fn().mockResolvedValue({ id: 2 }),
+        listGroupOutcomes: vi.fn().mockResolvedValue([]),
+        listGroupSubgroups: vi.fn().mockResolvedValue([]),
+        getOutcome: vi.fn().mockResolvedValue({ id: 3 }),
+        getOutcomeAlignments: vi.fn().mockResolvedValue([]),
+        getOutcomeResults: vi.fn().mockResolvedValue({ outcome_results: [] }),
+        getOutcomeRollups: vi.fn().mockResolvedValue({ rollups: [] }),
+        getOutcomeContributingScores: vi.fn().mockResolvedValue({ scores: [] }),
+        getOutcomeMasteryDistribution: vi.fn().mockResolvedValue({ outcomes: [] }),
+      },
+    } as unknown as CanvasClient
+  }
+
+  it('returns 12 read-only tool definitions', () => {
+    expect(outcomeTools(buildMockCanvas())).toHaveLength(12)
+  })
+
+  it('exports tools with the expected names', () => {
+    const names = outcomeTools(buildMockCanvas()).map((tool) => tool.name)
+    expect(names).toEqual([
+      'get_root_outcome_group',
+      'list_outcome_groups',
+      'list_outcome_group_links',
+      'get_outcome_group',
+      'list_outcome_group_outcomes',
+      'list_outcome_group_subgroups',
+      'get_outcome',
+      'get_outcome_alignments',
+      'get_outcome_results',
+      'get_outcome_rollups',
+      'get_outcome_contributing_scores',
+      'get_outcome_mastery_distribution',
+    ])
+  })
+
+  it('marks every outcome tool as read-only and open-world', () => {
+    for (const tool of outcomeTools(buildMockCanvas())) {
+      expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+    }
+  })
+
+  it('delegates get_root_outcome_group to the outcomes module', async () => {
+    const canvas = buildMockCanvas()
+    const tool = outcomeTools(canvas).find((t) => t.name === 'get_root_outcome_group')!
+    await tool.handler({ context_type: 'course', context_id: 42 })
+    expect(canvas.outcomes.getRootOutcomeGroup).toHaveBeenCalledWith('course', 42)
+  })
+
+  it('delegates list_outcome_group_links with detail options', async () => {
+    const canvas = buildMockCanvas()
+    const tool = outcomeTools(canvas).find((t) => t.name === 'list_outcome_group_links')!
+    await tool.handler({
+      context_type: 'account',
+      context_id: 9,
+      outcome_style: 'full',
+      outcome_group_style: 'full',
+    })
+    expect(canvas.outcomes.listOutcomeGroupLinks).toHaveBeenCalledWith('account', 9, {
+      outcome_style: 'full',
+      outcome_group_style: 'full',
+    })
+  })
+
+  it('delegates get_outcome with add_defaults', async () => {
+    const canvas = buildMockCanvas()
+    const tool = outcomeTools(canvas).find((t) => t.name === 'get_outcome')!
+    await tool.handler({ outcome_id: 5, add_defaults: true })
+    expect(canvas.outcomes.getOutcome).toHaveBeenCalledWith(5, { add_defaults: true })
+  })
+
+  it('delegates get_outcome_results filters', async () => {
+    const canvas = buildMockCanvas()
+    const tool = outcomeTools(canvas).find((t) => t.name === 'get_outcome_results')!
+    await tool.handler({
+      course_id: 42,
+      user_ids: [10, 'sis_user_id:abc'],
+      outcome_ids: [1, 2],
+      include_alignments: true,
+      include_hidden: true,
+    })
+    expect(canvas.outcomes.getOutcomeResults).toHaveBeenCalledWith(42, {
+      user_ids: [10, 'sis_user_id:abc'],
+      outcome_ids: [1, 2],
+      include_alignments: true,
+      include_hidden: true,
+    })
+  })
+
+  it('delegates get_outcome_rollups filters', async () => {
+    const canvas = buildMockCanvas()
+    const tool = outcomeTools(canvas).find((t) => t.name === 'get_outcome_rollups')!
+    await tool.handler({
+      course_id: 42,
+      aggregate: 'course',
+      aggregate_stat: 'mean',
+      user_ids: [10],
+      outcome_ids: [3],
+      include_courses: true,
+      exclude: ['missing_user_rollups'],
+      sort_by: 'student',
+      sort_order: 'asc',
+      add_defaults: true,
+    })
+    expect(canvas.outcomes.getOutcomeRollups).toHaveBeenCalledWith(42, {
+      aggregate: 'course',
+      aggregate_stat: 'mean',
+      user_ids: [10],
+      outcome_ids: [3],
+      include_courses: true,
+      exclude: ['missing_user_rollups'],
+      sort_by: 'student',
+      sort_outcome_id: undefined,
+      sort_order: 'asc',
+      add_defaults: true,
+    })
+  })
+
+  it('delegates get_outcome_mastery_distribution filters', async () => {
+    const canvas = buildMockCanvas()
+    const tool = outcomeTools(canvas).find(
+      (t) => t.name === 'get_outcome_mastery_distribution',
+    )!
+    await tool.handler({
+      course_id: 42,
+      exclude: ['missing_outcome_results'],
+      outcome_ids: [8],
+      student_ids: [10],
+      include_alignment_distributions: true,
+      only_assignment_alignments: true,
+      show_unpublished_assignments: true,
+      add_defaults: true,
+    })
+    expect(canvas.outcomes.getOutcomeMasteryDistribution).toHaveBeenCalledWith(42, {
+      exclude: ['missing_outcome_results'],
+      outcome_ids: [8],
+      student_ids: [10],
+      include_alignment_distributions: true,
+      only_assignment_alignments: true,
+      show_unpublished_assignments: true,
+      add_defaults: true,
+    })
+  })
+})

--- a/tests/tools/outcomes.test.ts
+++ b/tests/tools/outcomes.test.ts
@@ -128,9 +128,7 @@ describe('outcomeTools', () => {
 
   it('delegates get_outcome_mastery_distribution filters', async () => {
     const canvas = buildMockCanvas()
-    const tool = outcomeTools(canvas).find(
-      (t) => t.name === 'get_outcome_mastery_distribution',
-    )!
+    const tool = outcomeTools(canvas).find((t) => t.name === 'get_outcome_mastery_distribution')!
     await tool.handler({
       course_id: 42,
       exclude: ['missing_outcome_results'],

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -118,6 +118,20 @@ function buildFullMockCanvas(): CanvasClient {
       getStudentActivity: async () => ({}),
       getCourseActivityStream: async () => [],
     },
+    outcomes: {
+      getRootOutcomeGroup: async () => ({}),
+      listOutcomeGroups: async () => [],
+      listOutcomeGroupLinks: async () => [],
+      getOutcomeGroup: async () => ({}),
+      listGroupOutcomes: async () => [],
+      listGroupSubgroups: async () => [],
+      getOutcome: async () => ({}),
+      getOutcomeAlignments: async () => [],
+      getOutcomeResults: async () => ({ outcome_results: [] }),
+      getOutcomeRollups: async () => ({ rollups: [] }),
+      getOutcomeContributingScores: async () => ({ scores: [] }),
+      getOutcomeMasteryDistribution: async () => ({ outcomes: [] }),
+    },
     dashboard: {
       getDashboardCards: async () => [],
       getTodoItems: async () => [],
@@ -133,7 +147,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 88 tools across all domains', () => {
+  it('returns all 100 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 
@@ -235,6 +249,19 @@ describe('getAllTools', () => {
     expect(names).toContain('get_course_analytics')
     expect(names).toContain('get_student_analytics')
     expect(names).toContain('get_course_activity_stream')
+    // Outcomes (12)
+    expect(names).toContain('get_root_outcome_group')
+    expect(names).toContain('list_outcome_groups')
+    expect(names).toContain('list_outcome_group_links')
+    expect(names).toContain('get_outcome_group')
+    expect(names).toContain('list_outcome_group_outcomes')
+    expect(names).toContain('list_outcome_group_subgroups')
+    expect(names).toContain('get_outcome')
+    expect(names).toContain('get_outcome_alignments')
+    expect(names).toContain('get_outcome_results')
+    expect(names).toContain('get_outcome_rollups')
+    expect(names).toContain('get_outcome_contributing_scores')
+    expect(names).toContain('get_outcome_mastery_distribution')
     // Student (4)
     expect(names).toContain('get_my_courses')
     expect(names).toContain('get_my_grades')
@@ -246,7 +273,7 @@ describe('getAllTools', () => {
     expect(names).toContain('get_upcoming_events')
     expect(names).toContain('get_missing_submissions')
 
-    expect(tools).toHaveLength(88)
+    expect(tools).toHaveLength(100)
   })
 
   it('all tools have openWorldHint: true', () => {


### PR DESCRIPTION
## Summary
- add a standalone outcomes canvas module covering outcome groups, links, details, alignments, results, rollups, contributing scores, and mastery distribution
- register 12 new read-only MCP tools for the outcomes domain and update the public tool inventory to 100 tools
- add canvas/tool tests for the new outcomes domain and update the registry coverage

## Validation
- pnpm typecheck
- pnpm test
- pnpm build

Closes BRU-468.