### PR TITLE
fix: harden generated discovery manifests

### DIFF
--- a/src/discovery/manifests.ts
+++ b/src/discovery/manifests.ts
@@ -1,6 +1,7 @@
-import { toolDomainCatalog } from '../tools/catalog'
+import type { CanvasClient } from '../canvas'
+import { toolDomainCatalog, type ToolDomainRegistration } from '../tools/catalog'
 import type { ToolAnnotations, ToolAudience, ToolDefinition } from '../tools/types'
-import { toolAudienceOverrides, workflowCatalog } from './catalog'
+import { toolAudienceOverrides, workflowCatalog, type WorkflowCatalogEntry } from './catalog'
 
 export interface ToolManifestEntry {
   name: string
@@ -31,10 +32,31 @@ interface RegisteredToolContext {
   defaultPrimaryAudience: ToolAudience
 }
 
-function getRegisteredToolContexts(): RegisteredToolContext[] {
-  const canvas = {} as never
+export interface ManifestBuildOptions {
+  toolCatalog?: readonly ToolDomainRegistration[]
+  workflowCatalog?: readonly WorkflowCatalogEntry[]
+  toolAudienceOverrides?: Readonly<Record<string, ToolAudience>>
+}
 
-  return toolDomainCatalog.flatMap((registration) =>
+function createManifestCanvasProxy(): CanvasClient {
+  return new Proxy(
+    {},
+    {
+      get(_target, property) {
+        throw new Error(
+          `Manifest generation accessed Canvas client during tool registration via "${String(property)}".`,
+        )
+      },
+    },
+  ) as CanvasClient
+}
+
+function getRegisteredToolContexts(
+  registrations: readonly ToolDomainRegistration[] = toolDomainCatalog,
+): RegisteredToolContext[] {
+  const canvas = createManifestCanvasProxy()
+
+  return registrations.flatMap((registration) =>
     registration.getTools(canvas).map((tool) => ({
       tool,
       domain: registration.domain,
@@ -43,8 +65,17 @@ function getRegisteredToolContexts(): RegisteredToolContext[] {
   )
 }
 
-function getAccess(annotations: ToolAnnotations): 'read' | 'write' {
-  return annotations.destructiveHint ? 'write' : 'read'
+function getAccess(toolName: string, annotations: ToolAnnotations): 'read' | 'write' {
+  const isReadOnly = annotations.readOnlyHint === true
+  const isDestructive = annotations.destructiveHint === true
+
+  if (isReadOnly === isDestructive) {
+    throw new Error(
+      `Tool "${toolName}" must declare exactly one of readOnlyHint or destructiveHint.`,
+    )
+  }
+
+  return isDestructive ? 'write' : 'read'
 }
 
 function compactAnnotations(annotations: ToolAnnotations): ToolAnnotations {
@@ -66,18 +97,28 @@ function compactAnnotations(annotations: ToolAnnotations): ToolAnnotations {
   return compacted
 }
 
-function getRelatedWorkflowIds(toolName: string): string[] {
-  return workflowCatalog
+function getRelatedWorkflowIds(
+  toolName: string,
+  workflows: readonly WorkflowCatalogEntry[] = workflowCatalog,
+): string[] {
+  return workflows
     .filter((workflow) => workflow.relatedTools.includes(toolName))
     .map((workflow) => workflow.id)
 }
 
-function getPrimaryAudience(toolName: string, defaultPrimaryAudience: ToolAudience): ToolAudience {
-  return toolAudienceOverrides[toolName] ?? defaultPrimaryAudience
+function getPrimaryAudience(
+  toolName: string,
+  defaultPrimaryAudience: ToolAudience,
+  audienceOverrides: Readonly<Record<string, ToolAudience>> = toolAudienceOverrides,
+): ToolAudience {
+  return audienceOverrides[toolName] ?? defaultPrimaryAudience
 }
 
-function assertWorkflowLinksExist(toolNames: Set<string>): void {
-  for (const workflow of workflowCatalog) {
+function assertWorkflowLinksExist(
+  toolNames: Set<string>,
+  workflows: readonly WorkflowCatalogEntry[] = workflowCatalog,
+): void {
+  for (const workflow of workflows) {
     for (const relatedTool of workflow.relatedTools) {
       if (!toolNames.has(relatedTool)) {
         throw new Error(`Workflow "${workflow.id}" references unknown tool "${relatedTool}".`)
@@ -86,20 +127,36 @@ function assertWorkflowLinksExist(toolNames: Set<string>): void {
   }
 }
 
-export function buildToolManifest(): ToolManifestDocument {
-  const registeredTools = getRegisteredToolContexts()
+function assertAudienceOverrideLinksExist(
+  toolNames: Set<string>,
+  audienceOverrides: Readonly<Record<string, ToolAudience>> = toolAudienceOverrides,
+): void {
+  for (const toolName of Object.keys(audienceOverrides)) {
+    if (!toolNames.has(toolName)) {
+      throw new Error(`Audience override references unknown tool "${toolName}".`)
+    }
+  }
+}
+
+export function buildToolManifest(options: ManifestBuildOptions = {}): ToolManifestDocument {
+  const registeredTools = getRegisteredToolContexts(options.toolCatalog)
   const toolNames = new Set(registeredTools.map(({ tool }) => tool.name))
 
-  assertWorkflowLinksExist(toolNames)
+  assertAudienceOverrideLinksExist(toolNames, options.toolAudienceOverrides)
+  assertWorkflowLinksExist(toolNames, options.workflowCatalog)
 
   const tools = registeredTools.map(({ tool, domain, defaultPrimaryAudience }) => ({
     name: tool.name,
     domain,
     description: tool.description,
     annotations: compactAnnotations(tool.annotations),
-    access: getAccess(tool.annotations),
-    primaryAudience: getPrimaryAudience(tool.name, defaultPrimaryAudience),
-    relatedWorkflows: getRelatedWorkflowIds(tool.name),
+    access: getAccess(tool.name, tool.annotations),
+    primaryAudience: getPrimaryAudience(
+      tool.name,
+      defaultPrimaryAudience,
+      options.toolAudienceOverrides,
+    ),
+    relatedWorkflows: getRelatedWorkflowIds(tool.name, options.workflowCatalog),
   }))
 
   return {
@@ -110,15 +167,17 @@ export function buildToolManifest(): ToolManifestDocument {
   }
 }
 
-export function buildWorkflowManifest(): WorkflowManifestDocument {
-  const toolManifest = buildToolManifest()
-  const toolNames = new Set(toolManifest.tools.map((tool) => tool.name))
+export function buildWorkflowManifest(
+  options: ManifestBuildOptions = {},
+): WorkflowManifestDocument {
+  const registeredTools = getRegisteredToolContexts(options.toolCatalog)
+  const toolNames = new Set(registeredTools.map(({ tool }) => tool.name))
 
-  assertWorkflowLinksExist(toolNames)
+  assertWorkflowLinksExist(toolNames, options.workflowCatalog)
 
   return {
     schemaVersion: '1.0',
-    workflowCount: workflowCatalog.length,
-    workflows: workflowCatalog,
+    workflowCount: (options.workflowCatalog ?? workflowCatalog).length,
+    workflows: options.workflowCatalog ?? workflowCatalog,
   }
 }

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -2,6 +2,33 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { buildToolManifest, buildWorkflowManifest } from '../../src/discovery/manifests'
+import type { ToolDomainRegistration } from '../../src/tools/catalog'
+import type { ToolAudience, ToolDefinition } from '../../src/tools/types'
+
+function createTool(
+  name: string,
+  annotations: ToolDefinition['annotations'],
+  description = `${name} description`,
+): ToolDefinition {
+  return {
+    name,
+    description,
+    inputSchema: {},
+    annotations,
+    handler: async () => undefined,
+  }
+}
+
+function createRegistration(
+  tool: ToolDefinition,
+  defaultPrimaryAudience: ToolAudience = 'shared',
+): ToolDomainRegistration {
+  return {
+    domain: 'test',
+    defaultPrimaryAudience,
+    getTools: () => [tool],
+  }
+}
 
 describe('tool manifest generation', () => {
   it('serializes the registered tool surface with discovery metadata', () => {
@@ -41,6 +68,69 @@ describe('tool manifest generation', () => {
     const committed = JSON.parse(readFileSync(resolve('docs/generated/tool-manifest.json'), 'utf8'))
 
     expect(committed).toEqual(generated)
+  })
+
+  it('fails when an audience override references an unknown tool', () => {
+    expect(() =>
+      buildToolManifest({
+        toolCatalog: [createRegistration(createTool('known_tool', { readOnlyHint: true }))],
+        toolAudienceOverrides: {
+          missing_tool: 'student',
+        },
+      }),
+    ).toThrow('Audience override references unknown tool "missing_tool".')
+  })
+
+  it('fails when a tool omits both readOnlyHint and destructiveHint', () => {
+    expect(() =>
+      buildToolManifest({
+        toolCatalog: [
+          createRegistration(
+            createTool('ambiguous_tool', {
+              openWorldHint: true,
+            }),
+          ),
+        ],
+        toolAudienceOverrides: {},
+        workflowCatalog: [],
+      }),
+    ).toThrow('Tool "ambiguous_tool" must declare exactly one of readOnlyHint or destructiveHint.')
+  })
+
+  it('fails when a tool declares both readOnlyHint and destructiveHint', () => {
+    expect(() =>
+      buildToolManifest({
+        toolCatalog: [
+          createRegistration(
+            createTool('contradictory_tool', {
+              readOnlyHint: true,
+              destructiveHint: true,
+            }),
+          ),
+        ],
+        toolAudienceOverrides: {},
+        workflowCatalog: [],
+      }),
+    ).toThrow(
+      'Tool "contradictory_tool" must declare exactly one of readOnlyHint or destructiveHint.',
+    )
+  })
+
+  it('fails when tool registration touches the Canvas client during manifest generation', () => {
+    expect(() =>
+      buildToolManifest({
+        toolCatalog: [
+          {
+            domain: 'test',
+            defaultPrimaryAudience: 'shared',
+            getTools: (canvas) => {
+              void canvas.users
+              return [createTool('health_check', { readOnlyHint: true })]
+            },
+          },
+        ],
+      }),
+    ).toThrow('Manifest generation accessed Canvas client during tool registration via "users".')
   })
 })
 
@@ -93,5 +183,23 @@ describe('workflow manifest generation', () => {
     )
 
     expect(committed).toEqual(generated)
+  })
+
+  it('fails when a workflow references an unknown tool', () => {
+    expect(() =>
+      buildWorkflowManifest({
+        toolCatalog: [createRegistration(createTool('known_tool', { readOnlyHint: true }))],
+        workflowCatalog: [
+          {
+            id: 'bad-workflow',
+            title: 'Bad Workflow',
+            description: 'References a missing tool.',
+            primaryAudience: 'student',
+            status: 'proposed',
+            relatedTools: ['missing_tool'],
+          },
+        ],
+      }),
+    ).toThrow('Workflow "bad-workflow" references unknown tool "missing_tool".')
   })
 })


### PR DESCRIPTION
## Summary
- validate that every discovery audience override points at a registered tool
- require each manifest tool to declare exactly one of \eadOnlyHint\ or \destructiveHint\ when classifying access
- replace the manifest builder's \{} as never\ Canvas placeholder with a throwing proxy and avoid rebuilding the full tool manifest during workflow validation
- add invariant tests for unknown overrides, ambiguous access annotations, bad workflow links, and registration-time Canvas access

Closes #66.

## Validation
- pnpm typecheck && pnpm test && pnpm build