### PR TITLE
feat: expose Canvas include[] and standard query params on list/get tools

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 104,
+  "toolCount": 105,
   "tools": [
     {
       "name": "health_check",
@@ -18,7 +18,7 @@
     {
       "name": "list_courses",
       "domain": "courses",
-      "description": "List courses for the authenticated user. Optionally filter by enrollment state.",
+      "description": "List courses for the authenticated user. `include` adds optional fields (teachers, total_students, term, syllabus_body, etc.). `state[]` narrows by course workflow state; `enrollment_state` narrows by the caller’s enrollment state.",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true
@@ -30,7 +30,7 @@
     {
       "name": "get_course",
       "domain": "courses",
-      "description": "Get details for a single course by ID, including term and total student count.",
+      "description": "Get details for a single course. Defaults to requesting `term` and `total_students`. Pass `include` to replace the default set with custom Canvas include[] fields (teachers, permissions, syllabus_body, sections, etc.).",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true
@@ -79,7 +79,7 @@
     {
       "name": "list_assignments",
       "domain": "assignments",
-      "description": "List all assignments in a course.",
+      "description": "List all assignments in a course. Use `include` to request submission, all_dates, overrides, score_statistics, etc. Use `bucket` to filter by past/upcoming/overdue/etc. Other filters: `search_term`, `assignment_ids`, `order_by`.",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true
@@ -93,7 +93,7 @@
     {
       "name": "get_assignment",
       "domain": "assignments",
-      "description": "Get details for a single assignment by ID.",
+      "description": "Get details for a single assignment by ID. Use `include` to request submission, overrides, all_dates, score_statistics, and other optional fields.",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true
@@ -107,7 +107,7 @@
     {
       "name": "list_assignment_groups",
       "domain": "assignments",
-      "description": "List assignment groups (categories like Homework, Exams) in a course.",
+      "description": "List assignment groups (categories like Homework, Exams) in a course. Use `include=assignments` to nest assignments under each group; other includes add submission, overrides, score_statistics, etc.",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true
@@ -157,7 +157,7 @@
     {
       "name": "list_submissions",
       "domain": "submissions",
-      "description": "List all submissions for an assignment in a course.",
+      "description": "List all submissions for an assignment. Use `include` to attach user, assignment, rubric_assessment, submission_history, or visibility. Filter with `student_ids`, `workflow_state`, or `grading_period_id`. Defaults to including submission_comments.",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true
@@ -171,7 +171,7 @@
     {
       "name": "get_submission",
       "domain": "submissions",
-      "description": "Get a single submission for a specific user on an assignment, including comments.",
+      "description": "Get a single submission for a specific user on an assignment. Defaults to including submission_comments. Pass `include` to add rubric_assessment, submission_history, visibility, course, user, or read_status.",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true
@@ -486,7 +486,7 @@
     {
       "name": "search_users",
       "domain": "users",
-      "description": "Search for users in a Canvas account by name, login, or email.",
+      "description": "Search for users in a Canvas account by name, login, or email. Use `include` to request email, last_login, avatar_url, time_zone, or uuid in the response.",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true
@@ -498,7 +498,7 @@
     {
       "name": "list_course_users",
       "domain": "users",
-      "description": "List all users in a course, optionally filtered by enrollment type.",
+      "description": "List users in a course with optional Canvas filters. Use `include` to request email, enrollments, avatar_url, bio, and other fields otherwise omitted from the default response. Use `enrollment_type` / `enrollment_state` to narrow by role or status, `search_term` to filter by name/login, `user_ids` to fetch a specific subset, and `sort`/`order` to control ordering.",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true
@@ -534,7 +534,19 @@
     {
       "name": "list_enrollments",
       "domain": "enrollments",
-      "description": "List all enrollments for the authenticated user across courses.",
+      "description": "List all enrollments for the authenticated user across courses. Optional filters and includes mirror Canvas `GET /users/self/enrollments`.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "admin",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_course_enrollments",
+      "domain": "enrollments",
+      "description": "List enrollments within a specific course with Canvas filters. Use `include=grades` / `include=current_points` for richer grade data, `type[]` to limit to a role, and `user_id` to focus on a single user.",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true

--- a/src/canvas/assignments.ts
+++ b/src/canvas/assignments.ts
@@ -1,4 +1,5 @@
 import type { CanvasHttpClient } from './client'
+import type { CanvasQueryParams } from './query'
 import type {
   CanvasAssignment,
   CanvasAssignmentGroup,
@@ -6,22 +7,119 @@ import type {
   UpdateAssignmentParams,
 } from './types'
 
+export type AssignmentListInclude =
+  | 'submission'
+  | 'assignment_visibility'
+  | 'all_dates'
+  | 'overrides'
+  | 'observed_users'
+  | 'can_edit'
+  | 'score_statistics'
+
+export type AssignmentGetInclude =
+  | 'submission'
+  | 'assignment_visibility'
+  | 'overrides'
+  | 'observed_users'
+  | 'can_edit'
+  | 'score_statistics'
+  | 'all_dates'
+
+export type AssignmentBucket =
+  | 'past'
+  | 'overdue'
+  | 'undated'
+  | 'ungraded'
+  | 'unsubmitted'
+  | 'upcoming'
+  | 'future'
+
+export type AssignmentOrderBy = 'position' | 'name' | 'due_at'
+
+export type AssignmentGroupInclude =
+  | 'assignments'
+  | 'discussion_topic'
+  | 'all_dates'
+  | 'assignment_visibility'
+  | 'overrides'
+  | 'submission'
+  | 'observed_users'
+  | 'can_edit'
+  | 'score_statistics'
+
+export interface ListAssignmentsOptions {
+  include?: ReadonlyArray<AssignmentListInclude>
+  search_term?: string
+  override_assignment_dates?: boolean
+  needs_grading_count_by_section?: boolean
+  bucket?: AssignmentBucket
+  assignment_ids?: ReadonlyArray<number>
+  order_by?: AssignmentOrderBy
+  post_to_sis?: boolean
+}
+
+export interface GetAssignmentOptions {
+  include?: ReadonlyArray<AssignmentGetInclude>
+  override_assignment_dates?: boolean
+  needs_grading_count_by_section?: boolean
+  all_dates?: boolean
+}
+
+export interface ListAssignmentGroupsOptions {
+  include?: ReadonlyArray<AssignmentGroupInclude>
+  assignment_ids?: ReadonlyArray<number>
+  exclude_assignment_submission_types?: ReadonlyArray<string>
+  override_assignment_dates?: boolean
+  grading_period_id?: number
+  scope_assignments_to_student?: boolean
+}
+
+function toQuery(opts: object): CanvasQueryParams {
+  const params: CanvasQueryParams = {}
+  for (const [key, value] of Object.entries(opts)) {
+    if (value === undefined || value === null) continue
+    if (Array.isArray(value)) {
+      if (value.length === 0) continue
+      params[key] = value as ReadonlyArray<string | number | boolean>
+    } else if (
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean'
+    ) {
+      params[key] = value
+    }
+  }
+  return params
+}
+
 export class AssignmentsModule {
   constructor(private client: CanvasHttpClient) {}
 
-  async list(courseId: number): Promise<CanvasAssignment[]> {
-    return this.client.paginate<CanvasAssignment>(`/api/v1/courses/${courseId}/assignments`)
-  }
-
-  async get(courseId: number, assignmentId: number): Promise<CanvasAssignment> {
-    return this.client.request<CanvasAssignment>(
-      `/api/v1/courses/${courseId}/assignments/${assignmentId}`,
+  async list(courseId: number, opts: ListAssignmentsOptions = {}): Promise<CanvasAssignment[]> {
+    return this.client.paginate<CanvasAssignment>(
+      `/api/v1/courses/${courseId}/assignments`,
+      toQuery(opts),
     )
   }
 
-  async listGroups(courseId: number): Promise<CanvasAssignmentGroup[]> {
+  async get(
+    courseId: number,
+    assignmentId: number,
+    opts: GetAssignmentOptions = {},
+  ): Promise<CanvasAssignment> {
+    return this.client.request<CanvasAssignment>(
+      `/api/v1/courses/${courseId}/assignments/${assignmentId}`,
+      { query: toQuery(opts) },
+    )
+  }
+
+  async listGroups(
+    courseId: number,
+    opts: ListAssignmentGroupsOptions = {},
+  ): Promise<CanvasAssignmentGroup[]> {
     return this.client.paginate<CanvasAssignmentGroup>(
       `/api/v1/courses/${courseId}/assignment_groups`,
+      toQuery(opts),
     )
   }
 

--- a/src/canvas/client.ts
+++ b/src/canvas/client.ts
@@ -1,3 +1,4 @@
+import { appendCanvasQuery, type CanvasQueryParams } from './query'
 import type { CanvasClientConfig, CanvasErrorResponse } from './types'
 
 export class CanvasApiError extends Error {
@@ -14,6 +15,15 @@ export class CanvasApiError extends Error {
 
 const DEFAULT_MAX_PAGINATION_PAGES = 1000
 const USER_AGENT = 'canvas-lms-mcp/1.0'
+
+export interface CanvasRequestOptions extends RequestInit {
+  /**
+   * Query params to append to the endpoint URL. Arrays produce repeated
+   * `key[]=v1&key[]=v2` entries (the convention Canvas uses for `include[]`).
+   * Preserves any query string already present on the endpoint.
+   */
+  query?: CanvasQueryParams
+}
 
 export class CanvasHttpClient {
   private token: string
@@ -35,11 +45,17 @@ export class CanvasHttpClient {
    * Returns `undefined` (typed as `T`) when Canvas responds with 204 No Content,
    * which is the expected response for DELETE operations.
    */
-  async request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
-    const url = endpoint.startsWith('http') ? endpoint : `${this._baseUrl}${endpoint}`
+  async request<T>(endpoint: string, options: CanvasRequestOptions = {}): Promise<T> {
+    const { query, ...init } = options
+    let url = endpoint.startsWith('http') ? endpoint : `${this._baseUrl}${endpoint}`
+    if (query) {
+      const parsed = new URL(url)
+      appendCanvasQuery(parsed.searchParams, query)
+      url = parsed.toString()
+    }
 
-    const method = (options.method ?? 'GET').toUpperCase()
-    if (options.body != null && (method === 'GET' || method === 'HEAD')) {
+    const method = (init.method ?? 'GET').toUpperCase()
+    if (init.body != null && (method === 'GET' || method === 'HEAD')) {
       throw new Error(
         `GET requests must not include a body (Canvas CloudFront CDN rejects them with 403): ${endpoint}`,
       )
@@ -49,15 +65,15 @@ export class CanvasHttpClient {
       Authorization: `Bearer ${this.token}`,
       'User-Agent': USER_AGENT,
     }
-    if (options.body) {
+    if (init.body) {
       headers['Content-Type'] = 'application/json'
     }
 
     const response = await fetch(url, {
-      ...options,
+      ...init,
       headers: {
         ...headers,
-        ...options.headers,
+        ...init.headers,
       },
     })
 
@@ -75,14 +91,12 @@ export class CanvasHttpClient {
     return response.json() as Promise<T>
   }
 
-  async paginate<T>(endpoint: string, params?: Record<string, string>): Promise<T[]> {
+  async paginate<T>(endpoint: string, params?: CanvasQueryParams): Promise<T[]> {
     const url = new URL(`${this._baseUrl}${endpoint}`)
-    url.searchParams.set('per_page', '100')
-    if (params) {
-      for (const [key, value] of Object.entries(params)) {
-        url.searchParams.set(key, value)
-      }
+    if (!url.searchParams.has('per_page')) {
+      url.searchParams.set('per_page', '100')
     }
+    appendCanvasQuery(url.searchParams, params)
 
     const results: T[] = []
     let nextUrl: string | null = url.toString()
@@ -116,15 +130,13 @@ export class CanvasHttpClient {
   async paginateEnvelope<T>(
     endpoint: string,
     envelopeKey: string,
-    params?: Record<string, string>,
+    params?: CanvasQueryParams,
   ): Promise<T[]> {
     const url = new URL(`${this._baseUrl}${endpoint}`)
-    url.searchParams.set('per_page', '100')
-    if (params) {
-      for (const [key, value] of Object.entries(params)) {
-        url.searchParams.set(key, value)
-      }
+    if (!url.searchParams.has('per_page')) {
+      url.searchParams.set('per_page', '100')
     }
+    appendCanvasQuery(url.searchParams, params)
 
     const results: T[] = []
     let nextUrl: string | null = url.toString()

--- a/src/canvas/courses.ts
+++ b/src/canvas/courses.ts
@@ -1,29 +1,83 @@
 import type { CanvasHttpClient } from './client'
+import type { CanvasQueryParams } from './query'
 import type { CanvasCourse, CreateCourseParams, UpdateCourseParams } from './types'
+
+export type CourseEnrollmentState = 'active' | 'invited_or_pending' | 'completed'
+
+export type CourseWorkflowState = 'unpublished' | 'available' | 'completed' | 'deleted'
+
+export type CourseListInclude =
+  | 'needs_grading_count'
+  | 'syllabus_body'
+  | 'public_description'
+  | 'total_scores'
+  | 'current_grading_period_scores'
+  | 'grading_periods'
+  | 'term'
+  | 'account'
+  | 'course_progress'
+  | 'sections'
+  | 'storage_quota_used_mb'
+  | 'total_students'
+  | 'passback_status'
+  | 'favorites'
+  | 'teachers'
+  | 'observed_users'
+  | 'tabs'
+  | 'course_image'
+  | 'banner_image'
+  | 'concluded'
+  | 'lti_context_id'
+  | 'post_manually'
+
+export type CourseGetInclude =
+  | CourseListInclude
+  | 'all_courses'
+  | 'permissions'
+  | 'public_description'
+
+export interface ListCoursesOptions {
+  enrollment_state?: CourseEnrollmentState
+  state?: ReadonlyArray<CourseWorkflowState>
+  enrollment_role_id?: number
+  include?: ReadonlyArray<CourseListInclude>
+  exclude_blueprint_courses?: boolean
+}
+
+export interface GetCourseOptions {
+  include?: ReadonlyArray<CourseGetInclude>
+  teacher_limit?: number
+}
+
+const DEFAULT_LIST_INCLUDE: ReadonlyArray<CourseListInclude> = ['term']
+const DEFAULT_GET_INCLUDE: ReadonlyArray<CourseGetInclude> = ['term', 'total_students']
 
 export class CoursesModule {
   constructor(private client: CanvasHttpClient) {}
 
-  async list(params?: { enrollment_state?: string }): Promise<CanvasCourse[]> {
-    const queryParams: Record<string, string> = {
-      'include[]': 'term',
+  async list(opts: ListCoursesOptions = {}): Promise<CanvasCourse[]> {
+    const params: CanvasQueryParams = {}
+    params.include = opts.include && opts.include.length > 0 ? opts.include : DEFAULT_LIST_INCLUDE
+    if (opts.enrollment_state) params.enrollment_state = opts.enrollment_state
+    if (opts.state && opts.state.length > 0) params.state = opts.state
+    if (opts.enrollment_role_id !== undefined) params.enrollment_role_id = opts.enrollment_role_id
+    if (opts.exclude_blueprint_courses !== undefined) {
+      params.exclude_blueprint_courses = opts.exclude_blueprint_courses
     }
-    if (params?.enrollment_state) {
-      queryParams.enrollment_state = params.enrollment_state
-    }
-    return this.client.paginate<CanvasCourse>('/api/v1/courses', queryParams)
+    return this.client.paginate<CanvasCourse>('/api/v1/courses', params)
   }
 
-  async get(courseId: number): Promise<CanvasCourse> {
-    return this.client.request<CanvasCourse>(
-      `/api/v1/courses/${courseId}?include[]=term&include[]=total_students`,
-    )
+  async get(courseId: number, opts: GetCourseOptions = {}): Promise<CanvasCourse> {
+    const include = opts.include && opts.include.length > 0 ? opts.include : DEFAULT_GET_INCLUDE
+    const query: CanvasQueryParams = { include }
+    if (opts.teacher_limit !== undefined) query.teacher_limit = opts.teacher_limit
+    return this.client.request<CanvasCourse>(`/api/v1/courses/${courseId}`, { query })
   }
 
   async getSyllabus(courseId: number): Promise<string | null> {
-    const course = await this.client.request<CanvasCourse>(
-      `/api/v1/courses/${courseId}?include[]=syllabus_body`,
-    )
+    const course = await this.client.request<CanvasCourse>(`/api/v1/courses/${courseId}`, {
+      query: { include: ['syllabus_body'] },
+    })
     return course.syllabus_body ?? null
   }
 

--- a/src/canvas/enrollments.ts
+++ b/src/canvas/enrollments.ts
@@ -1,11 +1,96 @@
 import type { CanvasHttpClient } from './client'
+import type { CanvasQueryParams } from './query'
 import type { CanvasEnrollment } from './types'
+
+export type EnrollmentType =
+  | 'StudentEnrollment'
+  | 'TeacherEnrollment'
+  | 'TaEnrollment'
+  | 'DesignerEnrollment'
+  | 'ObserverEnrollment'
+
+export type EnrollmentState =
+  | 'active'
+  | 'invited'
+  | 'creation_pending'
+  | 'deleted'
+  | 'rejected'
+  | 'completed'
+  | 'inactive'
+  | 'current_and_invited'
+  | 'current_and_future'
+  | 'current_and_concluded'
+
+export type EnrollmentInclude =
+  | 'avatar_url'
+  | 'group_ids'
+  | 'locked'
+  | 'observed_users'
+  | 'can_be_removed'
+  | 'uuid'
+  | 'current_points'
+  | 'grades'
+
+export interface ListCourseEnrollmentsOptions {
+  type?: ReadonlyArray<EnrollmentType>
+  role?: ReadonlyArray<string>
+  state?: ReadonlyArray<EnrollmentState>
+  include?: ReadonlyArray<EnrollmentInclude>
+  user_id?: number | string
+  grading_period_id?: number
+  enrollment_term_id?: number
+  sis_account_id?: ReadonlyArray<string>
+  sis_course_id?: ReadonlyArray<string>
+  sis_section_id?: ReadonlyArray<string>
+  sis_user_id?: ReadonlyArray<string>
+  created_for_sis_id?: ReadonlyArray<boolean>
+}
+
+export interface ListUserEnrollmentsOptions {
+  type?: ReadonlyArray<EnrollmentType>
+  role?: ReadonlyArray<string>
+  state?: ReadonlyArray<EnrollmentState>
+  include?: ReadonlyArray<EnrollmentInclude>
+  grading_period_id?: number
+  enrollment_term_id?: number
+}
+
+function buildParams(opts: object): CanvasQueryParams {
+  const params: CanvasQueryParams = {}
+  for (const [key, value] of Object.entries(opts)) {
+    if (value === undefined || value === null) continue
+    if (Array.isArray(value)) {
+      if (value.length === 0) continue
+      params[key] = value as ReadonlyArray<string | number | boolean>
+    } else if (
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean'
+    ) {
+      params[key] = value
+    }
+  }
+  return params
+}
 
 export class EnrollmentsModule {
   constructor(private client: CanvasHttpClient) {}
 
-  async list(): Promise<CanvasEnrollment[]> {
-    return this.client.paginate<CanvasEnrollment>('/api/v1/users/self/enrollments')
+  async list(opts: ListUserEnrollmentsOptions = {}): Promise<CanvasEnrollment[]> {
+    return this.client.paginate<CanvasEnrollment>(
+      '/api/v1/users/self/enrollments',
+      buildParams(opts),
+    )
+  }
+
+  async listForCourse(
+    courseId: number,
+    opts: ListCourseEnrollmentsOptions = {},
+  ): Promise<CanvasEnrollment[]> {
+    return this.client.paginate<CanvasEnrollment>(
+      `/api/v1/courses/${courseId}/enrollments`,
+      buildParams(opts),
+    )
   }
 
   async enroll(
@@ -38,11 +123,11 @@ export class EnrollmentsModule {
     if (courseId !== undefined) {
       return this.client.paginate<CanvasEnrollment>(`/api/v1/courses/${courseId}/enrollments`, {
         user_id: 'self',
-        'include[]': 'grades',
+        include: ['grades'],
       })
     }
     return this.client.paginate<CanvasEnrollment>('/api/v1/users/self/enrollments', {
-      'include[]': 'grades',
+      include: ['grades'],
     })
   }
 }

--- a/src/canvas/index.ts
+++ b/src/canvas/index.ts
@@ -70,4 +70,7 @@ export class CanvasClient {
 }
 
 export { CanvasHttpClient, CanvasApiError } from './client'
+export type { CanvasRequestOptions } from './client'
+export { appendCanvasQuery, toCanvasQuery } from './query'
+export type { CanvasQueryParams, CanvasQueryPrimitive, CanvasQueryValue } from './query'
 export type * from './types'

--- a/src/canvas/query.ts
+++ b/src/canvas/query.ts
@@ -1,0 +1,28 @@
+export type CanvasQueryPrimitive = string | number | boolean
+
+export type CanvasQueryValue = CanvasQueryPrimitive | ReadonlyArray<CanvasQueryPrimitive>
+
+export type CanvasQueryParams = Record<string, CanvasQueryValue | undefined | null>
+
+export function appendCanvasQuery(target: URLSearchParams, params?: CanvasQueryParams): void {
+  if (!params) return
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue
+    if (Array.isArray(value)) {
+      if (value.length === 0) continue
+      const arrayKey = key.endsWith('[]') ? key : `${key}[]`
+      for (const item of value) {
+        if (item === undefined || item === null) continue
+        target.append(arrayKey, String(item))
+      }
+    } else {
+      target.set(key, String(value))
+    }
+  }
+}
+
+export function toCanvasQuery(params?: CanvasQueryParams): URLSearchParams {
+  const search = new URLSearchParams()
+  appendCanvasQuery(search, params)
+  return search
+}

--- a/src/canvas/submissions.ts
+++ b/src/canvas/submissions.ts
@@ -1,19 +1,90 @@
 import type { CanvasHttpClient } from './client'
+import type { CanvasQueryParams } from './query'
 import type { CanvasSubmission } from './types'
+
+export type SubmissionListInclude =
+  | 'submission_history'
+  | 'submission_comments'
+  | 'rubric_assessment'
+  | 'assignment'
+  | 'visibility'
+  | 'course'
+  | 'user'
+  | 'group'
+  | 'read_status'
+  | 'sub_assignment_submissions'
+
+export type SubmissionGetInclude =
+  | 'submission_history'
+  | 'submission_comments'
+  | 'rubric_assessment'
+  | 'visibility'
+  | 'course'
+  | 'user'
+  | 'read_status'
+
+export type SubmissionWorkflowState = 'submitted' | 'unsubmitted' | 'graded' | 'pending_review'
+
+export interface ListSubmissionsOptions {
+  include?: ReadonlyArray<SubmissionListInclude>
+  student_ids?: ReadonlyArray<number | string>
+  assignment_ids?: ReadonlyArray<number>
+  section_ids?: ReadonlyArray<number>
+  grouped?: boolean
+  workflow_state?: SubmissionWorkflowState
+  grading_period_id?: number
+  post_to_sis?: boolean
+  submitted_since?: string
+  graded_since?: string
+}
+
+export interface GetSubmissionOptions {
+  include?: ReadonlyArray<SubmissionGetInclude>
+}
+
+const DEFAULT_LIST_INCLUDE: ReadonlyArray<SubmissionListInclude> = ['submission_comments']
+const DEFAULT_GET_INCLUDE: ReadonlyArray<SubmissionGetInclude> = ['submission_comments']
+
+function buildListParams(opts: ListSubmissionsOptions): CanvasQueryParams {
+  const params: CanvasQueryParams = {}
+  params.include = opts.include && opts.include.length > 0 ? opts.include : DEFAULT_LIST_INCLUDE
+  if (opts.student_ids && opts.student_ids.length > 0) params.student_ids = opts.student_ids
+  if (opts.assignment_ids && opts.assignment_ids.length > 0)
+    params.assignment_ids = opts.assignment_ids
+  if (opts.section_ids && opts.section_ids.length > 0) params.section_ids = opts.section_ids
+  if (opts.grouped !== undefined) params.grouped = opts.grouped
+  if (opts.workflow_state) params.workflow_state = opts.workflow_state
+  if (opts.grading_period_id !== undefined) params.grading_period_id = opts.grading_period_id
+  if (opts.post_to_sis !== undefined) params.post_to_sis = opts.post_to_sis
+  if (opts.submitted_since) params.submitted_since = opts.submitted_since
+  if (opts.graded_since) params.graded_since = opts.graded_since
+  return params
+}
 
 export class SubmissionsModule {
   constructor(private client: CanvasHttpClient) {}
 
-  async list(courseId: number, assignmentId: number): Promise<CanvasSubmission[]> {
+  async list(
+    courseId: number,
+    assignmentId: number,
+    opts: ListSubmissionsOptions = {},
+  ): Promise<CanvasSubmission[]> {
     return this.client.paginate<CanvasSubmission>(
       `/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions`,
-      { 'include[]': 'submission_comments' },
+      buildListParams(opts),
     )
   }
 
-  async get(courseId: number, assignmentId: number, userId: number): Promise<CanvasSubmission> {
+  async get(
+    courseId: number,
+    assignmentId: number,
+    userId: number,
+    opts: GetSubmissionOptions = {},
+  ): Promise<CanvasSubmission> {
+    const include = opts.include && opts.include.length > 0 ? opts.include : DEFAULT_GET_INCLUDE
     return this.client.request<CanvasSubmission>(
-      `/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions/${userId}?include[]=submission_comments`,
+      `/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions/${userId}`,
+      { query: { include } },
     )
   }
 
@@ -52,7 +123,7 @@ export class SubmissionsModule {
   async listMy(courseId: number): Promise<CanvasSubmission[]> {
     return this.client.paginate<CanvasSubmission>(
       `/api/v1/courses/${courseId}/students/submissions`,
-      { 'student_ids[]': 'self' },
+      { student_ids: ['self'] },
     )
   }
 }

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -25,6 +25,68 @@ export interface CanvasCourse {
   syllabus_body?: string
   term?: CanvasTerm
   enrollments?: CanvasEnrollment[]
+  account_id?: number
+  root_account_id?: number
+  is_public?: boolean
+  is_public_to_auth_users?: boolean
+  public_syllabus?: boolean
+  public_syllabus_to_auth?: boolean
+  public_description?: string | null
+  storage_quota_mb?: number
+  storage_quota_used_mb?: number
+  hide_final_grades?: boolean
+  license?: string | null
+  allow_student_assignment_edits?: boolean
+  allow_wiki_comments?: boolean
+  allow_student_forum_attachments?: boolean
+  open_enrollment?: boolean
+  self_enrollment?: boolean
+  restrict_enrollments_to_course_dates?: boolean
+  course_format?: string | null
+  access_restricted_by_date?: boolean
+  time_zone?: string
+  blueprint?: boolean
+  template?: boolean
+  created_at?: string
+  start_at?: string | null
+  end_at?: string | null
+  default_view?: string
+  locale?: string
+  apply_assignment_group_weights?: boolean
+  permissions?: Record<string, boolean>
+  sections?: CanvasCourseSection[]
+  teachers?: Array<{
+    id: number
+    anonymous_id?: string
+    display_name: string
+    avatar_image_url?: string | null
+    html_url?: string
+    pronouns?: string | null
+  }>
+  course_progress?: CanvasCourseProgress
+  image_download_url?: string | null
+  banner_image_download_url?: string | null
+  concluded?: boolean
+  post_manually?: boolean
+}
+
+export interface CanvasCourseSection {
+  id: number
+  name: string
+  start_at?: string | null
+  end_at?: string | null
+  created_at?: string
+  restrict_enrollments_to_section_dates?: boolean
+  nonxlist_course_id?: number | null
+  sis_section_id?: string | null
+  sis_course_id?: string | null
+}
+
+export interface CanvasCourseProgress {
+  requirement_count: number
+  requirement_completed_count: number
+  next_requirement_url?: string | null
+  completed_at?: string | null
 }
 
 export interface CanvasTerm {
@@ -47,9 +109,30 @@ export interface CanvasEnrollment {
   user_id: number
   type: string
   role: string
+  role_id?: number
   enrollment_state: string
   created_at?: string
+  updated_at?: string
+  start_at?: string | null
+  end_at?: string | null
+  course_section_id?: number
+  last_activity_at?: string | null
+  last_attended_at?: string | null
+  total_activity_time?: number
+  html_url?: string
+  sis_account_id?: string | null
+  sis_course_id?: string | null
+  sis_section_id?: string | null
+  sis_user_id?: string | null
   grades?: CanvasEnrollmentGrades
+  user?: CanvasUser
+  current_points?: number | null
+  locked?: boolean
+  can_be_removed?: boolean
+  avatar_url?: string
+  observed_users?: CanvasUser[]
+  group_ids?: number[]
+  uuid?: string
 }
 
 export interface CreateCourseParams {
@@ -76,6 +159,8 @@ export interface CanvasAssignment {
   name: string
   description: string | null
   due_at: string | null
+  unlock_at?: string | null
+  lock_at?: string | null
   points_possible: number
   grading_type: string
   submission_types: string[]
@@ -84,6 +169,56 @@ export interface CanvasAssignment {
   group_category_id?: number | null
   quiz_id?: number | null
   allowed_attempts: number
+  assignment_group_id?: number
+  position?: number
+  muted?: boolean
+  published?: boolean
+  only_visible_to_overrides?: boolean
+  locked_for_user?: boolean
+  html_url?: string
+  all_dates?: CanvasAssignmentDate[]
+  overrides?: CanvasAssignmentOverride[]
+  submission?: CanvasSubmission | CanvasSubmission[]
+  has_submitted_submissions?: boolean
+  needs_grading_count?: number
+  can_edit?: boolean
+  score_statistics?: {
+    min: number
+    max: number
+    mean: number
+    upper_q?: number
+    median?: number
+    lower_q?: number
+  }
+  assignment_visibility?: number[]
+  is_quiz_assignment?: boolean
+  in_closed_grading_period?: boolean
+  post_to_sis?: boolean
+  integration_id?: string | null
+  integration_data?: Record<string, unknown>
+}
+
+export interface CanvasAssignmentDate {
+  id?: number
+  base?: boolean
+  title?: string
+  due_at: string | null
+  unlock_at: string | null
+  lock_at: string | null
+}
+
+export interface CanvasAssignmentOverride {
+  id: number
+  assignment_id: number
+  title: string
+  due_at?: string | null
+  unlock_at?: string | null
+  lock_at?: string | null
+  all_day?: boolean
+  all_day_date?: string | null
+  student_ids?: number[]
+  group_id?: number
+  course_section_id?: number
 }
 
 export interface CanvasAssignmentGroup {
@@ -91,7 +226,15 @@ export interface CanvasAssignmentGroup {
   name: string
   position: number
   group_weight: number
+  sis_source_id?: string | null
+  integration_data?: Record<string, unknown>
+  rules?: {
+    drop_lowest?: number
+    drop_highest?: number
+    never_drop?: number[]
+  }
   assignments?: CanvasAssignment[]
+  any_assignment_in_closed_grading_period?: boolean
 }
 
 export interface CanvasUpcomingEvent {
@@ -113,16 +256,42 @@ export interface CanvasSubmission {
   id: number
   assignment_id: number
   user_id: number
+  grader_id?: number | null
   submitted_at: string | null
+  graded_at?: string | null
+  posted_at?: string | null
   score: number | null
+  entered_score?: number | null
   grade: string | null
+  entered_grade?: string | null
   body: string | null
   url: string | null
   attempt: number | null
   workflow_state: string
+  late?: boolean
+  missing?: boolean
+  late_policy_status?: string | null
+  points_deducted?: number | null
+  seconds_late?: number
+  excused?: boolean | null
+  grade_matches_current_submission?: boolean
+  assignment_visible?: boolean
+  anonymous_id?: string
+  preview_url?: string
+  html_url?: string
+  read_status?: 'read' | 'unread'
   custom_grade_status_id?: number | null
   attachments?: CanvasAttachment[]
   submission_comments?: CanvasSubmissionComment[]
+  submission_history?: CanvasSubmission[]
+  rubric_assessment?: Record<
+    string,
+    { points?: number | null; comments?: string | null; rating_id?: string | null }
+  >
+  user?: CanvasUser
+  assignment?: CanvasAssignment
+  course?: CanvasCourse
+  group?: CanvasGroup
 }
 
 export interface CanvasAttachment {
@@ -284,9 +453,25 @@ export interface CanvasFileUploadInfo {
 export interface CanvasUser {
   id: number
   name: string
+  sortable_name?: string
+  short_name?: string
   login_id?: string
+  sis_user_id?: string | null
+  integration_id?: string | null
   email?: string
   avatar_url?: string
+  time_zone?: string
+  locale?: string | null
+  last_login?: string | null
+  bio?: string | null
+  pronouns?: string | null
+  uuid?: string
+  created_at?: string
+  effective_locale?: string
+  enrollments?: CanvasEnrollment[]
+  permissions?: Record<string, boolean>
+  custom_links?: Array<{ text: string; url: string; tool_id?: string; icon_class?: string }>
+  locked?: boolean
 }
 
 export interface CanvasUserProfile {

--- a/src/canvas/users.ts
+++ b/src/canvas/users.ts
@@ -1,12 +1,50 @@
 import type { CanvasHttpClient } from './client'
+import type { CanvasQueryParams } from './query'
 import type { CanvasUpcomingEvent, CanvasUser, CanvasUserProfile } from './types'
+
+export type CourseUserEnrollmentType = 'student' | 'teacher' | 'ta' | 'observer' | 'designer'
+
+export type CourseUserEnrollmentState = 'active' | 'invited' | 'rejected' | 'completed' | 'inactive'
+
+export type CourseUserInclude =
+  | 'email'
+  | 'enrollments'
+  | 'locked'
+  | 'avatar_url'
+  | 'test_student'
+  | 'bio'
+  | 'custom_links'
+  | 'current_grading_period_scores'
+  | 'uuid'
+
+export type UserSort = 'username' | 'email' | 'sis_id' | 'integration_id' | 'last_login'
+
+export type SearchUserInclude = 'email' | 'last_login' | 'avatar_url' | 'time_zone' | 'uuid'
+
+export interface ListCourseUsersOptions {
+  enrollment_type?: CourseUserEnrollmentType | ReadonlyArray<CourseUserEnrollmentType>
+  enrollment_state?: ReadonlyArray<CourseUserEnrollmentState>
+  enrollment_role_id?: number
+  include?: ReadonlyArray<CourseUserInclude>
+  user_ids?: ReadonlyArray<number | string>
+  user_id?: number | string
+  search_term?: string
+  sort?: UserSort
+  order?: 'asc' | 'desc'
+}
+
+export interface SearchUsersOptions {
+  sort?: UserSort
+  order?: 'asc' | 'desc'
+  include?: ReadonlyArray<SearchUserInclude>
+}
 
 export class UsersModule {
   constructor(private client: CanvasHttpClient) {}
 
   async listStudents(courseId: number): Promise<CanvasUser[]> {
     return this.client.paginate<CanvasUser>(`/api/v1/courses/${courseId}/users`, {
-      'enrollment_type[]': 'student',
+      enrollment_type: ['student'],
     })
   }
 
@@ -21,18 +59,35 @@ export class UsersModule {
   async searchUsers(
     accountId: number,
     searchTerm: string,
-    sort?: string,
-    order?: string,
+    opts: SearchUsersOptions = {},
   ): Promise<CanvasUser[]> {
-    const params: Record<string, string> = { search_term: searchTerm }
-    if (sort) params.sort = sort
-    if (order) params.order = order
+    const params: CanvasQueryParams = { search_term: searchTerm }
+    if (opts.sort) params.sort = opts.sort
+    if (opts.order) params.order = opts.order
+    if (opts.include && opts.include.length > 0) params.include = opts.include
     return this.client.paginate<CanvasUser>(`/api/v1/accounts/${accountId}/users`, params)
   }
 
-  async listCourseUsers(courseId: number, enrollmentType?: string): Promise<CanvasUser[]> {
-    const params: Record<string, string> = {}
-    if (enrollmentType) params['enrollment_type[]'] = enrollmentType
+  async listCourseUsers(
+    courseId: number,
+    opts: ListCourseUsersOptions = {},
+  ): Promise<CanvasUser[]> {
+    const params: CanvasQueryParams = {}
+    if (opts.enrollment_type !== undefined) {
+      params.enrollment_type = Array.isArray(opts.enrollment_type)
+        ? opts.enrollment_type
+        : [opts.enrollment_type]
+    }
+    if (opts.enrollment_state && opts.enrollment_state.length > 0) {
+      params.enrollment_state = opts.enrollment_state
+    }
+    if (opts.enrollment_role_id !== undefined) params.enrollment_role_id = opts.enrollment_role_id
+    if (opts.include && opts.include.length > 0) params.include = opts.include
+    if (opts.user_ids && opts.user_ids.length > 0) params.user_ids = opts.user_ids
+    if (opts.user_id !== undefined) params.user_id = opts.user_id
+    if (opts.search_term) params.search_term = opts.search_term
+    if (opts.sort) params.sort = opts.sort
+    if (opts.order) params.order = opts.order
     return this.client.paginate<CanvasUser>(`/api/v1/courses/${courseId}/users`, params)
   }
 

--- a/src/tools/assignments.ts
+++ b/src/tools/assignments.ts
@@ -1,54 +1,220 @@
 import { z } from 'zod'
 import type { CanvasClient } from '../canvas'
+import type {
+  AssignmentBucket,
+  AssignmentGetInclude,
+  AssignmentGroupInclude,
+  AssignmentListInclude,
+  AssignmentOrderBy,
+  GetAssignmentOptions,
+  ListAssignmentGroupsOptions,
+  ListAssignmentsOptions,
+} from '../canvas/assignments'
 import type { ToolDefinition } from './types'
+
+const ASSIGNMENT_LIST_INCLUDE = [
+  'submission',
+  'assignment_visibility',
+  'all_dates',
+  'overrides',
+  'observed_users',
+  'can_edit',
+  'score_statistics',
+] as const
+
+const ASSIGNMENT_GET_INCLUDE = [
+  'submission',
+  'assignment_visibility',
+  'overrides',
+  'observed_users',
+  'can_edit',
+  'score_statistics',
+  'all_dates',
+] as const
+
+const ASSIGNMENT_BUCKET = [
+  'past',
+  'overdue',
+  'undated',
+  'ungraded',
+  'unsubmitted',
+  'upcoming',
+  'future',
+] as const
+
+const ASSIGNMENT_ORDER_BY = ['position', 'name', 'due_at'] as const
+
+const ASSIGNMENT_GROUP_INCLUDE = [
+  'assignments',
+  'discussion_topic',
+  'all_dates',
+  'assignment_visibility',
+  'overrides',
+  'submission',
+  'observed_users',
+  'can_edit',
+  'score_statistics',
+] as const
 
 export function assignmentTools(canvas: CanvasClient): ToolDefinition[] {
   return [
     {
       name: 'list_assignments',
-      description: 'List all assignments in a course.',
+      description:
+        'List all assignments in a course. Use `include` to request submission, all_dates, overrides, score_statistics, etc. Use `bucket` to filter by past/upcoming/overdue/etc. Other filters: `search_term`, `assignment_ids`, `order_by`.',
       inputSchema: {
         course_id: z.number().describe('The Canvas course ID'),
+        include: z
+          .array(z.enum(ASSIGNMENT_LIST_INCLUDE))
+          .optional()
+          .describe('Extra fields to include on each assignment (Canvas include[] param)'),
+        search_term: z
+          .string()
+          .optional()
+          .describe('Partial name substring to filter assignments by'),
+        bucket: z
+          .enum(ASSIGNMENT_BUCKET)
+          .optional()
+          .describe('Only include assignments in the given bucket'),
+        assignment_ids: z
+          .array(z.number())
+          .optional()
+          .describe('Restrict to the given list of assignment IDs'),
+        order_by: z.enum(ASSIGNMENT_ORDER_BY).optional().describe('Field to sort the result by'),
+        override_assignment_dates: z
+          .boolean()
+          .optional()
+          .describe(
+            'Apply assignment overrides to due/unlock/lock dates (default Canvas behavior: true)',
+          ),
+        needs_grading_count_by_section: z
+          .boolean()
+          .optional()
+          .describe('Break needs_grading_count down by section'),
+        post_to_sis: z
+          .boolean()
+          .optional()
+          .describe('Filter to assignments that are/are not posted to SIS'),
       },
       annotations: {
         readOnlyHint: true,
         openWorldHint: true,
       },
       handler: async (params) => {
-        const course_id = params.course_id as number
-        return canvas.assignments.list(course_id)
+        const opts: ListAssignmentsOptions = {}
+        if (params.include !== undefined)
+          opts.include = params.include as ReadonlyArray<AssignmentListInclude>
+        if (params.search_term !== undefined) opts.search_term = params.search_term as string
+        if (params.bucket !== undefined) opts.bucket = params.bucket as AssignmentBucket
+        if (params.assignment_ids !== undefined)
+          opts.assignment_ids = params.assignment_ids as ReadonlyArray<number>
+        if (params.order_by !== undefined) opts.order_by = params.order_by as AssignmentOrderBy
+        if (params.override_assignment_dates !== undefined)
+          opts.override_assignment_dates = params.override_assignment_dates as boolean
+        if (params.needs_grading_count_by_section !== undefined)
+          opts.needs_grading_count_by_section = params.needs_grading_count_by_section as boolean
+        if (params.post_to_sis !== undefined) opts.post_to_sis = params.post_to_sis as boolean
+        return canvas.assignments.list(params.course_id as number, opts)
       },
     },
     {
       name: 'get_assignment',
-      description: 'Get details for a single assignment by ID.',
+      description:
+        'Get details for a single assignment by ID. Use `include` to request submission, overrides, all_dates, score_statistics, and other optional fields.',
       inputSchema: {
         course_id: z.number().describe('The Canvas course ID'),
         assignment_id: z.number().describe('The Canvas assignment ID'),
+        include: z
+          .array(z.enum(ASSIGNMENT_GET_INCLUDE))
+          .optional()
+          .describe('Extra fields to include on the assignment (Canvas include[] param)'),
+        override_assignment_dates: z
+          .boolean()
+          .optional()
+          .describe('Apply assignment overrides to due/unlock/lock dates'),
+        needs_grading_count_by_section: z
+          .boolean()
+          .optional()
+          .describe('Break needs_grading_count down by section'),
+        all_dates: z
+          .boolean()
+          .optional()
+          .describe('Return all dates associated with this assignment'),
       },
       annotations: {
         readOnlyHint: true,
         openWorldHint: true,
       },
       handler: async (params) => {
-        const course_id = params.course_id as number
-        const assignment_id = params.assignment_id as number
-        return canvas.assignments.get(course_id, assignment_id)
+        const opts: GetAssignmentOptions = {}
+        if (params.include !== undefined)
+          opts.include = params.include as ReadonlyArray<AssignmentGetInclude>
+        if (params.override_assignment_dates !== undefined)
+          opts.override_assignment_dates = params.override_assignment_dates as boolean
+        if (params.needs_grading_count_by_section !== undefined)
+          opts.needs_grading_count_by_section = params.needs_grading_count_by_section as boolean
+        if (params.all_dates !== undefined) opts.all_dates = params.all_dates as boolean
+        return canvas.assignments.get(
+          params.course_id as number,
+          params.assignment_id as number,
+          opts,
+        )
       },
     },
     {
       name: 'list_assignment_groups',
-      description: 'List assignment groups (categories like Homework, Exams) in a course.',
+      description:
+        'List assignment groups (categories like Homework, Exams) in a course. Use `include=assignments` to nest assignments under each group; other includes add submission, overrides, score_statistics, etc.',
       inputSchema: {
         course_id: z.number().describe('The Canvas course ID'),
+        include: z
+          .array(z.enum(ASSIGNMENT_GROUP_INCLUDE))
+          .optional()
+          .describe('Extra fields to include (Canvas include[] param)'),
+        assignment_ids: z
+          .array(z.number())
+          .optional()
+          .describe(
+            'When combined with include=assignments, restrict nested assignments to these IDs',
+          ),
+        exclude_assignment_submission_types: z
+          .array(z.string())
+          .optional()
+          .describe('Exclude assignments whose submission_types match any of these values'),
+        override_assignment_dates: z
+          .boolean()
+          .optional()
+          .describe('Apply assignment overrides to due/unlock/lock dates'),
+        grading_period_id: z
+          .number()
+          .int()
+          .optional()
+          .describe('Scope to a specific grading period'),
+        scope_assignments_to_student: z
+          .boolean()
+          .optional()
+          .describe('Limit assignments to what the current student can see'),
       },
       annotations: {
         readOnlyHint: true,
         openWorldHint: true,
       },
       handler: async (params) => {
-        const course_id = params.course_id as number
-        return canvas.assignments.listGroups(course_id)
+        const opts: ListAssignmentGroupsOptions = {}
+        if (params.include !== undefined)
+          opts.include = params.include as ReadonlyArray<AssignmentGroupInclude>
+        if (params.assignment_ids !== undefined)
+          opts.assignment_ids = params.assignment_ids as ReadonlyArray<number>
+        if (params.exclude_assignment_submission_types !== undefined)
+          opts.exclude_assignment_submission_types =
+            params.exclude_assignment_submission_types as ReadonlyArray<string>
+        if (params.override_assignment_dates !== undefined)
+          opts.override_assignment_dates = params.override_assignment_dates as boolean
+        if (params.grading_period_id !== undefined)
+          opts.grading_period_id = params.grading_period_id as number
+        if (params.scope_assignments_to_student !== undefined)
+          opts.scope_assignments_to_student = params.scope_assignments_to_student as boolean
+        return canvas.assignments.listGroups(params.course_id as number, opts)
       },
     },
     {

--- a/src/tools/courses.ts
+++ b/src/tools/courses.ts
@@ -1,41 +1,120 @@
 import { z } from 'zod'
 import type { CanvasClient } from '../canvas'
+import type {
+  CourseEnrollmentState,
+  CourseGetInclude,
+  CourseListInclude,
+  CourseWorkflowState,
+  GetCourseOptions,
+  ListCoursesOptions,
+} from '../canvas/courses'
 import type { ToolDefinition } from './types'
+
+const COURSE_LIST_INCLUDE = [
+  'needs_grading_count',
+  'syllabus_body',
+  'public_description',
+  'total_scores',
+  'current_grading_period_scores',
+  'grading_periods',
+  'term',
+  'account',
+  'course_progress',
+  'sections',
+  'storage_quota_used_mb',
+  'total_students',
+  'passback_status',
+  'favorites',
+  'teachers',
+  'observed_users',
+  'tabs',
+  'course_image',
+  'banner_image',
+  'concluded',
+  'lti_context_id',
+  'post_manually',
+] as const
+
+const COURSE_GET_INCLUDE = [...COURSE_LIST_INCLUDE, 'all_courses', 'permissions'] as const
+
+const COURSE_WORKFLOW_STATE = ['unpublished', 'available', 'completed', 'deleted'] as const
+
+const COURSE_ENROLLMENT_STATE = ['active', 'invited_or_pending', 'completed'] as const
 
 export function courseTools(canvas: CanvasClient): ToolDefinition[] {
   return [
     {
       name: 'list_courses',
       description:
-        'List courses for the authenticated user. Optionally filter by enrollment state.',
+        'List courses for the authenticated user. `include` adds optional fields (teachers, total_students, term, syllabus_body, etc.). `state[]` narrows by course workflow state; `enrollment_state` narrows by the caller’s enrollment state.',
       inputSchema: {
         enrollment_state: z
-          .enum(['active', 'completed', 'all'])
+          .enum(COURSE_ENROLLMENT_STATE)
           .optional()
-          .describe('Filter courses by enrollment state'),
+          .describe('Filter courses by the caller’s enrollment state'),
+        state: z
+          .array(z.enum(COURSE_WORKFLOW_STATE))
+          .optional()
+          .describe('Filter by course workflow state'),
+        enrollment_role_id: z
+          .number()
+          .int()
+          .optional()
+          .describe('Filter by specific enrollment role ID'),
+        include: z
+          .array(z.enum(COURSE_LIST_INCLUDE))
+          .optional()
+          .describe('Extra fields to include on each course (Canvas include[] param)'),
+        exclude_blueprint_courses: z
+          .boolean()
+          .optional()
+          .describe('Exclude blueprint courses from the results'),
       },
       annotations: {
         readOnlyHint: true,
         openWorldHint: true,
       },
       handler: async (params) => {
-        const enrollment_state = params.enrollment_state as string | undefined
-        return canvas.courses.list({ enrollment_state })
+        const opts: ListCoursesOptions = {}
+        if (params.enrollment_state !== undefined)
+          opts.enrollment_state = params.enrollment_state as CourseEnrollmentState
+        if (params.state !== undefined)
+          opts.state = params.state as ReadonlyArray<CourseWorkflowState>
+        if (params.enrollment_role_id !== undefined)
+          opts.enrollment_role_id = params.enrollment_role_id as number
+        if (params.include !== undefined)
+          opts.include = params.include as ReadonlyArray<CourseListInclude>
+        if (params.exclude_blueprint_courses !== undefined)
+          opts.exclude_blueprint_courses = params.exclude_blueprint_courses as boolean
+        return canvas.courses.list(opts)
       },
     },
     {
       name: 'get_course',
-      description: 'Get details for a single course by ID, including term and total student count.',
+      description:
+        'Get details for a single course. Defaults to requesting `term` and `total_students`. Pass `include` to replace the default set with custom Canvas include[] fields (teachers, permissions, syllabus_body, sections, etc.).',
       inputSchema: {
         course_id: z.number().describe('The Canvas course ID'),
+        include: z
+          .array(z.enum(COURSE_GET_INCLUDE))
+          .optional()
+          .describe('Extra fields to include on the course (Canvas include[] param)'),
+        teacher_limit: z
+          .number()
+          .int()
+          .optional()
+          .describe('Limit on the number of teachers returned when include=teachers'),
       },
       annotations: {
         readOnlyHint: true,
         openWorldHint: true,
       },
       handler: async (params) => {
-        const course_id = params.course_id as number
-        return canvas.courses.get(course_id)
+        const opts: GetCourseOptions = {}
+        if (params.include !== undefined)
+          opts.include = params.include as ReadonlyArray<CourseGetInclude>
+        if (params.teacher_limit !== undefined) opts.teacher_limit = params.teacher_limit as number
+        return canvas.courses.get(params.course_id as number, opts)
       },
     },
     {

--- a/src/tools/enrollments.ts
+++ b/src/tools/enrollments.ts
@@ -1,19 +1,146 @@
 import { z } from 'zod'
 import type { CanvasClient } from '../canvas'
+import type {
+  EnrollmentInclude,
+  EnrollmentState,
+  EnrollmentType,
+  ListCourseEnrollmentsOptions,
+  ListUserEnrollmentsOptions,
+} from '../canvas/enrollments'
 import type { ToolDefinition } from './types'
+
+const ENROLLMENT_TYPE = [
+  'StudentEnrollment',
+  'TeacherEnrollment',
+  'TaEnrollment',
+  'DesignerEnrollment',
+  'ObserverEnrollment',
+] as const
+
+const ENROLLMENT_STATE = [
+  'active',
+  'invited',
+  'creation_pending',
+  'deleted',
+  'rejected',
+  'completed',
+  'inactive',
+  'current_and_invited',
+  'current_and_future',
+  'current_and_concluded',
+] as const
+
+const ENROLLMENT_INCLUDE = [
+  'avatar_url',
+  'group_ids',
+  'locked',
+  'observed_users',
+  'can_be_removed',
+  'uuid',
+  'current_points',
+  'grades',
+] as const
 
 export function enrollmentTools(canvas: CanvasClient): ToolDefinition[] {
   return [
     {
       name: 'list_enrollments',
-      description: 'List all enrollments for the authenticated user across courses.',
-      inputSchema: {},
+      description:
+        'List all enrollments for the authenticated user across courses. Optional filters and includes mirror Canvas `GET /users/self/enrollments`.',
+      inputSchema: {
+        type: z
+          .array(z.enum(ENROLLMENT_TYPE))
+          .optional()
+          .describe('Filter by one or more enrollment types'),
+        state: z
+          .array(z.enum(ENROLLMENT_STATE))
+          .optional()
+          .describe('Filter by one or more enrollment states'),
+        role: z
+          .array(z.string())
+          .optional()
+          .describe('Filter by enrollment role names (as defined in the Canvas account)'),
+        include: z
+          .array(z.enum(ENROLLMENT_INCLUDE))
+          .optional()
+          .describe('Extra fields to include on each enrollment (Canvas include[] param)'),
+        grading_period_id: z
+          .number()
+          .int()
+          .optional()
+          .describe('Return enrollments scoped to this grading period'),
+        enrollment_term_id: z
+          .number()
+          .int()
+          .optional()
+          .describe('Limit to enrollments in the given term'),
+      },
       annotations: {
         readOnlyHint: true,
         openWorldHint: true,
       },
-      handler: async () => {
-        return canvas.enrollments.list()
+      handler: async (params) => {
+        const opts: ListUserEnrollmentsOptions = {}
+        if (params.type !== undefined) opts.type = params.type as ReadonlyArray<EnrollmentType>
+        if (params.state !== undefined) opts.state = params.state as ReadonlyArray<EnrollmentState>
+        if (params.role !== undefined) opts.role = params.role as ReadonlyArray<string>
+        if (params.include !== undefined)
+          opts.include = params.include as ReadonlyArray<EnrollmentInclude>
+        if (params.grading_period_id !== undefined)
+          opts.grading_period_id = params.grading_period_id as number
+        if (params.enrollment_term_id !== undefined)
+          opts.enrollment_term_id = params.enrollment_term_id as number
+        return canvas.enrollments.list(opts)
+      },
+    },
+    {
+      name: 'list_course_enrollments',
+      description:
+        'List enrollments within a specific course with Canvas filters. Use `include=grades` / `include=current_points` for richer grade data, `type[]` to limit to a role, and `user_id` to focus on a single user.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        type: z
+          .array(z.enum(ENROLLMENT_TYPE))
+          .optional()
+          .describe('Filter by one or more enrollment types'),
+        state: z.array(z.enum(ENROLLMENT_STATE)).optional().describe('Filter by enrollment states'),
+        role: z.array(z.string()).optional().describe('Filter by custom role names'),
+        include: z
+          .array(z.enum(ENROLLMENT_INCLUDE))
+          .optional()
+          .describe('Extra fields to include (Canvas include[] param)'),
+        user_id: z
+          .union([z.number(), z.string()])
+          .optional()
+          .describe('Filter to a specific user (may be numeric ID or "self")'),
+        grading_period_id: z
+          .number()
+          .int()
+          .optional()
+          .describe('Scope grade-related includes to this grading period'),
+        enrollment_term_id: z
+          .number()
+          .int()
+          .optional()
+          .describe('Limit to enrollments in the given term'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const opts: ListCourseEnrollmentsOptions = {}
+        if (params.type !== undefined) opts.type = params.type as ReadonlyArray<EnrollmentType>
+        if (params.state !== undefined) opts.state = params.state as ReadonlyArray<EnrollmentState>
+        if (params.role !== undefined) opts.role = params.role as ReadonlyArray<string>
+        if (params.include !== undefined)
+          opts.include = params.include as ReadonlyArray<EnrollmentInclude>
+        if (params.user_id !== undefined) opts.user_id = params.user_id as number | string
+        if (params.grading_period_id !== undefined)
+          opts.grading_period_id = params.grading_period_id as number
+        if (params.enrollment_term_id !== undefined)
+          opts.enrollment_term_id = params.enrollment_term_id as number
+        return canvas.enrollments.listForCourse(params.course_id as number, opts)
       },
     },
     {

--- a/src/tools/submissions.ts
+++ b/src/tools/submissions.ts
@@ -1,44 +1,127 @@
 import { z } from 'zod'
 import type { CanvasClient } from '../canvas'
+import type {
+  GetSubmissionOptions,
+  ListSubmissionsOptions,
+  SubmissionGetInclude,
+  SubmissionListInclude,
+  SubmissionWorkflowState,
+} from '../canvas/submissions'
 import type { ToolDefinition } from './types'
+
+const SUBMISSION_LIST_INCLUDE = [
+  'submission_history',
+  'submission_comments',
+  'rubric_assessment',
+  'assignment',
+  'visibility',
+  'course',
+  'user',
+  'group',
+  'read_status',
+  'sub_assignment_submissions',
+] as const
+
+const SUBMISSION_GET_INCLUDE = [
+  'submission_history',
+  'submission_comments',
+  'rubric_assessment',
+  'visibility',
+  'course',
+  'user',
+  'read_status',
+] as const
+
+const SUBMISSION_WORKFLOW_STATE = ['submitted', 'unsubmitted', 'graded', 'pending_review'] as const
 
 export function submissionTools(canvas: CanvasClient): ToolDefinition[] {
   return [
     {
       name: 'list_submissions',
-      description: 'List all submissions for an assignment in a course.',
+      description:
+        'List all submissions for an assignment. Use `include` to attach user, assignment, rubric_assessment, submission_history, or visibility. Filter with `student_ids`, `workflow_state`, or `grading_period_id`. Defaults to including submission_comments.',
       inputSchema: {
         course_id: z.number().describe('The Canvas course ID'),
         assignment_id: z.number().describe('The Canvas assignment ID'),
+        include: z
+          .array(z.enum(SUBMISSION_LIST_INCLUDE))
+          .optional()
+          .describe(
+            'Extra fields to include (Canvas include[] param). Defaults to ["submission_comments"] when omitted.',
+          ),
+        student_ids: z
+          .array(z.union([z.number(), z.string()]))
+          .optional()
+          .describe(
+            'Restrict to submissions for these user IDs. Use "all" or "self" for shortcuts.',
+          ),
+        section_ids: z
+          .array(z.number())
+          .optional()
+          .describe('Restrict to submissions in these sections'),
+        grouped: z
+          .boolean()
+          .optional()
+          .describe('Return one submission per group rather than per student'),
+        workflow_state: z
+          .enum(SUBMISSION_WORKFLOW_STATE)
+          .optional()
+          .describe('Only include submissions in this workflow state'),
+        grading_period_id: z.number().int().optional().describe('Restrict to a grading period'),
       },
       annotations: {
         readOnlyHint: true,
         openWorldHint: true,
       },
       handler: async (params) => {
-        const course_id = params.course_id as number
-        const assignment_id = params.assignment_id as number
-        return canvas.submissions.list(course_id, assignment_id)
+        const opts: ListSubmissionsOptions = {}
+        if (params.include !== undefined)
+          opts.include = params.include as ReadonlyArray<SubmissionListInclude>
+        if (params.student_ids !== undefined)
+          opts.student_ids = params.student_ids as ReadonlyArray<number | string>
+        if (params.section_ids !== undefined)
+          opts.section_ids = params.section_ids as ReadonlyArray<number>
+        if (params.grouped !== undefined) opts.grouped = params.grouped as boolean
+        if (params.workflow_state !== undefined)
+          opts.workflow_state = params.workflow_state as SubmissionWorkflowState
+        if (params.grading_period_id !== undefined)
+          opts.grading_period_id = params.grading_period_id as number
+        return canvas.submissions.list(
+          params.course_id as number,
+          params.assignment_id as number,
+          opts,
+        )
       },
     },
     {
       name: 'get_submission',
       description:
-        'Get a single submission for a specific user on an assignment, including comments.',
+        'Get a single submission for a specific user on an assignment. Defaults to including submission_comments. Pass `include` to add rubric_assessment, submission_history, visibility, course, user, or read_status.',
       inputSchema: {
         course_id: z.number().describe('The Canvas course ID'),
         assignment_id: z.number().describe('The Canvas assignment ID'),
         user_id: z.number().describe('The Canvas user ID'),
+        include: z
+          .array(z.enum(SUBMISSION_GET_INCLUDE))
+          .optional()
+          .describe(
+            'Extra fields to include (Canvas include[] param). Defaults to ["submission_comments"] when omitted.',
+          ),
       },
       annotations: {
         readOnlyHint: true,
         openWorldHint: true,
       },
       handler: async (params) => {
-        const course_id = params.course_id as number
-        const assignment_id = params.assignment_id as number
-        const user_id = params.user_id as number
-        return canvas.submissions.get(course_id, assignment_id, user_id)
+        const opts: GetSubmissionOptions = {}
+        if (params.include !== undefined)
+          opts.include = params.include as ReadonlyArray<SubmissionGetInclude>
+        return canvas.submissions.get(
+          params.course_id as number,
+          params.assignment_id as number,
+          params.user_id as number,
+          opts,
+        )
       },
     },
     {

--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -1,6 +1,37 @@
 import { z } from 'zod'
 import type { CanvasClient } from '../canvas'
+import type {
+  CourseUserEnrollmentState,
+  CourseUserEnrollmentType,
+  CourseUserInclude,
+  ListCourseUsersOptions,
+  SearchUserInclude,
+  SearchUsersOptions,
+  UserSort,
+} from '../canvas/users'
 import type { ToolDefinition } from './types'
+
+const COURSE_USER_ENROLLMENT_TYPE = ['student', 'teacher', 'ta', 'observer', 'designer'] as const
+const COURSE_USER_ENROLLMENT_STATE = [
+  'active',
+  'invited',
+  'rejected',
+  'completed',
+  'inactive',
+] as const
+const COURSE_USER_INCLUDE = [
+  'email',
+  'enrollments',
+  'locked',
+  'avatar_url',
+  'test_student',
+  'bio',
+  'custom_links',
+  'current_grading_period_scores',
+  'uuid',
+] as const
+const USER_SORT = ['username', 'email', 'sis_id', 'integration_id', 'last_login'] as const
+const SEARCH_USER_INCLUDE = ['email', 'last_login', 'avatar_url', 'time_zone', 'uuid'] as const
 
 export function userTools(canvas: CanvasClient): ToolDefinition[] {
   return [
@@ -48,14 +79,67 @@ export function userTools(canvas: CanvasClient): ToolDefinition[] {
     },
     {
       name: 'search_users',
-      description: 'Search for users in a Canvas account by name, login, or email.',
+      description:
+        'Search for users in a Canvas account by name, login, or email. Use `include` to request email, last_login, avatar_url, time_zone, or uuid in the response.',
       inputSchema: {
         account_id: z.number().describe('The Canvas account ID'),
         search_term: z.string().describe('The search term (name, login, or email)'),
-        sort: z
-          .enum(['username', 'email', 'sis_id', 'last_login'])
+        sort: z.enum(USER_SORT).optional().describe('Sort field'),
+        order: z.enum(['asc', 'desc']).optional().describe('Sort order'),
+        include: z
+          .array(z.enum(SEARCH_USER_INCLUDE))
           .optional()
-          .describe('Sort field'),
+          .describe('Extra fields to include on each user (Canvas include[] param)'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const opts: SearchUsersOptions = {}
+        if (params.sort !== undefined) opts.sort = params.sort as UserSort
+        if (params.order !== undefined) opts.order = params.order as 'asc' | 'desc'
+        if (params.include !== undefined)
+          opts.include = params.include as ReadonlyArray<SearchUserInclude>
+        return canvas.users.searchUsers(
+          params.account_id as number,
+          params.search_term as string,
+          opts,
+        )
+      },
+    },
+    {
+      name: 'list_course_users',
+      description:
+        'List users in a course with optional Canvas filters. Use `include` to request email, enrollments, avatar_url, bio, and other fields otherwise omitted from the default response. Use `enrollment_type` / `enrollment_state` to narrow by role or status, `search_term` to filter by name/login, `user_ids` to fetch a specific subset, and `sort`/`order` to control ordering.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        enrollment_type: z
+          .array(z.enum(COURSE_USER_ENROLLMENT_TYPE))
+          .optional()
+          .describe('Filter by one or more enrollment types'),
+        enrollment_state: z
+          .array(z.enum(COURSE_USER_ENROLLMENT_STATE))
+          .optional()
+          .describe('Filter by enrollment state (e.g. active, invited)'),
+        enrollment_role_id: z
+          .number()
+          .int()
+          .optional()
+          .describe('Filter by a specific enrollment role ID (overrides enrollment_type)'),
+        include: z
+          .array(z.enum(COURSE_USER_INCLUDE))
+          .optional()
+          .describe('Extra fields to include on each user (Canvas include[] param)'),
+        user_ids: z
+          .array(z.union([z.number(), z.string()]))
+          .optional()
+          .describe('Restrict the result to the given user IDs'),
+        search_term: z
+          .string()
+          .optional()
+          .describe('Partial name or full login/SIS ID to filter users by'),
+        sort: z.enum(USER_SORT).optional().describe('Sort field'),
         order: z.enum(['asc', 'desc']).optional().describe('Sort order'),
       },
       annotations: {
@@ -63,33 +147,22 @@ export function userTools(canvas: CanvasClient): ToolDefinition[] {
         openWorldHint: true,
       },
       handler: async (params) => {
-        return canvas.users.searchUsers(
-          params.account_id as number,
-          params.search_term as string,
-          params.sort as string | undefined,
-          params.order as string | undefined,
-        )
-      },
-    },
-    {
-      name: 'list_course_users',
-      description: 'List all users in a course, optionally filtered by enrollment type.',
-      inputSchema: {
-        course_id: z.number().describe('The Canvas course ID'),
-        enrollment_type: z
-          .enum(['student', 'teacher', 'ta', 'observer', 'designer'])
-          .optional()
-          .describe('Filter by enrollment type'),
-      },
-      annotations: {
-        readOnlyHint: true,
-        openWorldHint: true,
-      },
-      handler: async (params) => {
-        return canvas.users.listCourseUsers(
-          params.course_id as number,
-          params.enrollment_type as string | undefined,
-        )
+        const opts: ListCourseUsersOptions = {}
+        if (params.enrollment_type !== undefined)
+          opts.enrollment_type = params.enrollment_type as ReadonlyArray<CourseUserEnrollmentType>
+        if (params.enrollment_state !== undefined)
+          opts.enrollment_state =
+            params.enrollment_state as ReadonlyArray<CourseUserEnrollmentState>
+        if (params.enrollment_role_id !== undefined)
+          opts.enrollment_role_id = params.enrollment_role_id as number
+        if (params.include !== undefined)
+          opts.include = params.include as ReadonlyArray<CourseUserInclude>
+        if (params.user_ids !== undefined)
+          opts.user_ids = params.user_ids as ReadonlyArray<number | string>
+        if (params.search_term !== undefined) opts.search_term = params.search_term as string
+        if (params.sort !== undefined) opts.sort = params.sort as UserSort
+        if (params.order !== undefined) opts.order = params.order as 'asc' | 'desc'
+        return canvas.users.listCourseUsers(params.course_id as number, opts)
       },
     },
   ]

--- a/tests/canvas/assignments.test.ts
+++ b/tests/canvas/assignments.test.ts
@@ -46,7 +46,7 @@ describe('AssignmentsModule', () => {
 
       const result = await assignments.list(100)
       expect(result).toEqual(mockAssignments)
-      expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/100/assignments')
+      expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/100/assignments', {})
     })
 
     it('returns empty array when no assignments', async () => {
@@ -60,7 +60,26 @@ describe('AssignmentsModule', () => {
       vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
 
       await assignments.list(42)
-      expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/42/assignments')
+      expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/42/assignments', {})
+    })
+
+    it('forwards include[] and filters', async () => {
+      vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+
+      await assignments.list(100, {
+        include: ['submission', 'all_dates'],
+        bucket: 'upcoming',
+        search_term: 'hw',
+        assignment_ids: [1, 2, 3],
+        order_by: 'due_at',
+      })
+      expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/100/assignments', {
+        include: ['submission', 'all_dates'],
+        bucket: 'upcoming',
+        search_term: 'hw',
+        assignment_ids: [1, 2, 3],
+        order_by: 'due_at',
+      })
     })
   })
 
@@ -82,7 +101,9 @@ describe('AssignmentsModule', () => {
 
       const result = await assignments.get(100, 1)
       expect(result).toEqual(mockAssignment)
-      expect(client.request).toHaveBeenCalledWith('/api/v1/courses/100/assignments/1')
+      expect(client.request).toHaveBeenCalledWith('/api/v1/courses/100/assignments/1', {
+        query: {},
+      })
     })
 
     it('constructs correct URL for different IDs', async () => {
@@ -99,7 +120,30 @@ describe('AssignmentsModule', () => {
       })
 
       await assignments.get(42, 55)
-      expect(client.request).toHaveBeenCalledWith('/api/v1/courses/42/assignments/55')
+      expect(client.request).toHaveBeenCalledWith('/api/v1/courses/42/assignments/55', {
+        query: {},
+      })
+    })
+
+    it('forwards include[] and flags', async () => {
+      vi.spyOn(client, 'request').mockResolvedValueOnce({
+        id: 1,
+        name: 'HW',
+        description: null,
+        due_at: null,
+        points_possible: 10,
+        grading_type: 'points',
+        submission_types: [],
+        course_id: 100,
+        allowed_attempts: -1,
+      })
+      await assignments.get(100, 1, {
+        include: ['submission', 'overrides'],
+        all_dates: true,
+      })
+      expect(client.request).toHaveBeenCalledWith('/api/v1/courses/100/assignments/1', {
+        query: { include: ['submission', 'overrides'], all_dates: true },
+      })
     })
   })
 
@@ -114,7 +158,7 @@ describe('AssignmentsModule', () => {
 
       const result = await assignments.listGroups(100)
       expect(result).toEqual(mockGroups)
-      expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/100/assignment_groups')
+      expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/100/assignment_groups', {})
     })
 
     it('returns empty array when no groups', async () => {
@@ -122,6 +166,23 @@ describe('AssignmentsModule', () => {
 
       const result = await assignments.listGroups(100)
       expect(result).toEqual([])
+    })
+
+    it('forwards include[] and filters', async () => {
+      vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+
+      await assignments.listGroups(100, {
+        include: ['assignments', 'submission'],
+        assignment_ids: [7, 8],
+        grading_period_id: 5,
+        scope_assignments_to_student: true,
+      })
+      expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/100/assignment_groups', {
+        include: ['assignments', 'submission'],
+        assignment_ids: [7, 8],
+        grading_period_id: 5,
+        scope_assignments_to_student: true,
+      })
     })
   })
 

--- a/tests/canvas/courses.test.ts
+++ b/tests/canvas/courses.test.ts
@@ -16,7 +16,7 @@ describe('CoursesModule', () => {
   })
 
   describe('list', () => {
-    it('lists courses with pagination', async () => {
+    it('lists courses with default include[]=term', async () => {
       const mockCourses: CanvasCourse[] = [
         { id: 1, name: 'CS 101', course_code: 'CS101', workflow_state: 'available' },
         { id: 2, name: 'Math 201', course_code: 'MATH201', workflow_state: 'available' },
@@ -27,7 +27,7 @@ describe('CoursesModule', () => {
       const result = await courses.list()
       expect(result).toEqual(mockCourses)
       expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses', {
-        'include[]': 'term',
+        include: ['term'],
       })
     })
 
@@ -36,17 +36,29 @@ describe('CoursesModule', () => {
 
       await courses.list({ enrollment_state: 'completed' })
       expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses', {
-        'include[]': 'term',
+        include: ['term'],
         enrollment_state: 'completed',
       })
     })
 
-    it('omits enrollment_state when not provided', async () => {
+    it('honors a caller-provided include list', async () => {
       vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
-
-      await courses.list()
+      await courses.list({ include: ['teachers', 'total_students'] })
       expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses', {
-        'include[]': 'term',
+        include: ['teachers', 'total_students'],
+      })
+    })
+
+    it('forwards state[] and exclude_blueprint_courses', async () => {
+      vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+      await courses.list({
+        state: ['available', 'completed'],
+        exclude_blueprint_courses: true,
+      })
+      expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses', {
+        include: ['term'],
+        state: ['available', 'completed'],
+        exclude_blueprint_courses: true,
       })
     })
 
@@ -59,7 +71,7 @@ describe('CoursesModule', () => {
   })
 
   describe('get', () => {
-    it('gets a single course with term and total_students includes', async () => {
+    it('gets a single course with default include=[term, total_students]', async () => {
       const mockCourse: CanvasCourse = {
         id: 1,
         name: 'CS 101',
@@ -73,12 +85,12 @@ describe('CoursesModule', () => {
 
       const result = await courses.get(1)
       expect(result).toEqual(mockCourse)
-      expect(client.request).toHaveBeenCalledWith(
-        '/api/v1/courses/1?include[]=term&include[]=total_students',
-      )
+      expect(client.request).toHaveBeenCalledWith('/api/v1/courses/1', {
+        query: { include: ['term', 'total_students'] },
+      })
     })
 
-    it('constructs correct URL for different course IDs', async () => {
+    it('honors caller-provided include', async () => {
       vi.spyOn(client, 'request').mockResolvedValueOnce({
         id: 42,
         name: 'Art 300',
@@ -86,10 +98,10 @@ describe('CoursesModule', () => {
         workflow_state: 'available',
       })
 
-      await courses.get(42)
-      expect(client.request).toHaveBeenCalledWith(
-        '/api/v1/courses/42?include[]=term&include[]=total_students',
-      )
+      await courses.get(42, { include: ['teachers', 'permissions'], teacher_limit: 5 })
+      expect(client.request).toHaveBeenCalledWith('/api/v1/courses/42', {
+        query: { include: ['teachers', 'permissions'], teacher_limit: 5 },
+      })
     })
   })
 
@@ -107,7 +119,9 @@ describe('CoursesModule', () => {
 
       const result = await courses.getSyllabus(1)
       expect(result).toBe('<p>Welcome to CS 101</p>')
-      expect(client.request).toHaveBeenCalledWith('/api/v1/courses/1?include[]=syllabus_body')
+      expect(client.request).toHaveBeenCalledWith('/api/v1/courses/1', {
+        query: { include: ['syllabus_body'] },
+      })
     })
 
     it('returns null when syllabus_body is undefined', async () => {
@@ -133,7 +147,9 @@ describe('CoursesModule', () => {
       })
 
       await courses.getSyllabus(99)
-      expect(client.request).toHaveBeenCalledWith('/api/v1/courses/99?include[]=syllabus_body')
+      expect(client.request).toHaveBeenCalledWith('/api/v1/courses/99', {
+        query: { include: ['syllabus_body'] },
+      })
     })
   })
 

--- a/tests/canvas/enrollments.test.ts
+++ b/tests/canvas/enrollments.test.ts
@@ -27,7 +27,39 @@ describe('EnrollmentsModule', () => {
     ])
     const result = await enrollments.list()
     expect(result).toHaveLength(1)
-    expect(client.paginate).toHaveBeenCalledWith('/api/v1/users/self/enrollments')
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/users/self/enrollments', {})
+  })
+
+  it('forwards include and filters when listing user enrollments', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+    await enrollments.list({
+      type: ['StudentEnrollment'],
+      state: ['active'],
+      include: ['grades', 'current_points'],
+      grading_period_id: 7,
+    })
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/users/self/enrollments', {
+      type: ['StudentEnrollment'],
+      state: ['active'],
+      include: ['grades', 'current_points'],
+      grading_period_id: 7,
+    })
+  })
+
+  it('lists course-scoped enrollments with filters', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+    await enrollments.listForCourse(100, {
+      type: ['StudentEnrollment', 'TeacherEnrollment'],
+      state: ['active'],
+      include: ['grades', 'avatar_url'],
+      user_id: 'self',
+    })
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/100/enrollments', {
+      type: ['StudentEnrollment', 'TeacherEnrollment'],
+      state: ['active'],
+      include: ['grades', 'avatar_url'],
+      user_id: 'self',
+    })
   })
 
   it('returns empty array when no enrollments', async () => {
@@ -87,7 +119,7 @@ describe('EnrollmentsModule', () => {
       vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
       await enrollments.listMyGrades()
       expect(client.paginate).toHaveBeenCalledWith('/api/v1/users/self/enrollments', {
-        'include[]': 'grades',
+        include: ['grades'],
       })
     })
 
@@ -96,7 +128,7 @@ describe('EnrollmentsModule', () => {
       await enrollments.listMyGrades(42)
       expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/42/enrollments', {
         user_id: 'self',
-        'include[]': 'grades',
+        include: ['grades'],
       })
     })
   })

--- a/tests/canvas/query.test.ts
+++ b/tests/canvas/query.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { appendCanvasQuery, toCanvasQuery } from '../../src/canvas/query'
+
+describe('toCanvasQuery', () => {
+  it('returns an empty URLSearchParams when given no input', () => {
+    expect(toCanvasQuery().toString()).toBe('')
+    expect(toCanvasQuery({}).toString()).toBe('')
+  })
+
+  it('encodes scalar values via set (last write wins)', () => {
+    const params = toCanvasQuery({ per_page: 50, search_term: 'alice', published: true })
+    expect(params.get('per_page')).toBe('50')
+    expect(params.get('search_term')).toBe('alice')
+    expect(params.get('published')).toBe('true')
+  })
+
+  it('encodes arrays as repeated key[] entries matching Canvas convention', () => {
+    const params = toCanvasQuery({ include: ['email', 'enrollments'] })
+    expect(params.getAll('include[]')).toEqual(['email', 'enrollments'])
+    expect(params.toString()).toBe('include%5B%5D=email&include%5B%5D=enrollments')
+  })
+
+  it('does not double-suffix keys that already end in []', () => {
+    const params = toCanvasQuery({ 'student_ids[]': ['self', '1'] })
+    expect(params.getAll('student_ids[]')).toEqual(['self', '1'])
+    expect(params.getAll('student_ids[][]')).toEqual([])
+  })
+
+  it('skips undefined and null values', () => {
+    const params = toCanvasQuery({ search: undefined, extra: null, include: ['term'] })
+    expect(params.has('search')).toBe(false)
+    expect(params.has('extra')).toBe(false)
+    expect(params.getAll('include[]')).toEqual(['term'])
+  })
+
+  it('skips empty arrays', () => {
+    const params = toCanvasQuery({ include: [], student_ids: [] })
+    expect(params.toString()).toBe('')
+  })
+
+  it('stringifies number and boolean array entries', () => {
+    const params = toCanvasQuery({ assignment_ids: [1, 2, 3], flags: [true, false] })
+    expect(params.getAll('assignment_ids[]')).toEqual(['1', '2', '3'])
+    expect(params.getAll('flags[]')).toEqual(['true', 'false'])
+  })
+
+  it('appendCanvasQuery preserves existing entries on the target', () => {
+    const target = new URLSearchParams('per_page=100')
+    appendCanvasQuery(target, { include: ['term'] })
+    expect(target.get('per_page')).toBe('100')
+    expect(target.getAll('include[]')).toEqual(['term'])
+  })
+})

--- a/tests/canvas/submissions.test.ts
+++ b/tests/canvas/submissions.test.ts
@@ -49,7 +49,23 @@ describe('SubmissionsModule', () => {
       const result = await submissions.list(1, 10)
       expect(result).toEqual(mockSubmissions)
       expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/1/assignments/10/submissions', {
-        'include[]': 'submission_comments',
+        include: ['submission_comments'],
+      })
+    })
+
+    it('forwards explicit include[] plus student_ids and workflow_state filters', async () => {
+      vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+      await submissions.list(1, 10, {
+        include: ['user', 'rubric_assessment'],
+        student_ids: [5, 6],
+        workflow_state: 'submitted',
+        grouped: true,
+      })
+      expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/1/assignments/10/submissions', {
+        include: ['user', 'rubric_assessment'],
+        student_ids: [5, 6],
+        workflow_state: 'submitted',
+        grouped: true,
       })
     })
 
@@ -90,7 +106,8 @@ describe('SubmissionsModule', () => {
       const result = await submissions.get(1, 10, 100)
       expect(result).toEqual(mockSubmission)
       expect(client.request).toHaveBeenCalledWith(
-        '/api/v1/courses/1/assignments/10/submissions/100?include[]=submission_comments',
+        '/api/v1/courses/1/assignments/10/submissions/100',
+        { query: { include: ['submission_comments'] } },
       )
     })
 
@@ -110,7 +127,29 @@ describe('SubmissionsModule', () => {
 
       await submissions.get(42, 20, 300)
       expect(client.request).toHaveBeenCalledWith(
-        '/api/v1/courses/42/assignments/20/submissions/300?include[]=submission_comments',
+        '/api/v1/courses/42/assignments/20/submissions/300',
+        { query: { include: ['submission_comments'] } },
+      )
+    })
+
+    it('honors caller-provided include', async () => {
+      vi.spyOn(client, 'request').mockResolvedValueOnce({
+        id: 1,
+        assignment_id: 10,
+        user_id: 100,
+        submitted_at: null,
+        score: null,
+        grade: null,
+        body: null,
+        url: null,
+        attempt: null,
+        workflow_state: 'submitted',
+      })
+
+      await submissions.get(1, 10, 100, { include: ['rubric_assessment', 'user'] })
+      expect(client.request).toHaveBeenCalledWith(
+        '/api/v1/courses/1/assignments/10/submissions/100',
+        { query: { include: ['rubric_assessment', 'user'] } },
       )
     })
   })
@@ -169,11 +208,11 @@ describe('SubmissionsModule', () => {
   })
 
   describe('listMy', () => {
-    it('fetches submissions for self with student_ids[]=self', async () => {
+    it('fetches submissions for self with student_ids=[self]', async () => {
       vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
       await submissions.listMy(10)
       expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/10/students/submissions', {
-        'student_ids[]': 'self',
+        student_ids: ['self'],
       })
     })
 
@@ -181,7 +220,7 @@ describe('SubmissionsModule', () => {
       vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
       await submissions.listMy(99)
       expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/99/students/submissions', {
-        'student_ids[]': 'self',
+        student_ids: ['self'],
       })
     })
   })

--- a/tests/canvas/users.test.ts
+++ b/tests/canvas/users.test.ts
@@ -22,7 +22,7 @@ describe('UsersModule', () => {
     const result = await users.listStudents(100)
     expect(result).toHaveLength(2)
     expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/100/users', {
-      'enrollment_type[]': 'student',
+      enrollment_type: ['student'],
     })
   })
 
@@ -59,11 +59,20 @@ describe('UsersModule', () => {
 
   it('searches users with sort and order', async () => {
     vi.spyOn(client, 'paginate').mockResolvedValueOnce([{ id: 1, name: 'Alice' }])
-    await users.searchUsers(1, 'alice', 'username', 'asc')
+    await users.searchUsers(1, 'alice', { sort: 'username', order: 'asc' })
     expect(client.paginate).toHaveBeenCalledWith('/api/v1/accounts/1/users', {
       search_term: 'alice',
       sort: 'username',
       order: 'asc',
+    })
+  })
+
+  it('forwards include on search', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+    await users.searchUsers(1, 'alice', { include: ['email', 'last_login'] })
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/accounts/1/users', {
+      search_term: 'alice',
+      include: ['email', 'last_login'],
     })
   })
 
@@ -77,12 +86,54 @@ describe('UsersModule', () => {
     expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/100/users', {})
   })
 
-  it('lists course users filtered by enrollment type', async () => {
+  it('lists course users filtered by enrollment type (array)', async () => {
     vi.spyOn(client, 'paginate').mockResolvedValueOnce([{ id: 2, name: 'Bob' }])
-    await users.listCourseUsers(100, 'teacher')
+    await users.listCourseUsers(100, { enrollment_type: ['teacher'] })
     expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/100/users', {
-      'enrollment_type[]': 'teacher',
+      enrollment_type: ['teacher'],
     })
+  })
+
+  it('accepts a single string for enrollment_type and wraps it as an array', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+    await users.listCourseUsers(100, { enrollment_type: 'ta' })
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/100/users', {
+      enrollment_type: ['ta'],
+    })
+  })
+
+  it('forwards include, enrollment_state, user_ids, search_term, sort/order', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+    await users.listCourseUsers(100, {
+      enrollment_type: ['student'],
+      enrollment_state: ['active', 'invited'],
+      include: ['email', 'enrollments'],
+      user_ids: [10, 'sis_user_id:abc'],
+      search_term: 'alice',
+      sort: 'last_login',
+      order: 'desc',
+      enrollment_role_id: 42,
+    })
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/100/users', {
+      enrollment_type: ['student'],
+      enrollment_state: ['active', 'invited'],
+      include: ['email', 'enrollments'],
+      user_ids: [10, 'sis_user_id:abc'],
+      search_term: 'alice',
+      sort: 'last_login',
+      order: 'desc',
+      enrollment_role_id: 42,
+    })
+  })
+
+  it('drops empty arrays so Canvas does not receive empty include[]', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+    await users.listCourseUsers(100, {
+      include: [],
+      enrollment_state: [],
+      user_ids: [],
+    })
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/100/users', {})
   })
 
   it('fetches upcoming assignment events filtered by type=Assignment', async () => {

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(104)
+    expect(manifest.tools).toHaveLength(105)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/tools/assignments.test.ts
+++ b/tests/tools/assignments.test.ts
@@ -71,11 +71,27 @@ describe('assignmentTools', () => {
       expect(tool.inputSchema).toHaveProperty('course_id')
     })
 
-    it('calls canvas.assignments.list with the course_id', async () => {
+    it('calls canvas.assignments.list with the course_id and empty opts', async () => {
       const canvas = buildMockCanvas()
       const tool = assignmentTools(canvas).find((t) => t.name === 'list_assignments')!
       await tool.handler({ course_id: 42 })
-      expect(canvas.assignments.list).toHaveBeenCalledWith(42)
+      expect(canvas.assignments.list).toHaveBeenCalledWith(42, {})
+    })
+
+    it('forwards include[], bucket, and search_term', async () => {
+      const canvas = buildMockCanvas()
+      const tool = assignmentTools(canvas).find((t) => t.name === 'list_assignments')!
+      await tool.handler({
+        course_id: 42,
+        include: ['submission', 'all_dates'],
+        bucket: 'upcoming',
+        search_term: 'hw',
+      })
+      expect(canvas.assignments.list).toHaveBeenCalledWith(42, {
+        include: ['submission', 'all_dates'],
+        bucket: 'upcoming',
+        search_term: 'hw',
+      })
     })
 
     it('returns the assignment list from Canvas', async () => {
@@ -109,11 +125,26 @@ describe('assignmentTools', () => {
       expect(tool.inputSchema).toHaveProperty('assignment_id')
     })
 
-    it('calls canvas.assignments.get with course_id and assignment_id', async () => {
+    it('calls canvas.assignments.get with course_id, assignment_id and empty opts', async () => {
       const canvas = buildMockCanvas()
       const tool = assignmentTools(canvas).find((t) => t.name === 'get_assignment')!
       await tool.handler({ course_id: 1, assignment_id: 101 })
-      expect(canvas.assignments.get).toHaveBeenCalledWith(1, 101)
+      expect(canvas.assignments.get).toHaveBeenCalledWith(1, 101, {})
+    })
+
+    it('forwards include[] and flags', async () => {
+      const canvas = buildMockCanvas()
+      const tool = assignmentTools(canvas).find((t) => t.name === 'get_assignment')!
+      await tool.handler({
+        course_id: 1,
+        assignment_id: 101,
+        include: ['submission', 'overrides'],
+        all_dates: true,
+      })
+      expect(canvas.assignments.get).toHaveBeenCalledWith(1, 101, {
+        include: ['submission', 'overrides'],
+        all_dates: true,
+      })
     })
 
     it('returns the assignment from Canvas', async () => {
@@ -146,11 +177,25 @@ describe('assignmentTools', () => {
       expect(tool.inputSchema).toHaveProperty('course_id')
     })
 
-    it('calls canvas.assignments.listGroups with the course_id', async () => {
+    it('calls canvas.assignments.listGroups with the course_id and empty opts', async () => {
       const canvas = buildMockCanvas()
       const tool = assignmentTools(canvas).find((t) => t.name === 'list_assignment_groups')!
       await tool.handler({ course_id: 42 })
-      expect(canvas.assignments.listGroups).toHaveBeenCalledWith(42)
+      expect(canvas.assignments.listGroups).toHaveBeenCalledWith(42, {})
+    })
+
+    it('forwards include[] and filters', async () => {
+      const canvas = buildMockCanvas()
+      const tool = assignmentTools(canvas).find((t) => t.name === 'list_assignment_groups')!
+      await tool.handler({
+        course_id: 42,
+        include: ['assignments', 'submission'],
+        grading_period_id: 3,
+      })
+      expect(canvas.assignments.listGroups).toHaveBeenCalledWith(42, {
+        include: ['assignments', 'submission'],
+        grading_period_id: 3,
+      })
     })
 
     it('returns the assignment groups from Canvas', async () => {

--- a/tests/tools/courses.test.ts
+++ b/tests/tools/courses.test.ts
@@ -103,11 +103,20 @@ describe('courseTools', () => {
       expect(tool.inputSchema).toHaveProperty('course_id')
     })
 
-    it('calls canvas.courses.get with the course_id', async () => {
+    it('calls canvas.courses.get with the course_id and empty opts', async () => {
       const canvas = buildMockCanvas()
       const tool = courseTools(canvas).find((t) => t.name === 'get_course')!
       await tool.handler({ course_id: 42 })
-      expect(canvas.courses.get).toHaveBeenCalledWith(42)
+      expect(canvas.courses.get).toHaveBeenCalledWith(42, {})
+    })
+
+    it('forwards include[] to canvas.courses.get', async () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'get_course')!
+      await tool.handler({ course_id: 42, include: ['teachers', 'permissions'] })
+      expect(canvas.courses.get).toHaveBeenCalledWith(42, {
+        include: ['teachers', 'permissions'],
+      })
     })
 
     it('returns the course from Canvas', async () => {

--- a/tests/tools/enrollments.test.ts
+++ b/tests/tools/enrollments.test.ts
@@ -18,19 +18,25 @@ describe('enrollmentTools', () => {
     return {
       enrollments: {
         list: vi.fn().mockResolvedValue([mockEnrollment]),
+        listForCourse: vi.fn().mockResolvedValue([mockEnrollment]),
         enroll: vi.fn().mockResolvedValue(mockEnrollment),
         remove: vi.fn().mockResolvedValue(mockEnrollment),
       },
     } as unknown as CanvasClient
   }
 
-  it('returns an array with 3 tool definitions', () => {
-    expect(enrollmentTools(buildMockCanvas())).toHaveLength(3)
+  it('returns an array with 4 tool definitions', () => {
+    expect(enrollmentTools(buildMockCanvas())).toHaveLength(4)
   })
 
   it('exports tools with correct names', () => {
     const names = enrollmentTools(buildMockCanvas()).map((t) => t.name)
-    expect(names).toEqual(['list_enrollments', 'enroll_user', 'remove_enrollment'])
+    expect(names).toEqual([
+      'list_enrollments',
+      'list_course_enrollments',
+      'enroll_user',
+      'remove_enrollment',
+    ])
   })
 
   describe('list_enrollments', () => {
@@ -39,12 +45,54 @@ describe('enrollmentTools', () => {
       expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
     })
 
-    it('delegates to canvas.enrollments.list', async () => {
+    it('delegates to canvas.enrollments.list with empty opts', async () => {
       const canvas = buildMockCanvas()
       const tool = enrollmentTools(canvas).find((t) => t.name === 'list_enrollments')!
       const result = await tool.handler({})
-      expect(canvas.enrollments.list).toHaveBeenCalled()
+      expect(canvas.enrollments.list).toHaveBeenCalledWith({})
       expect(result).toEqual([mockEnrollment])
+    })
+
+    it('forwards type, state, and include', async () => {
+      const canvas = buildMockCanvas()
+      const tool = enrollmentTools(canvas).find((t) => t.name === 'list_enrollments')!
+      await tool.handler({
+        type: ['StudentEnrollment'],
+        state: ['active'],
+        include: ['grades'],
+      })
+      expect(canvas.enrollments.list).toHaveBeenCalledWith({
+        type: ['StudentEnrollment'],
+        state: ['active'],
+        include: ['grades'],
+      })
+    })
+  })
+
+  describe('list_course_enrollments', () => {
+    it('has read-only annotations', () => {
+      const tool = enrollmentTools(buildMockCanvas()).find(
+        (t) => t.name === 'list_course_enrollments',
+      )!
+      expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+    })
+
+    it('delegates to canvas.enrollments.listForCourse with filters', async () => {
+      const canvas = buildMockCanvas()
+      const tool = enrollmentTools(canvas).find((t) => t.name === 'list_course_enrollments')!
+      await tool.handler({
+        course_id: 100,
+        type: ['StudentEnrollment'],
+        state: ['active'],
+        include: ['grades', 'current_points'],
+        user_id: 'self',
+      })
+      expect(canvas.enrollments.listForCourse).toHaveBeenCalledWith(100, {
+        type: ['StudentEnrollment'],
+        state: ['active'],
+        include: ['grades', 'current_points'],
+        user_id: 'self',
+      })
     })
   })
 

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -65,6 +65,7 @@ function buildFullMockCanvas(): CanvasClient {
     groups: { list: async () => [], listMembers: async () => [] },
     enrollments: {
       list: async () => [],
+      listForCourse: async () => [],
       enroll: async () => ({}),
       remove: async () => ({}),
       listMyGrades: async () => [],
@@ -153,7 +154,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 104 tools across all domains', () => {
+  it('returns all 105 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 
@@ -209,8 +210,9 @@ describe('getAllTools', () => {
     // Groups (2)
     expect(names).toContain('list_groups')
     expect(names).toContain('list_group_members')
-    // Enrollments (3)
+    // Enrollments (4)
     expect(names).toContain('list_enrollments')
+    expect(names).toContain('list_course_enrollments')
     expect(names).toContain('enroll_user')
     expect(names).toContain('remove_enrollment')
     // Discussions (7)
@@ -284,7 +286,7 @@ describe('getAllTools', () => {
     expect(names).toContain('get_upcoming_events')
     expect(names).toContain('get_missing_submissions')
 
-    expect(tools).toHaveLength(104)
+    expect(tools).toHaveLength(105)
   })
 
   it('all tools have openWorldHint: true', () => {

--- a/tests/tools/submissions.test.ts
+++ b/tests/tools/submissions.test.ts
@@ -63,11 +63,28 @@ describe('submissionTools', () => {
       expect(tool.inputSchema).toHaveProperty('assignment_id')
     })
 
-    it('calls canvas.submissions.list with course_id and assignment_id', async () => {
+    it('calls canvas.submissions.list with course_id, assignment_id, and empty opts', async () => {
       const canvas = buildMockCanvas()
       const tool = submissionTools(canvas).find((t) => t.name === 'list_submissions')!
       await tool.handler({ course_id: 1, assignment_id: 101 })
-      expect(canvas.submissions.list).toHaveBeenCalledWith(1, 101)
+      expect(canvas.submissions.list).toHaveBeenCalledWith(1, 101, {})
+    })
+
+    it('forwards include[] and filters', async () => {
+      const canvas = buildMockCanvas()
+      const tool = submissionTools(canvas).find((t) => t.name === 'list_submissions')!
+      await tool.handler({
+        course_id: 1,
+        assignment_id: 101,
+        include: ['user', 'rubric_assessment'],
+        student_ids: [5, 6],
+        workflow_state: 'submitted',
+      })
+      expect(canvas.submissions.list).toHaveBeenCalledWith(1, 101, {
+        include: ['user', 'rubric_assessment'],
+        student_ids: [5, 6],
+        workflow_state: 'submitted',
+      })
     })
 
     it('returns the submission list from Canvas', async () => {
@@ -102,11 +119,25 @@ describe('submissionTools', () => {
       expect(tool.inputSchema).toHaveProperty('user_id')
     })
 
-    it('calls canvas.submissions.get with all three IDs', async () => {
+    it('calls canvas.submissions.get with all three IDs and empty opts', async () => {
       const canvas = buildMockCanvas()
       const tool = submissionTools(canvas).find((t) => t.name === 'get_submission')!
       await tool.handler({ course_id: 1, assignment_id: 101, user_id: 5 })
-      expect(canvas.submissions.get).toHaveBeenCalledWith(1, 101, 5)
+      expect(canvas.submissions.get).toHaveBeenCalledWith(1, 101, 5, {})
+    })
+
+    it('forwards include[] to canvas.submissions.get', async () => {
+      const canvas = buildMockCanvas()
+      const tool = submissionTools(canvas).find((t) => t.name === 'get_submission')!
+      await tool.handler({
+        course_id: 1,
+        assignment_id: 101,
+        user_id: 5,
+        include: ['rubric_assessment', 'user'],
+      })
+      expect(canvas.submissions.get).toHaveBeenCalledWith(1, 101, 5, {
+        include: ['rubric_assessment', 'user'],
+      })
     })
 
     it('returns the submission from Canvas', async () => {

--- a/tests/tools/users.test.ts
+++ b/tests/tools/users.test.ts
@@ -105,14 +105,26 @@ describe('userTools', () => {
       const canvas = buildMockCanvas()
       const tool = userTools(canvas).find((t) => t.name === 'search_users')!
       await tool.handler({ account_id: 1, search_term: 'alice' })
-      expect(canvas.users.searchUsers).toHaveBeenCalledWith(1, 'alice', undefined, undefined)
+      expect(canvas.users.searchUsers).toHaveBeenCalledWith(1, 'alice', {})
     })
 
     it('passes optional sort and order', async () => {
       const canvas = buildMockCanvas()
       const tool = userTools(canvas).find((t) => t.name === 'search_users')!
       await tool.handler({ account_id: 1, search_term: 'alice', sort: 'username', order: 'asc' })
-      expect(canvas.users.searchUsers).toHaveBeenCalledWith(1, 'alice', 'username', 'asc')
+      expect(canvas.users.searchUsers).toHaveBeenCalledWith(1, 'alice', {
+        sort: 'username',
+        order: 'asc',
+      })
+    })
+
+    it('forwards include[] to search', async () => {
+      const canvas = buildMockCanvas()
+      const tool = userTools(canvas).find((t) => t.name === 'search_users')!
+      await tool.handler({ account_id: 1, search_term: 'alice', include: ['email', 'last_login'] })
+      expect(canvas.users.searchUsers).toHaveBeenCalledWith(1, 'alice', {
+        include: ['email', 'last_login'],
+      })
     })
   })
 
@@ -122,18 +134,42 @@ describe('userTools', () => {
       expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
     })
 
-    it('delegates to canvas.users.listCourseUsers', async () => {
+    it('delegates to canvas.users.listCourseUsers with empty options when none provided', async () => {
       const canvas = buildMockCanvas()
       const tool = userTools(canvas).find((t) => t.name === 'list_course_users')!
       await tool.handler({ course_id: 100 })
-      expect(canvas.users.listCourseUsers).toHaveBeenCalledWith(100, undefined)
+      expect(canvas.users.listCourseUsers).toHaveBeenCalledWith(100, {})
     })
 
-    it('passes optional enrollment_type', async () => {
+    it('forwards enrollment_type as an array', async () => {
       const canvas = buildMockCanvas()
       const tool = userTools(canvas).find((t) => t.name === 'list_course_users')!
-      await tool.handler({ course_id: 100, enrollment_type: 'teacher' })
-      expect(canvas.users.listCourseUsers).toHaveBeenCalledWith(100, 'teacher')
+      await tool.handler({ course_id: 100, enrollment_type: ['teacher'] })
+      expect(canvas.users.listCourseUsers).toHaveBeenCalledWith(100, {
+        enrollment_type: ['teacher'],
+      })
+    })
+
+    it('forwards include[], enrollment_state, user_ids, sort, and search_term', async () => {
+      const canvas = buildMockCanvas()
+      const tool = userTools(canvas).find((t) => t.name === 'list_course_users')!
+      await tool.handler({
+        course_id: 100,
+        include: ['email', 'enrollments'],
+        enrollment_state: ['active'],
+        user_ids: [1, 2],
+        search_term: 'alice',
+        sort: 'last_login',
+        order: 'desc',
+      })
+      expect(canvas.users.listCourseUsers).toHaveBeenCalledWith(100, {
+        include: ['email', 'enrollments'],
+        enrollment_state: ['active'],
+        user_ids: [1, 2],
+        search_term: 'alice',
+        sort: 'last_login',
+        order: 'desc',
+      })
     })
   })
 })


### PR DESCRIPTION
Closes #75.

## Summary

- Shared `src/canvas/query.ts` helper (`toCanvasQuery` / `appendCanvasQuery`) that encodes arrays as repeated `key[]=v1&key[]=v2` entries, skips `undefined`/`null`, and drops empty arrays. `CanvasHttpClient.paginate`, `paginateEnvelope`, and `request({ query })` now all accept primitives or arrays of primitives — no more per-module query string concatenation.
- Canvas modules for users, courses, assignments, submissions, and enrollments switched to typed options objects. Each module exports real Canvas include/filter vocabulary (`CourseUserInclude`, `AssignmentListInclude`, `SubmissionListInclude`, `EnrollmentInclude`, etc.). New `canvas.enrollments.listForCourse(...)` covers the course-scoped enrollment surface called out in the issue.
- Response types widened so the new includes are typed on the way back: `CanvasUser`, `CanvasCourse`, `CanvasAssignment`, `CanvasSubmission`, `CanvasEnrollment`, `CanvasAssignmentGroup`.
- Hot-path MCP tools expose the new surface as first-class, discoverable Zod params — `list_course_users`, `list_courses`, `get_course`, `list_assignments`, `get_assignment`, `list_assignment_groups`, `list_submissions`, `get_submission`, `list_enrollments`, `search_users`, plus a new `list_course_enrollments` tool. That takes the inventory from 104 → 105 tools, picked up automatically by `pnpm generate:manifests`.
- Tests: new `tests/canvas/query.test.ts` covers the encoder directly; hot-path module and tool tests now assert both the new params shape and `include[]`/filter forwarding. `tests/discovery/manifests.test.ts` and `tests/tools/registry.test.ts` updated for the new tool count.

## Concrete fix from the issue

`list_course_users({ course_id: 3154, enrollment_type: ['student'], include: ['email'] })` now hits `GET /api/v1/courses/3154/users?enrollment_type[]=student&include[]=email` — the exact call the issue asked for.

## Backward compatibility

Non-breaking. Every new option is optional. Existing default behaviors preserved:
- `get_course` still defaults to `include=[term, total_students]`
- `courses.list()` still defaults to `include=[term]`
- `submissions.list/get` still default to `include=[submission_comments]`
- `enrollments.listMyGrades(...)` still defaults to `include=[grades]`

Intentional scope cut: did not expose an `extra_query` escape hatch, a `fields` response projector, or per-tool pagination knobs. Those are orthogonal and can ship in follow-ups — this PR focuses on the explicit, typed surface.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` — 582 tests, 55 files, all pass
- [x] `pnpm build`
- [x] `pnpm generate:manifests` regenerates `docs/generated/tool-manifest.json`