### PR TITLE
feat: add generated discovery manifests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,15 @@ When adding a new Canvas capability:
 4. Register the tools in `src/tools/index.ts`.
 5. Add tests covering success cases, errors, and pagination when relevant.
 
+If you add, remove, rename, or reclassify tools or workflow catalog entries, regenerate the
+agent-discovery artifacts before opening the PR:
+
+```bash
+pnpm generate:manifests
+```
+
+The committed files in `docs/generated/` are expected to stay in sync with the live registry.
+
 ## Pull Requests
 
 - Use a clear title and explain the user-facing impact.

--- a/docs/agent-discovery.md
+++ b/docs/agent-discovery.md
@@ -1,0 +1,19 @@
+# Agent Discovery Manifests
+
+`canvas-lms-mcp` ships generated discovery artifacts for agent tooling under `docs/generated/`:
+
+- `tool-manifest.json` describes the registered MCP tool surface.
+- `workflow-manifest.json` describes workflow catalog entries that link back to related tools.
+
+These files are generated from the live tool registry and the in-repo workflow catalog source.
+
+## Regenerating
+
+Run:
+
+```bash
+pnpm generate:manifests
+```
+
+Regenerate whenever you add, remove, rename, or reclassify a tool, or when you change the
+workflow catalog.

--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,0 +1,1241 @@
+{
+  "schemaVersion": "1.0",
+  "packageName": "canvas-lms-mcp",
+  "toolCount": 100,
+  "tools": [
+    {
+      "name": "health_check",
+      "domain": "health",
+      "description": "Check if the Canvas API is reachable and the token is valid. Returns ok/error status.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_courses",
+      "domain": "courses",
+      "description": "List courses for the authenticated user. Optionally filter by enrollment state.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_course",
+      "domain": "courses",
+      "description": "Get details for a single course by ID, including term and total student count.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_syllabus",
+      "domain": "courses",
+      "description": "Get the syllabus HTML body for a course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "create_course",
+      "domain": "courses",
+      "description": "Create a new course in a Canvas account. Returns the created course object.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "update_course",
+      "domain": "courses",
+      "description": "Update an existing course. Only provided fields are changed; omitted fields are left as-is.",
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_assignments",
+      "domain": "assignments",
+      "description": "List all assignments in a course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": [
+        "educator-assignment-review"
+      ]
+    },
+    {
+      "name": "get_assignment",
+      "domain": "assignments",
+      "description": "Get details for a single assignment by ID.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": [
+        "educator-assignment-review"
+      ]
+    },
+    {
+      "name": "list_assignment_groups",
+      "domain": "assignments",
+      "description": "List assignment groups (categories like Homework, Exams) in a course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "create_assignment",
+      "domain": "assignments",
+      "description": "Create a new assignment in a course.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "update_assignment",
+      "domain": "assignments",
+      "description": "Update an existing assignment in a course.",
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "delete_assignment",
+      "domain": "assignments",
+      "description": "Delete an assignment from a course.",
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_submissions",
+      "domain": "submissions",
+      "description": "List all submissions for an assignment in a course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": [
+        "educator-assignment-review"
+      ]
+    },
+    {
+      "name": "get_submission",
+      "domain": "submissions",
+      "description": "Get a single submission for a specific user on an assignment, including comments.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": [
+        "educator-assignment-review"
+      ]
+    },
+    {
+      "name": "grade_submission",
+      "domain": "submissions",
+      "description": "Post or update a grade for a submission. Requires grading permissions.",
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": [
+        "educator-assignment-review"
+      ]
+    },
+    {
+      "name": "comment_on_submission",
+      "domain": "submissions",
+      "description": "Add a text comment to a submission.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": [
+        "educator-assignment-review"
+      ]
+    },
+    {
+      "name": "list_rubrics",
+      "domain": "rubrics",
+      "description": "List all rubrics in a course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_rubric",
+      "domain": "rubrics",
+      "description": "Get details for a single rubric by ID, including criteria.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": [
+        "educator-assignment-review"
+      ]
+    },
+    {
+      "name": "get_rubric_assessment",
+      "domain": "rubrics",
+      "description": "Get the rubric assessment for a specific student submission on an assignment.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "submit_rubric_assessment",
+      "domain": "rubrics",
+      "description": "Submit a rubric assessment with scores and comments for each criterion.",
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": [
+        "educator-assignment-review"
+      ]
+    },
+    {
+      "name": "list_quizzes",
+      "domain": "quizzes",
+      "description": "List all quizzes in a course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_quiz",
+      "domain": "quizzes",
+      "description": "Get details for a single quiz by ID.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_quiz_submissions",
+      "domain": "quizzes",
+      "description": "List all submissions for a quiz.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_quiz_questions",
+      "domain": "quizzes",
+      "description": "List all questions in a quiz.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_quiz_submission_answers",
+      "domain": "quizzes",
+      "description": "Get a student's answers for a quiz submission.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "score_quiz_question",
+      "domain": "quizzes",
+      "description": "Score a specific question in a quiz submission. Specify attempt to score a particular attempt (omit for latest). Requires grading permissions.",
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_files",
+      "domain": "files",
+      "description": "List all files in a course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_folders",
+      "domain": "files",
+      "description": "List all folders in a course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_file",
+      "domain": "files",
+      "description": "Get metadata for a single file by ID, including download URL.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "upload_file",
+      "domain": "files",
+      "description": "Upload a file to a course. Content must be base64-encoded. Canvas performs a multi-step upload internally.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "delete_file",
+      "domain": "files",
+      "description": "Delete a file by ID. This action is permanent.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_students",
+      "domain": "users",
+      "description": "List all students enrolled in a course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_user",
+      "domain": "users",
+      "description": "Get details for a single user by ID.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_profile",
+      "domain": "users",
+      "description": "Get the profile of the currently authenticated user.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "search_users",
+      "domain": "users",
+      "description": "Search for users in a Canvas account by name, login, or email.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_course_users",
+      "domain": "users",
+      "description": "List all users in a course, optionally filtered by enrollment type.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_groups",
+      "domain": "groups",
+      "description": "List all groups in a course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "student",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_group_members",
+      "domain": "groups",
+      "description": "List all members of a group.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "student",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_enrollments",
+      "domain": "enrollments",
+      "description": "List all enrollments for the authenticated user across courses.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "admin",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "enroll_user",
+      "domain": "enrollments",
+      "description": "Enroll a user in a course with a specified role.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "admin",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "remove_enrollment",
+      "domain": "enrollments",
+      "description": "Remove or conclude an enrollment from a course.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "admin",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_discussions",
+      "domain": "discussions",
+      "description": "List all discussion topics in a course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_discussion",
+      "domain": "discussions",
+      "description": "Get details for a single discussion topic by ID.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_announcements",
+      "domain": "discussions",
+      "description": "List all announcements in a course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "post_discussion_entry",
+      "domain": "discussions",
+      "description": "Post a new entry (reply) to a discussion topic.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "create_discussion",
+      "domain": "discussions",
+      "description": "Create a new discussion topic in a course.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "update_discussion",
+      "domain": "discussions",
+      "description": "Update an existing discussion topic.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "delete_discussion",
+      "domain": "discussions",
+      "description": "Delete a discussion topic from a course.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_modules",
+      "domain": "modules",
+      "description": "List all modules in a course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_module",
+      "domain": "modules",
+      "description": "Get details for a single module by ID.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_module_items",
+      "domain": "modules",
+      "description": "List all items within a module.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "create_module",
+      "domain": "modules",
+      "description": "Create a new module in a course.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "update_module",
+      "domain": "modules",
+      "description": "Update an existing module (rename, reposition, publish/unpublish).",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "create_module_item",
+      "domain": "modules",
+      "description": "Add an item (Assignment, Page, Quiz, File, Discussion, ExternalUrl, ExternalTool, SubHeader) to a module.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_pages",
+      "domain": "pages",
+      "description": "List all wiki pages in a course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_page",
+      "domain": "pages",
+      "description": "Get a single wiki page by its URL slug.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "create_page",
+      "domain": "pages",
+      "description": "Create a new wiki page in a course.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "update_page",
+      "domain": "pages",
+      "description": "Update an existing wiki page.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "delete_page",
+      "domain": "pages",
+      "description": "Delete a wiki page from a course.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_calendar_events",
+      "domain": "calendar",
+      "description": "List calendar events for a course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "create_calendar_event",
+      "domain": "calendar",
+      "description": "Create a new calendar event in Canvas.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "update_calendar_event",
+      "domain": "calendar",
+      "description": "Update an existing calendar event. Only provided fields are changed.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_conversations",
+      "domain": "conversations",
+      "description": "List conversations (inbox messages) for the authenticated user.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_conversation",
+      "domain": "conversations",
+      "description": "Get a single conversation with its full message thread.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_conversation_unread_count",
+      "domain": "conversations",
+      "description": "Get the number of unread conversations for the authenticated user.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "send_conversation",
+      "domain": "conversations",
+      "description": "Send a new conversation message to one or more recipients.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_peer_reviews",
+      "domain": "peer_reviews",
+      "description": "List all peer reviews for an assignment in a course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "student",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_submission_peer_reviews",
+      "domain": "peer_reviews",
+      "description": "List peer reviews assigned to a specific submission.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "student",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "create_peer_review",
+      "domain": "peer_reviews",
+      "description": "Assign a user to peer-review a submission.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "delete_peer_review",
+      "domain": "peer_reviews",
+      "description": "Remove a peer review assignment from a submission.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_account",
+      "domain": "accounts",
+      "description": "Get details for a Canvas account by ID.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "admin",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_accounts",
+      "domain": "accounts",
+      "description": "List all accounts accessible to the authenticated user.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "admin",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_sub_accounts",
+      "domain": "accounts",
+      "description": "List sub-accounts under a given Canvas account.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "admin",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_account_courses",
+      "domain": "accounts",
+      "description": "List courses under a given Canvas account.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "admin",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_account_users",
+      "domain": "accounts",
+      "description": "List users in a Canvas account.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "admin",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_account_reports",
+      "domain": "accounts",
+      "description": "List available report types for a Canvas account.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "admin",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "search_course_content",
+      "domain": "analytics",
+      "description": "Search for content within a course. Searches pages, assignments, discussions, and announcements by keyword.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_course_analytics",
+      "domain": "analytics",
+      "description": "Get course-level activity analytics. Returns daily page view and participation counts.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_student_analytics",
+      "domain": "analytics",
+      "description": "Get per-student activity analytics for a course. Returns page views, participations, and submission timeline for a specific student.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_course_activity_stream",
+      "domain": "analytics",
+      "description": "Get a summary of recent activity in a course. Returns counts of recent events grouped by type (submissions, discussions, announcements, etc.).",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_root_outcome_group",
+      "domain": "outcomes",
+      "description": "Get the root outcome group for an account or course context.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_outcome_groups",
+      "domain": "outcomes",
+      "description": "List all outcome groups for an account or course context.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_outcome_group_links",
+      "domain": "outcomes",
+      "description": "List all outcome links in an account or course context.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_outcome_group",
+      "domain": "outcomes",
+      "description": "Get details for a specific outcome group in an account or course context.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_outcome_group_outcomes",
+      "domain": "outcomes",
+      "description": "List the linked outcomes directly under a specific outcome group.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_outcome_group_subgroups",
+      "domain": "outcomes",
+      "description": "List the immediate child outcome groups under a specific outcome group.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_outcome",
+      "domain": "outcomes",
+      "description": "Get the full details for a specific learning outcome by ID.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_outcome_alignments",
+      "domain": "outcomes",
+      "description": "Get outcome alignments for a course, optionally filtered to a specific student or assignment.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_outcome_results",
+      "domain": "outcomes",
+      "description": "Get per-student outcome results for a course, with optional outcome, student, and alignment filters.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_outcome_rollups",
+      "domain": "outcomes",
+      "description": "Get outcome rollups for a course, optionally aggregated or filtered by students, outcomes, and sort options.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_outcome_contributing_scores",
+      "domain": "outcomes",
+      "description": "Get assignment or quiz scores that contributed to a specific outcome for one or more students in a course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_outcome_mastery_distribution",
+      "domain": "outcomes",
+      "description": "Get mastery distribution analytics for outcomes in a course, optionally filtered by students or outcomes.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_my_courses",
+      "domain": "student",
+      "description": "List active courses for the authenticated student.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "student",
+      "relatedWorkflows": [
+        "student-weekly-planning"
+      ]
+    },
+    {
+      "name": "get_my_grades",
+      "domain": "student",
+      "description": "Get grade data for the authenticated student. If course_id is omitted, returns grades across all enrolled courses.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "student",
+      "relatedWorkflows": [
+        "student-weekly-planning"
+      ]
+    },
+    {
+      "name": "get_my_submissions",
+      "domain": "student",
+      "description": "List all submissions for the authenticated student in a course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "student",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_my_upcoming_assignments",
+      "domain": "student",
+      "description": "List upcoming assignment events for the authenticated student.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "student",
+      "relatedWorkflows": [
+        "student-weekly-planning"
+      ]
+    },
+    {
+      "name": "get_dashboard_cards",
+      "domain": "dashboard",
+      "description": "Get the current user's dashboard course cards with position, color, and image.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "student",
+      "relatedWorkflows": [
+        "student-weekly-planning"
+      ]
+    },
+    {
+      "name": "get_todo_items",
+      "domain": "dashboard",
+      "description": "Get the current user's to-do items, including upcoming assignments and grading tasks.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "student",
+      "relatedWorkflows": [
+        "student-weekly-planning"
+      ]
+    },
+    {
+      "name": "get_upcoming_events",
+      "domain": "dashboard",
+      "description": "Get the current user's upcoming calendar events and assignments.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "student",
+      "relatedWorkflows": [
+        "student-weekly-planning"
+      ]
+    },
+    {
+      "name": "get_missing_submissions",
+      "domain": "dashboard",
+      "description": "Get assignments with missing submissions for the current user.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "student",
+      "relatedWorkflows": []
+    }
+  ]
+}

--- a/docs/generated/workflow-manifest.json
+++ b/docs/generated/workflow-manifest.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0",
+  "workflowCount": 2,
+  "workflows": [
+    {
+      "id": "educator-assignment-review",
+      "title": "Educator Assignment Review",
+      "description": "Review an assignment, inspect submissions, apply grades, and leave feedback.",
+      "primaryAudience": "educator",
+      "status": "proposed",
+      "relatedTools": [
+        "list_assignments",
+        "get_assignment",
+        "list_submissions",
+        "get_submission",
+        "get_rubric",
+        "grade_submission",
+        "comment_on_submission",
+        "submit_rubric_assessment"
+      ]
+    },
+    {
+      "id": "student-weekly-planning",
+      "title": "Student Weekly Planning",
+      "description": "Review dashboard items, upcoming deadlines, and current course load for weekly planning.",
+      "primaryAudience": "student",
+      "status": "proposed",
+      "relatedTools": [
+        "get_dashboard_cards",
+        "get_todo_items",
+        "get_upcoming_events",
+        "get_my_upcoming_assignments",
+        "get_my_courses",
+        "get_my_grades"
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
+    "generate:manifests": "tsx scripts/generate-manifests.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint src/ tests/ && prettier --check src/ tests/",
@@ -91,6 +92,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "prettier": "^3.8.2",
+    "tsx": "^4.20.6",
     "tsup": "^8.5.1",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,10 @@ importers:
         version: 3.8.2
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.9)(typescript@6.0.2)
+        version: 8.5.1(postcss@8.5.9)(tsx@4.21.0)(typescript@6.0.2)
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -56,7 +59,7 @@ importers:
         version: 8.58.1(eslint@10.2.0)(typescript@6.0.2)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0))
 
 packages:
 
@@ -1018,6 +1021,9 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
@@ -1407,6 +1413,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   rolldown@1.0.0-rc.15:
     resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1561,6 +1570,11 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2172,7 +2186,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7))
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -2183,13 +2197,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7))':
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -2592,6 +2606,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
@@ -2847,11 +2865,12 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.9):
+  postcss-load-config@6.0.1(postcss@8.5.9)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       postcss: 8.5.9
+      tsx: 4.21.0
 
   postcss@8.5.9:
     dependencies:
@@ -2892,6 +2911,8 @@ snapshots:
   require-from-string@2.0.2: {}
 
   resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   rolldown@1.0.0-rc.15:
     dependencies:
@@ -3084,7 +3105,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  tsup@8.5.1(postcss@8.5.9)(typescript@6.0.2):
+  tsup@8.5.1(postcss@8.5.9)(tsx@4.21.0)(typescript@6.0.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -3095,7 +3116,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.9)
+      postcss-load-config: 6.0.1(postcss@8.5.9)(tsx@4.21.0)
       resolve-from: 5.0.0
       rollup: 4.60.1
       source-map: 0.7.6
@@ -3111,6 +3132,13 @@ snapshots:
       - supports-color
       - tsx
       - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:
@@ -3147,7 +3175,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7):
+  vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -3158,11 +3186,12 @@ snapshots:
       '@types/node': 25.6.0
       esbuild: 0.27.7
       fsevents: 2.3.3
+      tsx: 4.21.0
 
-  vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)):
+  vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7))
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -3179,7 +3208,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0

--- a/scripts/generate-manifests.ts
+++ b/scripts/generate-manifests.ts
@@ -1,0 +1,17 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { buildToolManifest, buildWorkflowManifest } from '../src/discovery/manifests'
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+async function main(): Promise<void> {
+  const outputDir = resolve('docs/generated')
+
+  await mkdir(outputDir, { recursive: true })
+  await writeJson(resolve(outputDir, 'tool-manifest.json'), buildToolManifest())
+  await writeJson(resolve(outputDir, 'workflow-manifest.json'), buildWorkflowManifest())
+}
+
+await main()

--- a/src/discovery/catalog.ts
+++ b/src/discovery/catalog.ts
@@ -1,0 +1,80 @@
+import type { ToolAudience } from '../tools/types'
+
+export interface WorkflowCatalogEntry {
+  id: string
+  title: string
+  description: string
+  primaryAudience: ToolAudience
+  status: 'proposed' | 'available'
+  relatedTools: string[]
+}
+
+export const workflowCatalog: readonly WorkflowCatalogEntry[] = [
+  {
+    id: 'educator-assignment-review',
+    title: 'Educator Assignment Review',
+    description: 'Review an assignment, inspect submissions, apply grades, and leave feedback.',
+    primaryAudience: 'educator',
+    status: 'proposed',
+    relatedTools: [
+      'list_assignments',
+      'get_assignment',
+      'list_submissions',
+      'get_submission',
+      'get_rubric',
+      'grade_submission',
+      'comment_on_submission',
+      'submit_rubric_assessment',
+    ],
+  },
+  {
+    id: 'student-weekly-planning',
+    title: 'Student Weekly Planning',
+    description:
+      'Review dashboard items, upcoming deadlines, and current course load for weekly planning.',
+    primaryAudience: 'student',
+    status: 'proposed',
+    relatedTools: [
+      'get_dashboard_cards',
+      'get_todo_items',
+      'get_upcoming_events',
+      'get_my_upcoming_assignments',
+      'get_my_courses',
+      'get_my_grades',
+    ],
+  },
+]
+
+export const toolAudienceOverrides: Readonly<Record<string, ToolAudience>> = {
+  create_course: 'educator',
+  update_course: 'educator',
+  list_assignments: 'shared',
+  get_assignment: 'shared',
+  list_assignment_groups: 'shared',
+  list_quizzes: 'shared',
+  get_quiz: 'shared',
+  list_quiz_questions: 'shared',
+  list_files: 'shared',
+  list_folders: 'shared',
+  get_file: 'shared',
+  get_profile: 'shared',
+  list_groups: 'student',
+  list_group_members: 'student',
+  list_discussions: 'shared',
+  get_discussion: 'shared',
+  list_announcements: 'shared',
+  list_modules: 'shared',
+  get_module: 'shared',
+  list_module_items: 'shared',
+  list_pages: 'shared',
+  get_page: 'shared',
+  list_calendar_events: 'shared',
+  list_conversations: 'shared',
+  get_conversation: 'shared',
+  get_conversation_unread_count: 'shared',
+  send_conversation: 'shared',
+  list_peer_reviews: 'student',
+  get_submission_peer_reviews: 'student',
+  create_peer_review: 'educator',
+  delete_peer_review: 'educator',
+}

--- a/src/discovery/index.ts
+++ b/src/discovery/index.ts
@@ -1,0 +1,1 @@
+export { buildToolManifest, buildWorkflowManifest } from './manifests'

--- a/src/discovery/manifests.ts
+++ b/src/discovery/manifests.ts
@@ -1,0 +1,124 @@
+import { toolDomainCatalog } from '../tools/catalog'
+import type { ToolAnnotations, ToolAudience, ToolDefinition } from '../tools/types'
+import { toolAudienceOverrides, workflowCatalog } from './catalog'
+
+export interface ToolManifestEntry {
+  name: string
+  domain: string
+  description: string
+  annotations: ToolAnnotations
+  access: 'read' | 'write'
+  primaryAudience: ToolAudience
+  relatedWorkflows: string[]
+}
+
+export interface ToolManifestDocument {
+  schemaVersion: '1.0'
+  packageName: 'canvas-lms-mcp'
+  toolCount: number
+  tools: ToolManifestEntry[]
+}
+
+export interface WorkflowManifestDocument {
+  schemaVersion: '1.0'
+  workflowCount: number
+  workflows: typeof workflowCatalog
+}
+
+interface RegisteredToolContext {
+  tool: ToolDefinition
+  domain: string
+  defaultPrimaryAudience: ToolAudience
+}
+
+function getRegisteredToolContexts(): RegisteredToolContext[] {
+  const canvas = {} as never
+
+  return toolDomainCatalog.flatMap((registration) =>
+    registration.getTools(canvas).map((tool) => ({
+      tool,
+      domain: registration.domain,
+      defaultPrimaryAudience: registration.defaultPrimaryAudience,
+    })),
+  )
+}
+
+function getAccess(annotations: ToolAnnotations): 'read' | 'write' {
+  return annotations.destructiveHint ? 'write' : 'read'
+}
+
+function compactAnnotations(annotations: ToolAnnotations): ToolAnnotations {
+  const compacted: ToolAnnotations = {}
+
+  if (annotations.readOnlyHint) {
+    compacted.readOnlyHint = true
+  }
+  if (annotations.destructiveHint) {
+    compacted.destructiveHint = true
+  }
+  if (annotations.idempotentHint) {
+    compacted.idempotentHint = true
+  }
+  if (annotations.openWorldHint) {
+    compacted.openWorldHint = true
+  }
+
+  return compacted
+}
+
+function getRelatedWorkflowIds(toolName: string): string[] {
+  return workflowCatalog
+    .filter((workflow) => workflow.relatedTools.includes(toolName))
+    .map((workflow) => workflow.id)
+}
+
+function getPrimaryAudience(toolName: string, defaultPrimaryAudience: ToolAudience): ToolAudience {
+  return toolAudienceOverrides[toolName] ?? defaultPrimaryAudience
+}
+
+function assertWorkflowLinksExist(toolNames: Set<string>): void {
+  for (const workflow of workflowCatalog) {
+    for (const relatedTool of workflow.relatedTools) {
+      if (!toolNames.has(relatedTool)) {
+        throw new Error(`Workflow "${workflow.id}" references unknown tool "${relatedTool}".`)
+      }
+    }
+  }
+}
+
+export function buildToolManifest(): ToolManifestDocument {
+  const registeredTools = getRegisteredToolContexts()
+  const toolNames = new Set(registeredTools.map(({ tool }) => tool.name))
+
+  assertWorkflowLinksExist(toolNames)
+
+  const tools = registeredTools.map(({ tool, domain, defaultPrimaryAudience }) => ({
+    name: tool.name,
+    domain,
+    description: tool.description,
+    annotations: compactAnnotations(tool.annotations),
+    access: getAccess(tool.annotations),
+    primaryAudience: getPrimaryAudience(tool.name, defaultPrimaryAudience),
+    relatedWorkflows: getRelatedWorkflowIds(tool.name),
+  }))
+
+  return {
+    schemaVersion: '1.0',
+    packageName: 'canvas-lms-mcp',
+    toolCount: tools.length,
+    tools,
+  }
+}
+
+export function buildWorkflowManifest(): WorkflowManifestDocument {
+  const toolManifest = buildToolManifest()
+  const toolNames = new Set(toolManifest.tools.map((tool) => tool.name))
+
+  assertWorkflowLinksExist(toolNames)
+
+  return {
+    schemaVersion: '1.0',
+    workflowCount: workflowCatalog.length,
+    workflows: workflowCatalog,
+  }
+}

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -1,0 +1,137 @@
+import type { CanvasClient } from '../canvas'
+import { accountTools } from './accounts'
+import { analyticsTools } from './analytics'
+import { assignmentTools } from './assignments'
+import { calendarTools } from './calendar'
+import { conversationTools } from './conversations'
+import { courseTools } from './courses'
+import { dashboardTools } from './dashboard'
+import { discussionTools } from './discussions'
+import { enrollmentTools } from './enrollments'
+import { fileTools } from './files'
+import { groupTools } from './groups'
+import { healthTools } from './health'
+import { moduleTools } from './modules'
+import { outcomeTools } from './outcomes'
+import { pageTools } from './pages'
+import { peerReviewTools } from './peer-reviews'
+import { quizTools } from './quizzes'
+import { rubricTools } from './rubrics'
+import { studentTools } from './student'
+import { submissionTools } from './submissions'
+import type { ToolAudience, ToolDefinition } from './types'
+import { userTools } from './users'
+
+export interface ToolDomainRegistration {
+  domain: string
+  defaultPrimaryAudience: ToolAudience
+  getTools: (canvas: CanvasClient) => ToolDefinition[]
+}
+
+export const toolDomainCatalog: readonly ToolDomainRegistration[] = [
+  {
+    domain: 'health',
+    defaultPrimaryAudience: 'shared',
+    getTools: healthTools,
+  },
+  {
+    domain: 'courses',
+    defaultPrimaryAudience: 'shared',
+    getTools: courseTools,
+  },
+  {
+    domain: 'assignments',
+    defaultPrimaryAudience: 'educator',
+    getTools: assignmentTools,
+  },
+  {
+    domain: 'submissions',
+    defaultPrimaryAudience: 'educator',
+    getTools: submissionTools,
+  },
+  {
+    domain: 'rubrics',
+    defaultPrimaryAudience: 'educator',
+    getTools: rubricTools,
+  },
+  {
+    domain: 'quizzes',
+    defaultPrimaryAudience: 'educator',
+    getTools: quizTools,
+  },
+  {
+    domain: 'files',
+    defaultPrimaryAudience: 'shared',
+    getTools: fileTools,
+  },
+  {
+    domain: 'users',
+    defaultPrimaryAudience: 'educator',
+    getTools: userTools,
+  },
+  {
+    domain: 'groups',
+    defaultPrimaryAudience: 'shared',
+    getTools: groupTools,
+  },
+  {
+    domain: 'enrollments',
+    defaultPrimaryAudience: 'admin',
+    getTools: enrollmentTools,
+  },
+  {
+    domain: 'discussions',
+    defaultPrimaryAudience: 'shared',
+    getTools: discussionTools,
+  },
+  {
+    domain: 'modules',
+    defaultPrimaryAudience: 'educator',
+    getTools: moduleTools,
+  },
+  {
+    domain: 'pages',
+    defaultPrimaryAudience: 'educator',
+    getTools: pageTools,
+  },
+  {
+    domain: 'calendar',
+    defaultPrimaryAudience: 'shared',
+    getTools: calendarTools,
+  },
+  {
+    domain: 'conversations',
+    defaultPrimaryAudience: 'shared',
+    getTools: conversationTools,
+  },
+  {
+    domain: 'peer_reviews',
+    defaultPrimaryAudience: 'shared',
+    getTools: peerReviewTools,
+  },
+  {
+    domain: 'accounts',
+    defaultPrimaryAudience: 'admin',
+    getTools: accountTools,
+  },
+  {
+    domain: 'analytics',
+    defaultPrimaryAudience: 'educator',
+    getTools: analyticsTools,
+  },
+  {
+    domain: 'outcomes',
+    defaultPrimaryAudience: 'educator',
+    getTools: outcomeTools,
+  },
+  {
+    domain: 'student',
+    defaultPrimaryAudience: 'student',
+    getTools: studentTools,
+  },
+  {
+    domain: 'dashboard',
+    defaultPrimaryAudience: 'student',
+    getTools: dashboardTools,
+  },
+]

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,53 +2,11 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { CanvasClient } from '../canvas'
 import { CanvasApiError } from '../canvas/client'
 import type { ToolDefinition } from './types'
+import { toolDomainCatalog } from './catalog'
 import { formatError } from './errors'
-import { healthTools } from './health'
-import { courseTools } from './courses'
-import { assignmentTools } from './assignments'
-import { submissionTools } from './submissions'
-import { rubricTools } from './rubrics'
-import { quizTools } from './quizzes'
-import { fileTools } from './files'
-import { userTools } from './users'
-import { groupTools } from './groups'
-import { enrollmentTools } from './enrollments'
-import { discussionTools } from './discussions'
-import { moduleTools } from './modules'
-import { pageTools } from './pages'
-import { calendarTools } from './calendar'
-import { conversationTools } from './conversations'
-import { peerReviewTools } from './peer-reviews'
-import { accountTools } from './accounts'
-import { analyticsTools } from './analytics'
-import { studentTools } from './student'
-import { dashboardTools } from './dashboard'
-import { outcomeTools } from './outcomes'
 
 export function getAllTools(canvas: CanvasClient): ToolDefinition[] {
-  return [
-    ...healthTools(canvas),
-    ...courseTools(canvas),
-    ...assignmentTools(canvas),
-    ...submissionTools(canvas),
-    ...rubricTools(canvas),
-    ...quizTools(canvas),
-    ...fileTools(canvas),
-    ...userTools(canvas),
-    ...groupTools(canvas),
-    ...enrollmentTools(canvas),
-    ...discussionTools(canvas),
-    ...moduleTools(canvas),
-    ...pageTools(canvas),
-    ...calendarTools(canvas),
-    ...conversationTools(canvas),
-    ...peerReviewTools(canvas),
-    ...accountTools(canvas),
-    ...analyticsTools(canvas),
-    ...outcomeTools(canvas),
-    ...studentTools(canvas),
-    ...dashboardTools(canvas),
-  ]
+  return toolDomainCatalog.flatMap((registration) => registration.getTools(canvas))
 }
 
 export function registerAllTools(server: McpServer, canvas: CanvasClient): void {

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,5 +1,7 @@
 import type { z } from 'zod'
 
+export type ToolAudience = 'student' | 'educator' | 'admin' | 'shared'
+
 export interface ToolAnnotations {
   readOnlyHint?: boolean
   destructiveHint?: boolean

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { buildToolManifest, buildWorkflowManifest } from '../../src/discovery/manifests'
+
+describe('tool manifest generation', () => {
+  it('serializes the registered tool surface with discovery metadata', () => {
+    const manifest = buildToolManifest()
+
+    expect(manifest.schemaVersion).toBe('1.0')
+    expect(manifest.tools).toHaveLength(100)
+    expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
+      name: 'grade_submission',
+      domain: 'submissions',
+      description: 'Post or update a grade for a submission. Requires grading permissions.',
+      annotations: {
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      access: 'write',
+      primaryAudience: 'educator',
+      relatedWorkflows: ['educator-assignment-review'],
+    })
+    expect(manifest.tools.find((tool) => tool.name === 'get_outcome')).toEqual({
+      name: 'get_outcome',
+      domain: 'outcomes',
+      description: 'Get the full details for a specific learning outcome by ID.',
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      access: 'read',
+      primaryAudience: 'educator',
+      relatedWorkflows: [],
+    })
+  })
+
+  it('matches the committed generated JSON artifact', () => {
+    const generated = buildToolManifest()
+    const committed = JSON.parse(readFileSync(resolve('docs/generated/tool-manifest.json'), 'utf8'))
+
+    expect(committed).toEqual(generated)
+  })
+})
+
+describe('workflow manifest generation', () => {
+  it('links workflows to related tools through a stable schema', () => {
+    const manifest = buildWorkflowManifest()
+
+    expect(manifest.schemaVersion).toBe('1.0')
+    expect(manifest.workflows).toEqual([
+      {
+        id: 'educator-assignment-review',
+        title: 'Educator Assignment Review',
+        description: 'Review an assignment, inspect submissions, apply grades, and leave feedback.',
+        primaryAudience: 'educator',
+        status: 'proposed',
+        relatedTools: [
+          'list_assignments',
+          'get_assignment',
+          'list_submissions',
+          'get_submission',
+          'get_rubric',
+          'grade_submission',
+          'comment_on_submission',
+          'submit_rubric_assessment',
+        ],
+      },
+      {
+        id: 'student-weekly-planning',
+        title: 'Student Weekly Planning',
+        description:
+          'Review dashboard items, upcoming deadlines, and current course load for weekly planning.',
+        primaryAudience: 'student',
+        status: 'proposed',
+        relatedTools: [
+          'get_dashboard_cards',
+          'get_todo_items',
+          'get_upcoming_events',
+          'get_my_upcoming_assignments',
+          'get_my_courses',
+          'get_my_grades',
+        ],
+      },
+    ])
+  })
+
+  it('matches the committed generated JSON artifact', () => {
+    const generated = buildWorkflowManifest()
+    const committed = JSON.parse(
+      readFileSync(resolve('docs/generated/workflow-manifest.json'), 'utf8'),
+    )
+
+    expect(committed).toEqual(generated)
+  })
+})


### PR DESCRIPTION
## Summary
- add a generated discovery layer for tool and workflow manifests
- derive the tool manifest from the live MCP registry with domain, audience, access, and workflow links
- add an in-repo workflow catalog plus generation docs and parity tests for committed JSON artifacts

## Validation
- pnpm lint
- pnpm typecheck && pnpm test && pnpm build