### PR TITLE
feat: add read-only gradebook history tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Three-layer design with strict separation of concerns:
 ```
 Layer 1: src/canvas/       Standalone Canvas REST API client
                            Pure fetch, no MCP dependency, independently importable
-                           14 modular classes composed into CanvasClient facade
+                           Modular classes composed into CanvasClient facade
 
 Layer 2: src/tools/        MCP tool definitions
                            Each domain exports (canvas: CanvasClient) => ToolDefinition[]
@@ -57,7 +57,7 @@ AI Agent  -->  MCP Transport (stdio/HTTP)
 
 ## Tool Inventory
 
-100 tools total: 72 read-only, 28 write operations.
+104 tools total: 76 read-only, 28 write operations.
 
 | Domain | Tools |
 | --- | --- |
@@ -68,6 +68,7 @@ AI Agent  -->  MCP Transport (stdio/HTTP)
 | Rubrics | `list_rubrics`, `get_rubric`, `get_rubric_assessment`, `submit_rubric_assessment` |
 | Quizzes | `list_quizzes`, `get_quiz`, `list_quiz_submissions`, `list_quiz_questions`, `get_quiz_submission_answers`, `score_quiz_question` |
 | Files | `list_files`, `list_folders`, `get_file`, `upload_file`, `delete_file` |
+| Gradebook History | `list_gradebook_history_days`, `get_gradebook_history_day`, `list_gradebook_history_submissions`, `get_gradebook_history_feed` |
 | Users | `list_students`, `get_user`, `get_profile`, `search_users`, `list_course_users` |
 | Groups | `list_groups`, `list_group_members` |
 | Enrollments | `list_enrollments`, `enroll_user`, `remove_enrollment` |

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 
 MCP server for [Canvas LMS](https://www.instructure.com/canvas). Read courses, assignments, submissions, rubrics, quizzes; grade, comment, manage course content, and handle Canvas admin workflows from any AI agent.
 
-100 tools across Canvas courses, assignments, submissions, rubrics, quizzes, files, users, groups, enrollments, discussions, modules, pages, calendar, conversations, peer reviews, accounts, analytics, outcomes, student workflows, dashboard, and health checks. Three deployment modes: stdio, HTTP, and library import.
+104 tools across Canvas courses, assignments, submissions, gradebook history, rubrics, quizzes, files, users, groups, enrollments, discussions, modules, pages, calendar, conversations, peer reviews, accounts, analytics, outcomes, student workflows, dashboard, and health checks. Three deployment modes: stdio, HTTP, and library import.
 
 ## Comparison
 
 | | canvas-lms-mcp | [vishalsachdev/canvas-mcp](https://github.com/vishalsachdev/canvas-mcp) | [DMontgomery40/mcp-canvas-lms](https://github.com/DMontgomery40/mcp-canvas-lms) |
 |---|---|---|---|
 | Language | TypeScript | Python | TypeScript |
-| Tools | 88 | 80+ | 54 |
+| Tools | 104 | 80+ | 54 |
 | License | [![License: MIT](https://img.shields.io/github/license/bruchris/canvas-lms-mcp)](https://github.com/bruchris/canvas-lms-mcp/blob/main/LICENSE) | [![License](https://img.shields.io/github/license/vishalsachdev/canvas-mcp)](https://github.com/vishalsachdev/canvas-mcp/blob/main/LICENSE) | [![License](https://img.shields.io/github/license/DMontgomery40/mcp-canvas-lms)](https://github.com/DMontgomery40/mcp-canvas-lms/blob/main/LICENSE) |
 | Last commit | [![Last commit](https://img.shields.io/github/last-commit/bruchris/canvas-lms-mcp)](https://github.com/bruchris/canvas-lms-mcp) | [![Last commit](https://img.shields.io/github/last-commit/vishalsachdev/canvas-mcp)](https://github.com/vishalsachdev/canvas-mcp) | [![Last commit](https://img.shields.io/github/last-commit/DMontgomery40/mcp-canvas-lms)](https://github.com/DMontgomery40/mcp-canvas-lms) |
 
@@ -173,7 +173,7 @@ Once configured, try these prompts with your AI client:
 
 ## Tool Inventory
 
-### All Registered Tools (100)
+### All Registered Tools (104)
 
 | Category | Tools |
 |----------|-------|
@@ -184,6 +184,7 @@ Once configured, try these prompts with your AI client:
 | Rubrics | `list_rubrics`, `get_rubric`, `get_rubric_assessment`, `submit_rubric_assessment` |
 | Quizzes | `list_quizzes`, `get_quiz`, `list_quiz_submissions`, `list_quiz_questions`, `get_quiz_submission_answers`, `score_quiz_question` |
 | Files | `list_files`, `list_folders`, `get_file`, `upload_file`, `delete_file` |
+| Gradebook History | `list_gradebook_history_days`, `get_gradebook_history_day`, `list_gradebook_history_submissions`, `get_gradebook_history_feed` |
 | Users | `list_students`, `get_user`, `get_profile`, `search_users`, `list_course_users` |
 | Groups | `list_groups`, `list_group_members` |
 | Enrollments | `list_enrollments`, `enroll_user`, `remove_enrollment` |
@@ -199,7 +200,7 @@ Once configured, try these prompts with your AI client:
 | Student | `get_my_courses`, `get_my_grades`, `get_my_submissions`, `get_my_upcoming_assignments` |
 | Dashboard | `get_dashboard_cards`, `get_todo_items`, `get_upcoming_events`, `get_missing_submissions` |
 
-72 tools are read-only and 28 tools perform Canvas write operations.
+76 tools are read-only and 28 tools perform Canvas write operations.
 
 All write tools require appropriate Canvas permissions. Canvas enforces its own permission model -- the MCP server does not bypass it.
 

--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 100,
+  "toolCount": 104,
   "tools": [
     {
       "name": "health_check",
@@ -397,6 +397,54 @@
       },
       "access": "write",
       "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_gradebook_history_days",
+      "domain": "gradebook_history",
+      "description": "List the dates in a course gradebook history that contain grading activity, grouped by grader and assignment.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_gradebook_history_day",
+      "domain": "gradebook_history",
+      "description": "Get the graders and assignment IDs that had gradebook activity on a specific course date.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_gradebook_history_submissions",
+      "domain": "gradebook_history",
+      "description": "List versioned submission history for one grader and assignment on a specific gradebook history date.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_gradebook_history_feed",
+      "domain": "gradebook_history",
+      "description": "Get the paginated gradebook history feed for a course, optionally filtered by assignment or user and optionally sorted oldest-first.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
       "relatedWorkflows": []
     },
     {

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -148,7 +148,7 @@ const transport = new StdioServerTransport()
 await server.connect(transport)
 ```
 
-The `server` is a standard `McpServer` instance with all 100 tools and 2 resources registered. The `canvas` is the underlying `CanvasClient` instance if you need direct API access.
+The `server` is a standard `McpServer` instance with all 104 tools and 2 resources registered. The `canvas` is the underlying `CanvasClient` instance if you need direct API access.
 
 ### Standalone Canvas Client
 
@@ -174,7 +174,7 @@ await canvas.submissions.comment(courseId, assignmentId, userId, 'Great work!')
 
 ### Available Canvas Client Modules
 
-The `CanvasClient` facade exposes 14 domain modules:
+The `CanvasClient` facade exposes domain modules for every registered Canvas API area:
 
 | Module | Methods |
 |--------|---------|
@@ -184,6 +184,7 @@ The `CanvasClient` facade exposes 14 domain modules:
 | `canvas.rubrics` | `list(courseId)`, `get(courseId, id)`, `getAssessment(...)`, `submitAssessment(...)` |
 | `canvas.quizzes` | `list(courseId)`, `get(courseId, id)`, `listSubmissions(...)`, `listQuestions(...)`, `getSubmissionAnswers(id)`, `scoreQuestion(...)` |
 | `canvas.files` | `listFiles(courseId)`, `listFolders(courseId)`, `get(courseId, id)` |
+| `canvas.gradebookHistory` | `listDays(courseId)`, `getDay(courseId, date)`, `listSubmissions(...)`, `getFeed(...)` |
 | `canvas.users` | `listStudents(courseId)`, `get(id)`, `getProfile()` |
 | `canvas.groups` | `list(courseId)`, `listMembers(groupId)` |
 | `canvas.enrollments` | `list()` |

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "canvas-lms-mcp",
   "version": "1.4.2",
   "mcpName": "io.github.bruchris/canvas-lms-mcp",
-  "description": "TypeScript MCP 1.x server for Canvas LMS — 100 tools across Canvas courses, assignments, grades, quizzes, outcomes, discussions, admin workflows, and more.",
+  "description": "TypeScript MCP 1.x server for Canvas LMS — 104 tools across Canvas courses, assignments, grades, gradebook history, quizzes, outcomes, discussions, admin workflows, and more.",
   "type": "module",
   "exports": {
     ".": {

--- a/src/canvas/gradebook-history.ts
+++ b/src/canvas/gradebook-history.ts
@@ -1,0 +1,63 @@
+import type { CanvasHttpClient } from './client'
+import type {
+  CanvasGradebookHistoryDay,
+  CanvasGradebookHistoryGrader,
+  CanvasGradebookHistorySubmission,
+  CanvasGradebookHistorySubmissionVersion,
+} from './types'
+
+export interface GradebookHistoryFeedParams {
+  assignment_id?: number
+  user_id?: number
+  ascending?: boolean
+}
+
+export class GradebookHistoryModule {
+  constructor(private client: CanvasHttpClient) {}
+
+  async listDays(courseId: number): Promise<CanvasGradebookHistoryDay[]> {
+    return this.client.request<CanvasGradebookHistoryDay[]>(
+      `/api/v1/courses/${courseId}/gradebook_history/days`,
+    )
+  }
+
+  async getDay(courseId: number, date: string): Promise<CanvasGradebookHistoryGrader[]> {
+    return this.client.request<CanvasGradebookHistoryGrader[]>(
+      `/api/v1/courses/${courseId}/gradebook_history/${encodeURIComponent(date)}`,
+    )
+  }
+
+  async listSubmissions(
+    courseId: number,
+    date: string,
+    graderId: number,
+    assignmentId: number,
+  ): Promise<CanvasGradebookHistorySubmission[]> {
+    return this.client.request<CanvasGradebookHistorySubmission[]>(
+      `/api/v1/courses/${courseId}/gradebook_history/${encodeURIComponent(date)}/graders/${graderId}/assignments/${assignmentId}/submissions`,
+    )
+  }
+
+  async getFeed(
+    courseId: number,
+    params: GradebookHistoryFeedParams = {},
+  ): Promise<CanvasGradebookHistorySubmissionVersion[]> {
+    const searchParams = new URLSearchParams()
+
+    if (params.assignment_id !== undefined) {
+      searchParams.set('assignment_id', String(params.assignment_id))
+    }
+    if (params.user_id !== undefined) {
+      searchParams.set('user_id', String(params.user_id))
+    }
+    if (params.ascending !== undefined) {
+      searchParams.set('ascending', String(params.ascending))
+    }
+
+    const query = searchParams.toString()
+
+    return this.client.paginate<CanvasGradebookHistorySubmissionVersion>(
+      `/api/v1/courses/${courseId}/gradebook_history/feed${query ? `?${query}` : ''}`,
+    )
+  }
+}

--- a/src/canvas/index.ts
+++ b/src/canvas/index.ts
@@ -19,6 +19,7 @@ import { AccountsModule } from './accounts'
 import { AnalyticsModule } from './analytics'
 import { DashboardModule } from './dashboard'
 import { OutcomesModule } from './outcomes'
+import { GradebookHistoryModule } from './gradebook-history'
 
 export class CanvasClient {
   private client: CanvasHttpClient
@@ -41,6 +42,7 @@ export class CanvasClient {
   analytics: AnalyticsModule
   dashboard: DashboardModule
   outcomes: OutcomesModule
+  gradebookHistory: GradebookHistoryModule
 
   constructor(config: CanvasClientConfig) {
     this.client = new CanvasHttpClient(config)
@@ -63,6 +65,7 @@ export class CanvasClient {
     this.analytics = new AnalyticsModule(this.client)
     this.dashboard = new DashboardModule(this.client)
     this.outcomes = new OutcomesModule(this.client)
+    this.gradebookHistory = new GradebookHistoryModule(this.client)
   }
 }
 

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -142,6 +142,41 @@ export interface CanvasSubmissionComment {
   created_at: string
 }
 
+export interface CanvasGradebookHistoryGrader {
+  id: number
+  name: string
+  assignments: number[]
+}
+
+export interface CanvasGradebookHistoryDay {
+  date: string
+  graders: CanvasGradebookHistoryGrader[]
+}
+
+export interface CanvasGradebookHistorySubmissionVersion extends CanvasSubmission {
+  assignment_name?: string
+  current_grade?: string | null
+  current_graded_at?: string | null
+  current_grader?: string | null
+  grade_matches_current_submission?: boolean
+  graded_at?: string | null
+  grader?: string | null
+  grader_id?: number | null
+  new_grade?: string | null
+  new_graded_at?: string | null
+  new_grader?: string | null
+  previous_grade?: string | null
+  previous_graded_at?: string | null
+  previous_grader?: string | null
+  user_name?: string
+  submission_type?: string | null
+}
+
+export interface CanvasGradebookHistorySubmission {
+  submission_id: number
+  versions: CanvasGradebookHistorySubmissionVersion[] | null
+}
+
 // --- Rubrics ---
 
 export interface CanvasRubric {

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -9,6 +9,7 @@ import { dashboardTools } from './dashboard'
 import { discussionTools } from './discussions'
 import { enrollmentTools } from './enrollments'
 import { fileTools } from './files'
+import { gradebookHistoryTools } from './gradebook-history'
 import { groupTools } from './groups'
 import { healthTools } from './health'
 import { moduleTools } from './modules'
@@ -63,6 +64,11 @@ export const toolDomainCatalog: readonly ToolDomainRegistration[] = [
     domain: 'files',
     defaultPrimaryAudience: 'shared',
     getTools: fileTools,
+  },
+  {
+    domain: 'gradebook_history',
+    defaultPrimaryAudience: 'educator',
+    getTools: gradebookHistoryTools,
   },
   {
     domain: 'users',

--- a/src/tools/gradebook-history.ts
+++ b/src/tools/gradebook-history.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod'
+import type { CanvasClient } from '../canvas'
+import type { ToolDefinition } from './types'
+
+export function gradebookHistoryTools(canvas: CanvasClient): ToolDefinition[] {
+  return [
+    {
+      name: 'list_gradebook_history_days',
+      description:
+        'List the dates in a course gradebook history that contain grading activity, grouped by grader and assignment.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const course_id = params.course_id as number
+        return canvas.gradebookHistory.listDays(course_id)
+      },
+    },
+    {
+      name: 'get_gradebook_history_day',
+      description:
+        'Get the graders and assignment IDs that had gradebook activity on a specific course date.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        date: z.string().describe('The gradebook history date to inspect, in YYYY-MM-DD format'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const course_id = params.course_id as number
+        const date = params.date as string
+        return canvas.gradebookHistory.getDay(course_id, date)
+      },
+    },
+    {
+      name: 'list_gradebook_history_submissions',
+      description:
+        'List versioned submission history for one grader and assignment on a specific gradebook history date.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        date: z.string().describe('The gradebook history date to inspect, in YYYY-MM-DD format'),
+        grader_id: z.number().describe('The Canvas user ID of the grader'),
+        assignment_id: z.number().describe('The Canvas assignment ID'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const course_id = params.course_id as number
+        const date = params.date as string
+        const grader_id = params.grader_id as number
+        const assignment_id = params.assignment_id as number
+        return canvas.gradebookHistory.listSubmissions(course_id, date, grader_id, assignment_id)
+      },
+    },
+    {
+      name: 'get_gradebook_history_feed',
+      description:
+        'Get the paginated gradebook history feed for a course, optionally filtered by assignment or user and optionally sorted oldest-first.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        assignment_id: z
+          .number()
+          .optional()
+          .describe('Optional Canvas assignment ID to filter the feed'),
+        user_id: z.number().optional().describe('Optional Canvas user ID to filter the feed'),
+        ascending: z
+          .boolean()
+          .optional()
+          .describe('Set true to return the oldest gradebook history entries first'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const course_id = params.course_id as number
+        const assignment_id = params.assignment_id as number | undefined
+        const user_id = params.user_id as number | undefined
+        const ascending = params.ascending as boolean | undefined
+        return canvas.gradebookHistory.getFeed(course_id, { assignment_id, user_id, ascending })
+      },
+    },
+  ]
+}

--- a/tests/canvas/facade.test.ts
+++ b/tests/canvas/facade.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { CanvasClient, CanvasHttpClient, CanvasApiError } from '../../src/canvas/index'
 import { CoursesModule } from '../../src/canvas/courses'
+import { GradebookHistoryModule } from '../../src/canvas/gradebook-history'
 
 describe('CanvasClient facade', () => {
   it('creates a CanvasClient with courses module', () => {
@@ -10,6 +11,15 @@ describe('CanvasClient facade', () => {
     })
 
     expect(client.courses).toBeInstanceOf(CoursesModule)
+  })
+
+  it('creates a CanvasClient with gradebookHistory module', () => {
+    const client = new CanvasClient({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+    })
+
+    expect(client.gradebookHistory).toBeInstanceOf(GradebookHistoryModule)
   })
 
   it('re-exports CanvasHttpClient', () => {

--- a/tests/canvas/gradebook-history.test.ts
+++ b/tests/canvas/gradebook-history.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CanvasHttpClient } from '../../src/canvas/client'
+import { GradebookHistoryModule } from '../../src/canvas/gradebook-history'
+import type {
+  CanvasGradebookHistoryDay,
+  CanvasGradebookHistoryGrader,
+  CanvasGradebookHistorySubmission,
+  CanvasGradebookHistorySubmissionVersion,
+} from '../../src/canvas/types'
+
+describe('GradebookHistoryModule', () => {
+  let client: CanvasHttpClient
+  let gradebookHistory: GradebookHistoryModule
+
+  beforeEach(() => {
+    client = new CanvasHttpClient({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+    })
+    gradebookHistory = new GradebookHistoryModule(client)
+  })
+
+  describe('listDays', () => {
+    it('requests the gradebook history days endpoint', async () => {
+      const mockDays: CanvasGradebookHistoryDay[] = [
+        {
+          date: '2026-04-20',
+          graders: [{ id: 7, name: 'Prof Smith', assignments: [101, 102] }],
+        },
+      ]
+
+      vi.spyOn(client, 'request').mockResolvedValueOnce(mockDays)
+
+      const result = await gradebookHistory.listDays(42)
+
+      expect(result).toEqual(mockDays)
+      expect(client.request).toHaveBeenCalledWith('/api/v1/courses/42/gradebook_history/days')
+    })
+  })
+
+  describe('getDay', () => {
+    it('requests a specific gradebook history date', async () => {
+      const mockGraders: CanvasGradebookHistoryGrader[] = [
+        { id: 7, name: 'Prof Smith', assignments: [101, 102] },
+      ]
+
+      vi.spyOn(client, 'request').mockResolvedValueOnce(mockGraders)
+
+      const result = await gradebookHistory.getDay(42, '2026-04-20')
+
+      expect(result).toEqual(mockGraders)
+      expect(client.request).toHaveBeenCalledWith(
+        '/api/v1/courses/42/gradebook_history/2026-04-20',
+      )
+    })
+
+    it('encodes special characters in the date path segment', async () => {
+      vi.spyOn(client, 'request').mockResolvedValueOnce([])
+
+      await gradebookHistory.getDay(42, '2026-04-20+section-a')
+
+      expect(client.request).toHaveBeenCalledWith(
+        '/api/v1/courses/42/gradebook_history/2026-04-20%2Bsection-a',
+      )
+    })
+  })
+
+  describe('listSubmissions', () => {
+    it('requests the nested submissions endpoint for a grader and assignment', async () => {
+      const mockSubmissions: CanvasGradebookHistorySubmission[] = [
+        {
+          submission_id: 99,
+          versions: [
+            {
+              id: 99,
+              assignment_id: 101,
+              user_id: 12,
+              submitted_at: '2026-04-20T08:00:00Z',
+              score: 95,
+              grade: '95',
+              body: null,
+              url: null,
+              attempt: 1,
+              workflow_state: 'graded',
+              new_grade: '95',
+              previous_grade: '90',
+            },
+          ],
+        },
+      ]
+
+      vi.spyOn(client, 'request').mockResolvedValueOnce(mockSubmissions)
+
+      const result = await gradebookHistory.listSubmissions(42, '2026-04-20', 7, 101)
+
+      expect(result).toEqual(mockSubmissions)
+      expect(client.request).toHaveBeenCalledWith(
+        '/api/v1/courses/42/gradebook_history/2026-04-20/graders/7/assignments/101/submissions',
+      )
+    })
+  })
+
+  describe('getFeed', () => {
+    it('requests the gradebook history feed without filters by default', async () => {
+      const mockFeed: CanvasGradebookHistorySubmissionVersion[] = [
+        {
+          id: 99,
+          assignment_id: 101,
+          user_id: 12,
+          submitted_at: '2026-04-20T08:00:00Z',
+          score: 95,
+          grade: '95',
+          body: null,
+          url: null,
+          attempt: 1,
+          workflow_state: 'graded',
+          assignment_name: 'Essay 1',
+        },
+      ]
+
+      vi.spyOn(client, 'paginate').mockResolvedValueOnce(mockFeed)
+
+      const result = await gradebookHistory.getFeed(42)
+
+      expect(result).toEqual(mockFeed)
+      expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/42/gradebook_history/feed')
+    })
+
+    it('serializes optional feed filters into the query string', async () => {
+      vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+
+      await gradebookHistory.getFeed(42, {
+        assignment_id: 101,
+        user_id: 12,
+        ascending: true,
+      })
+
+      expect(client.paginate).toHaveBeenCalledWith(
+        '/api/v1/courses/42/gradebook_history/feed?assignment_id=101&user_id=12&ascending=true',
+      )
+    })
+  })
+})

--- a/tests/canvas/gradebook-history.test.ts
+++ b/tests/canvas/gradebook-history.test.ts
@@ -49,9 +49,7 @@ describe('GradebookHistoryModule', () => {
       const result = await gradebookHistory.getDay(42, '2026-04-20')
 
       expect(result).toEqual(mockGraders)
-      expect(client.request).toHaveBeenCalledWith(
-        '/api/v1/courses/42/gradebook_history/2026-04-20',
-      )
+      expect(client.request).toHaveBeenCalledWith('/api/v1/courses/42/gradebook_history/2026-04-20')
     })
 
     it('encodes special characters in the date path segment', async () => {

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(100)
+    expect(manifest.tools).toHaveLength(104)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',
@@ -48,6 +48,19 @@ describe('tool manifest generation', () => {
       access: 'write',
       primaryAudience: 'educator',
       relatedWorkflows: ['educator-assignment-review'],
+    })
+    expect(manifest.tools.find((tool) => tool.name === 'get_gradebook_history_feed')).toEqual({
+      name: 'get_gradebook_history_feed',
+      domain: 'gradebook_history',
+      description:
+        'Get the paginated gradebook history feed for a course, optionally filtered by assignment or user and optionally sorted oldest-first.',
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      access: 'read',
+      primaryAudience: 'educator',
+      relatedWorkflows: [],
     })
     expect(manifest.tools.find((tool) => tool.name === 'get_outcome')).toEqual({
       name: 'get_outcome',

--- a/tests/tools/gradebook-history.test.ts
+++ b/tests/tools/gradebook-history.test.ts
@@ -90,7 +90,9 @@ describe('gradebookHistoryTools', () => {
 
   it('delegates list_gradebook_history_days to canvas.gradebookHistory.listDays', async () => {
     const canvas = buildMockCanvas()
-    const tool = gradebookHistoryTools(canvas).find((t) => t.name === 'list_gradebook_history_days')!
+    const tool = gradebookHistoryTools(canvas).find(
+      (t) => t.name === 'list_gradebook_history_days',
+    )!
 
     const result = await tool.handler({ course_id: 42 })
 

--- a/tests/tools/gradebook-history.test.ts
+++ b/tests/tools/gradebook-history.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { CanvasClient } from '../../src/canvas'
+import type {
+  CanvasGradebookHistoryDay,
+  CanvasGradebookHistoryGrader,
+  CanvasGradebookHistorySubmission,
+  CanvasGradebookHistorySubmissionVersion,
+} from '../../src/canvas/types'
+import { gradebookHistoryTools } from '../../src/tools/gradebook-history'
+
+describe('gradebookHistoryTools', () => {
+  const mockDays: CanvasGradebookHistoryDay[] = [
+    {
+      date: '2026-04-20',
+      graders: [{ id: 7, name: 'Prof Smith', assignments: [101, 102] }],
+    },
+  ]
+  const mockGraders: CanvasGradebookHistoryGrader[] = [
+    { id: 7, name: 'Prof Smith', assignments: [101, 102] },
+  ]
+  const mockSubmissionHistory: CanvasGradebookHistorySubmission[] = [
+    {
+      submission_id: 99,
+      versions: [
+        {
+          id: 99,
+          assignment_id: 101,
+          user_id: 12,
+          submitted_at: '2026-04-20T08:00:00Z',
+          score: 95,
+          grade: '95',
+          body: null,
+          url: null,
+          attempt: 1,
+          workflow_state: 'graded',
+          new_grade: '95',
+          previous_grade: '90',
+        },
+      ],
+    },
+  ]
+  const mockFeed: CanvasGradebookHistorySubmissionVersion[] = [
+    {
+      id: 99,
+      assignment_id: 101,
+      user_id: 12,
+      submitted_at: '2026-04-20T08:00:00Z',
+      score: 95,
+      grade: '95',
+      body: null,
+      url: null,
+      attempt: 1,
+      workflow_state: 'graded',
+      assignment_name: 'Essay 1',
+    },
+  ]
+
+  function buildMockCanvas(): CanvasClient {
+    return {
+      gradebookHistory: {
+        listDays: vi.fn().mockResolvedValue(mockDays),
+        getDay: vi.fn().mockResolvedValue(mockGraders),
+        listSubmissions: vi.fn().mockResolvedValue(mockSubmissionHistory),
+        getFeed: vi.fn().mockResolvedValue(mockFeed),
+      },
+    } as unknown as CanvasClient
+  }
+
+  it('returns 4 tool definitions', () => {
+    expect(gradebookHistoryTools(buildMockCanvas())).toHaveLength(4)
+  })
+
+  it('exports tools with the expected names', () => {
+    expect(gradebookHistoryTools(buildMockCanvas()).map((tool) => tool.name)).toEqual([
+      'list_gradebook_history_days',
+      'get_gradebook_history_day',
+      'list_gradebook_history_submissions',
+      'get_gradebook_history_feed',
+    ])
+  })
+
+  it('marks every gradebook history tool as read-only', () => {
+    for (const tool of gradebookHistoryTools(buildMockCanvas())) {
+      expect(tool.annotations).toEqual({
+        readOnlyHint: true,
+        openWorldHint: true,
+      })
+    }
+  })
+
+  it('delegates list_gradebook_history_days to canvas.gradebookHistory.listDays', async () => {
+    const canvas = buildMockCanvas()
+    const tool = gradebookHistoryTools(canvas).find((t) => t.name === 'list_gradebook_history_days')!
+
+    const result = await tool.handler({ course_id: 42 })
+
+    expect(result).toEqual(mockDays)
+    expect(canvas.gradebookHistory.listDays).toHaveBeenCalledWith(42)
+  })
+
+  it('delegates get_gradebook_history_day to canvas.gradebookHistory.getDay', async () => {
+    const canvas = buildMockCanvas()
+    const tool = gradebookHistoryTools(canvas).find((t) => t.name === 'get_gradebook_history_day')!
+
+    const result = await tool.handler({ course_id: 42, date: '2026-04-20' })
+
+    expect(result).toEqual(mockGraders)
+    expect(canvas.gradebookHistory.getDay).toHaveBeenCalledWith(42, '2026-04-20')
+  })
+
+  it('delegates list_gradebook_history_submissions to canvas.gradebookHistory.listSubmissions', async () => {
+    const canvas = buildMockCanvas()
+    const tool = gradebookHistoryTools(canvas).find(
+      (t) => t.name === 'list_gradebook_history_submissions',
+    )!
+
+    const result = await tool.handler({
+      course_id: 42,
+      date: '2026-04-20',
+      grader_id: 7,
+      assignment_id: 101,
+    })
+
+    expect(result).toEqual(mockSubmissionHistory)
+    expect(canvas.gradebookHistory.listSubmissions).toHaveBeenCalledWith(42, '2026-04-20', 7, 101)
+  })
+
+  it('delegates get_gradebook_history_feed to canvas.gradebookHistory.getFeed', async () => {
+    const canvas = buildMockCanvas()
+    const tool = gradebookHistoryTools(canvas).find((t) => t.name === 'get_gradebook_history_feed')!
+
+    const result = await tool.handler({
+      course_id: 42,
+      assignment_id: 101,
+      user_id: 12,
+      ascending: true,
+    })
+
+    expect(result).toEqual(mockFeed)
+    expect(canvas.gradebookHistory.getFeed).toHaveBeenCalledWith(42, {
+      assignment_id: 101,
+      user_id: 12,
+      ascending: true,
+    })
+  })
+})

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -48,6 +48,12 @@ function buildFullMockCanvas(): CanvasClient {
       upload: async () => ({}),
       delete: async () => undefined,
     },
+    gradebookHistory: {
+      listDays: async () => [],
+      getDay: async () => [],
+      listSubmissions: async () => [],
+      getFeed: async () => [],
+    },
     users: {
       listStudents: async () => [],
       get: async () => ({}),
@@ -147,7 +153,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 100 tools across all domains', () => {
+  it('returns all 104 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 
@@ -189,6 +195,11 @@ describe('getAllTools', () => {
     expect(names).toContain('get_file')
     expect(names).toContain('upload_file')
     expect(names).toContain('delete_file')
+    // Gradebook History (4)
+    expect(names).toContain('list_gradebook_history_days')
+    expect(names).toContain('get_gradebook_history_day')
+    expect(names).toContain('list_gradebook_history_submissions')
+    expect(names).toContain('get_gradebook_history_feed')
     // Users (5)
     expect(names).toContain('list_students')
     expect(names).toContain('get_user')
@@ -273,7 +284,7 @@ describe('getAllTools', () => {
     expect(names).toContain('get_upcoming_events')
     expect(names).toContain('get_missing_submissions')
 
-    expect(tools).toHaveLength(100)
+    expect(tools).toHaveLength(104)
   })
 
   it('all tools have openWorldHint: true', () => {


### PR DESCRIPTION
## Summary
- add a new Canvas gradebook history client module and MCP tool domain
- expose the four read-only Gradebook History API endpoints with typed inputs
- add coverage for client, registry, discovery manifest, and docs/tool-count updates

## Validation
- pnpm generate:manifests
- pnpm typecheck
- pnpm test
- pnpm build