### PR TITLE
docs: add first workflow packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,9 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full contribution and validatio
 - [Student Guide](docs/student-guide.md) -- Token setup, AI client configuration, 10 example prompts
 - [Educator Guide](docs/educator-guide.md) -- Grading workflows, write operations, privacy considerations
 - [Integration Guide](docs/integration-guide.md) -- Three integration patterns with code examples
+- [Agent Discovery](docs/agent-discovery.md) -- Generated tool/workflow manifests and workflow-pack index
+- [Educator Assignment Review Workflow](docs/workflows/educator-assignment-review.md) -- Read-first grading flow with write-safety guidance
+- [Student Weekly Planning Workflow](docs/workflows/student-weekly-planning.md) -- Read-only weekly planning sequence for students
 
 ## License
 

--- a/docs/agent-discovery.md
+++ b/docs/agent-discovery.md
@@ -5,6 +5,14 @@
 - `tool-manifest.json` describes the registered MCP tool surface.
 - `workflow-manifest.json` describes workflow catalog entries that link back to related tools.
 
+Workflow packs live under `docs/workflows/` and are referenced from the workflow manifest via each
+entry's `documentationPath`.
+
+Current workflow packs:
+
+- `educator-assignment-review` → [Educator Assignment Review](workflows/educator-assignment-review.md)
+- `student-weekly-planning` → [Student Weekly Planning](workflows/student-weekly-planning.md)
+
 These files are generated from the live tool registry and the in-repo workflow catalog source.
 
 ## Regenerating

--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -247,7 +247,9 @@
       },
       "access": "read",
       "primaryAudience": "educator",
-      "relatedWorkflows": []
+      "relatedWorkflows": [
+        "educator-assignment-review"
+      ]
     },
     {
       "name": "submit_rubric_assessment",

--- a/docs/generated/workflow-manifest.json
+++ b/docs/generated/workflow-manifest.json
@@ -7,13 +7,15 @@
       "title": "Educator Assignment Review",
       "description": "Review an assignment, inspect submissions, apply grades, and leave feedback.",
       "primaryAudience": "educator",
-      "status": "proposed",
+      "status": "available",
+      "documentationPath": "docs/workflows/educator-assignment-review.md",
       "relatedTools": [
         "list_assignments",
         "get_assignment",
         "list_submissions",
         "get_submission",
         "get_rubric",
+        "get_rubric_assessment",
         "grade_submission",
         "comment_on_submission",
         "submit_rubric_assessment"
@@ -24,7 +26,8 @@
       "title": "Student Weekly Planning",
       "description": "Review dashboard items, upcoming deadlines, and current course load for weekly planning.",
       "primaryAudience": "student",
-      "status": "proposed",
+      "status": "available",
+      "documentationPath": "docs/workflows/student-weekly-planning.md",
       "relatedTools": [
         "get_dashboard_cards",
         "get_todo_items",

--- a/docs/workflows/educator-assignment-review.md
+++ b/docs/workflows/educator-assignment-review.md
@@ -1,0 +1,69 @@
+# Educator Assignment Review
+
+Use this workflow pack when an instructor or TA needs to review one Canvas assignment end to end: inspect the assignment brief, review one or more submissions, apply grades, and leave feedback without jumping between separate ad hoc prompts.
+
+## When to Use It
+
+- You are grading a single assignment in one course.
+- You need a repeatable review loop across multiple students.
+- The assignment may include a rubric and you want feedback to stay aligned with that rubric.
+- You want the agent to summarize grading progress before performing write actions.
+
+## Recommended Tool Sequence
+
+1. `list_assignments`
+   Use when you need to find the assignment ID inside a course.
+2. `get_assignment`
+   Confirm points possible, due date, submission type, and whether a rubric is attached.
+3. `list_submissions`
+   Build the grading queue and identify missing, late, or already graded submissions.
+4. `get_submission`
+   Inspect one student's submission details, attachments, prior comments, and current grade state.
+5. `get_rubric`
+   Load the rubric criteria before grading when the assignment uses rubric-based assessment.
+6. `get_rubric_assessment`
+   Check whether the student already has rubric scores so you do not overwrite them blindly.
+7. `grade_submission`
+   Set or update the score or grade.
+8. `comment_on_submission`
+   Add narrative feedback after the grade is confirmed.
+9. `submit_rubric_assessment`
+   Apply criterion-level rubric scores and comments when rubric grading is required.
+
+## Write-Safety Notes
+
+- `grade_submission` is a write action. Confirm the course, assignment, and student IDs before posting.
+- `submit_rubric_assessment` is also a write action and overwrites prior rubric values for the targeted criteria.
+- `comment_on_submission` is non-idempotent. Re-running the same prompt can create duplicate comments.
+- Prefer a read-first loop: inspect the assignment, submission, and existing rubric assessment before sending any write call.
+- If the agent proposes grades or comments, review the summary before allowing it to write in bulk across multiple students.
+
+## Example Prompts
+
+- "Run the educator assignment review workflow for the Week 4 essay in course 12345 and start with a grading queue summary."
+- "Review student 11111's submission for assignment 67890 in course 12345, show the rubric context, then draft feedback before posting anything."
+- "Grade the next ungraded submission for assignment 67890 in course 12345, using the rubric if present."
+- "Summarize which submissions for assignment 67890 are missing, late, already graded, or still need feedback."
+- "For assignment 67890 in course 12345, review student 11111, propose a score and comment, and wait for confirmation before writing."
+
+## Expected Output Shape
+
+The agent should return a structured grading summary before or alongside any write action, typically including:
+
+- Assignment context: course, assignment title, points possible, rubric availability.
+- Submission snapshot: student, submission state, submitted time, attachments, prior grade/comment status.
+- Recommended action: proposed score, rubric notes, and feedback draft.
+- Write plan: which Canvas write tools will be called next, if any.
+- Post-write confirmation: final grade/comment/rubric actions that were actually sent.
+
+## Related Tools
+
+- `list_assignments`
+- `get_assignment`
+- `list_submissions`
+- `get_submission`
+- `get_rubric`
+- `get_rubric_assessment`
+- `grade_submission`
+- `comment_on_submission`
+- `submit_rubric_assessment`

--- a/docs/workflows/student-weekly-planning.md
+++ b/docs/workflows/student-weekly-planning.md
@@ -1,0 +1,58 @@
+# Student Weekly Planning
+
+Use this workflow pack when a student wants a weekly planning pass across Canvas: what is due soon, what is already missing, which courses need attention, and where the heaviest workload sits for the next few days.
+
+## When to Use It
+
+- You want a weekly overview instead of checking each course separately.
+- You need a prioritized list of deadlines and missing work.
+- You want the agent to combine dashboard, calendar, and course data into one study plan.
+- You want a planning-friendly summary without making any changes in Canvas.
+
+## Recommended Tool Sequence
+
+1. `get_dashboard_cards`
+   Identify the active course set and gather quick dashboard context.
+2. `get_todo_items`
+   Pull Canvas todo items that already represent urgent student-facing work.
+3. `get_upcoming_events`
+   Review near-term due dates and calendar events across courses.
+4. `get_my_upcoming_assignments`
+   Build the assignment deadline list for the planning window.
+5. `get_my_courses`
+   Fill in course names, states, and enrollment context when the dashboard summary is not enough.
+6. `get_my_grades`
+   Add lightweight performance context so the plan can emphasize courses with lower current standing.
+
+## Write-Safety Notes
+
+- This workflow is read-only. It should never call a Canvas write tool.
+- The output is a planning aid, not an authoritative calendar replacement. If dates conflict, trust Canvas due dates and event timestamps.
+- Grade context should be used for prioritization, not for any inferred academic advice beyond the visible Canvas data.
+
+## Example Prompts
+
+- "Run the student weekly planning workflow and give me a plan for the next 7 days."
+- "What should I focus on this week across all my Canvas courses?"
+- "Use my dashboard, todo items, and upcoming assignments to build a prioritized study plan."
+- "Show me anything missing or due soon, then group the rest by course."
+- "Create a weekly planning summary that flags low-grade courses and the assignments I should tackle first."
+
+## Expected Output Shape
+
+The agent should return a planning summary with clear sections, typically including:
+
+- Week snapshot: date window, number of active courses, and the most urgent deadlines.
+- Priority list: overdue or missing work first, then upcoming assignments ordered by due date.
+- Course-by-course view: each course with relevant todo items, deadlines, and grade signal if available.
+- Suggested plan: a short schedule or sequence for the next few days based on urgency and course load.
+- Risks and gaps: anything with unclear due dates, missing grade visibility, or likely overload.
+
+## Related Tools
+
+- `get_dashboard_cards`
+- `get_todo_items`
+- `get_upcoming_events`
+- `get_my_upcoming_assignments`
+- `get_my_courses`
+- `get_my_grades`

--- a/src/discovery/catalog.ts
+++ b/src/discovery/catalog.ts
@@ -6,6 +6,7 @@ export interface WorkflowCatalogEntry {
   description: string
   primaryAudience: ToolAudience
   status: 'proposed' | 'available'
+  documentationPath: string
   relatedTools: string[]
 }
 
@@ -15,13 +16,15 @@ export const workflowCatalog: readonly WorkflowCatalogEntry[] = [
     title: 'Educator Assignment Review',
     description: 'Review an assignment, inspect submissions, apply grades, and leave feedback.',
     primaryAudience: 'educator',
-    status: 'proposed',
+    status: 'available',
+    documentationPath: 'docs/workflows/educator-assignment-review.md',
     relatedTools: [
       'list_assignments',
       'get_assignment',
       'list_submissions',
       'get_submission',
       'get_rubric',
+      'get_rubric_assessment',
       'grade_submission',
       'comment_on_submission',
       'submit_rubric_assessment',
@@ -33,7 +36,8 @@ export const workflowCatalog: readonly WorkflowCatalogEntry[] = [
     description:
       'Review dashboard items, upcoming deadlines, and current course load for weekly planning.',
     primaryAudience: 'student',
-    status: 'proposed',
+    status: 'available',
+    documentationPath: 'docs/workflows/student-weekly-planning.md',
     relatedTools: [
       'get_dashboard_cards',
       'get_todo_items',

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -145,13 +145,15 @@ describe('workflow manifest generation', () => {
         title: 'Educator Assignment Review',
         description: 'Review an assignment, inspect submissions, apply grades, and leave feedback.',
         primaryAudience: 'educator',
-        status: 'proposed',
+        status: 'available',
+        documentationPath: 'docs/workflows/educator-assignment-review.md',
         relatedTools: [
           'list_assignments',
           'get_assignment',
           'list_submissions',
           'get_submission',
           'get_rubric',
+          'get_rubric_assessment',
           'grade_submission',
           'comment_on_submission',
           'submit_rubric_assessment',
@@ -163,7 +165,8 @@ describe('workflow manifest generation', () => {
         description:
           'Review dashboard items, upcoming deadlines, and current course load for weekly planning.',
         primaryAudience: 'student',
-        status: 'proposed',
+        status: 'available',
+        documentationPath: 'docs/workflows/student-weekly-planning.md',
         relatedTools: [
           'get_dashboard_cards',
           'get_todo_items',


### PR DESCRIPTION
## Summary
- add repo-local workflow pack docs for educator assignment review and student weekly planning
- mark both workflows as available in the discovery catalog and attach stable documentation paths
- regenerate the discovery manifests and link the workflow packs from the discovery/README surfaces

## Validation
- pnpm typecheck
- pnpm test
- pnpm build