### PR TITLE
feat: scoped generated Canvas client prototype for users (#78)

### DIFF
--- a/docs/generated-client-prototype.md
+++ b/docs/generated-client-prototype.md
@@ -1,0 +1,200 @@
+# Generated Canvas client — prototype findings
+
+This document summarizes the scoped prototype built for
+[GitHub issue #78](https://github.com/bruchris/canvas-lms-mcp/issues/78)
+(`feat: auto-generate the Canvas REST client from an OpenAPI spec`).
+
+The prototype is intentionally narrow — one domain (`users`), one
+generator (`openapi-typescript` + `openapi-fetch`), one overlay pattern —
+so the real costs and constraints surface before any repo-wide migration
+and before the licensing decision is made.
+
+## What shipped
+
+| Piece                               | Path                                            |
+| ----------------------------------- | ----------------------------------------------- |
+| Hand-authored source spec           | `spec/canvas/prototype.yaml`                    |
+| Overlay demo                        | `spec/canvas/overrides/users.yaml`              |
+| Generation pipeline                 | `scripts/canvas-spec/generate.ts`               |
+| Generated types (checked in)        | `src/canvas/generated/types.ts`                 |
+| Generated-client users module       | `src/canvas/generated/users-client.ts`          |
+| Feature flag                        | `useGeneratedClient` on `CanvasClientConfig`    |
+| Shared interface                    | `UsersModuleApi` in `src/canvas/users.ts`       |
+| Parity tests                        | `tests/canvas/generated-users.test.ts`          |
+| Facade swap tests                   | new cases in `tests/canvas/facade.test.ts`      |
+
+All existing tests (604) still pass; both the hand-written `UsersModule`
+and the new `GeneratedUsersModule` are exercised.
+
+## Pipeline at a glance
+
+```
+spec/canvas/prototype.yaml       (hand-authored OpenAPI 3.1 — license-clean)
+        +
+spec/canvas/overrides/*.yaml     (overlay patches: enums, response shapes)
+        │
+        ▼
+scripts/canvas-spec/generate.ts  (deep-merge + openapi-typescript + prettier)
+        │
+        ▼
+src/canvas/generated/types.ts    (types only; no runtime)
+        │
+        ▼
+src/canvas/generated/users-client.ts
+        │ openapi-fetch for single requests
+        │ manual Link-header loop for pagination
+        │ Bearer + User-Agent via openapi-fetch middleware
+        ▼
+CanvasClient.users  ── feature flag selects hand-written or generated
+```
+
+Run end-to-end with `pnpm canvas:spec:generate`.
+
+## What the prototype proves works
+
+1. **`openapi-typescript` + `openapi-fetch` are a good match for this
+   server.** Zero runtime deps (openapi-fetch ships 6 kB of wrapper over
+   `fetch`), native `fetch`, first-class middleware for header injection,
+   and strong discriminated-union typing on `oneOf` (we use it on
+   `UpcomingEvent.id`, which is `integer | string`, and it survives
+   through to `types.ts` correctly).
+2. **Overlays do what issue #78 promised.** The overlay in
+   `overrides/users.yaml` adds `primary_email` to the `User` schema and
+   extends the account-users `include[]` enum with `uuid`. Both land
+   in `src/canvas/generated/types.ts` after regeneration. This is the
+   pattern that will paper over Canvas's known response-type bug
+   ([instructure/canvas-lms#2583](https://github.com/instructure/canvas-lms/issues/2583))
+   when the full spec source is wired in.
+3. **The feature-flag swap is seamless for tool code.** `CanvasClient.users`
+   is typed as `UsersModuleApi` (a shared interface). All 104 MCP tools
+   and every tool-layer test keep working unchanged. The flag is a
+   single config field (`useGeneratedClient`) that accepts `true`,
+   `false`, or a domain allowlist like `['users']`.
+4. **Parity is test-verifiable.** `tests/canvas/generated-users.test.ts`
+   mocks `globalThis.fetch` and asserts the wire-level behavior that
+   matters — Bearer header, `include[]` repeated-key serialization,
+   Link-header pagination, `maxPaginationPages` cap, empty-array
+   pruning, and `CanvasApiError` mapping. The hand-written module's
+   existing tests remain unchanged and still pass.
+
+## Real costs the prototype surfaced
+
+### 1. OpenAPI can't express Canvas's pagination contract
+
+Link-header pagination with `rel="next"` isn't in the spec and won't be.
+Bookmark-cursor pagination for some endpoints is an additional twist.
+Both stay hand-written — which means there's a persistent ~40-line
+helper per client (one in `CanvasHttpClient`, one in
+`GeneratedUsersModule`). **For a full migration, this belongs in a
+shared `paginateViaLinkHeader(fetch, url, headers, max)` utility that
+both worlds call into.** The prototype intentionally duplicates it to
+keep the diff surface minimal.
+
+### 2. Two separate type worlds
+
+`components.schemas.User` from the generated spec is a different TS
+type from `CanvasUser` in `src/canvas/types.ts`. Today the public
+surface of `GeneratedUsersModule` returns the hand-written types, with
+a `data as CanvasUser` cast at the boundary. Structurally they match,
+so the cast is safe — but this is the exact point at which **the full
+migration has to choose**: delete `src/canvas/types.ts` and consume
+generated types everywhere, OR keep a thin hand-written layer that
+converts. Each has costs:
+- **Going fully generated** means every response-trimming tool
+  (`students` normalization in `src/tools/users.ts`, etc.) has to be
+  re-verified against the generated types.
+- **Keeping hand-written types at the boundary** perpetuates the
+  problem the migration is trying to solve.
+
+### 3. openapi-fetch's path-template API doesn't fit Link-header URLs
+
+The `next` URL returned by Canvas is an absolute URL with the full
+query string embedded. openapi-fetch wants `(pathTemplate, { params })`.
+The prototype sidesteps this by using raw `fetch` for subsequent pages
+and reserving openapi-fetch for the first, typed page. The net effect
+is that **we only get openapi-fetch's type-checking on the first call
+of any paginated endpoint**. This is acceptable but worth calling out —
+the typing benefit is less dense than the marketing suggests.
+
+### 4. Generated file churn
+
+`openapi-typescript` emits a stable format when fed a stable input, but
+line-length and quote-style decisions can drift between releases. The
+prototype runs prettier over the output inside the generation script so
+the checked-in file is always lint-clean. If `openapi-typescript` is
+upgraded and changes its emit style, the diff will still be noisy. For
+a full migration, pin the version and treat `types.ts` diffs as
+review-worthy rather than "generated, ignore."
+
+## Generator size
+
+- `openapi-fetch`: runtime dep, **6 kB min** — added to `dependencies`.
+- `openapi-typescript`: dev-only, CLI-style, used by the generation script.
+- `yaml`: dev-only, used for parsing spec + overlays.
+
+Bundled `dist/` size with the feature flag off is unchanged
+(both modules are dead-code-eliminated when `users` uses the
+hand-written module). When the flag is on, `openapi-fetch` contributes
+about 6 kB minified to the bundle. The generated types file adds
+nothing to runtime (pure types).
+
+## What is NOT in the prototype
+
+- **No Canvas-sourced spec.** Canvas LMS is AGPL-3.0; its
+  `rake doc:openapi` output is AGPL-derived (see issue #78,
+  "License — this needs a decision, not a default"). Using that output
+  as the spec source is blocked on the licensing decision. The prototype
+  therefore hand-authors the source spec from public Canvas API
+  documentation, which is license-clean and has the side benefit of
+  removing any "needs a Canvas checkout with a DB" dependency from the
+  prototype CI path.
+- **No Redocly `bundle` step.** At one domain, a 60-line deep-merge in
+  the generation script is simpler than `@redocly/cli`. When multiple
+  domains land, switching to Redocly is a one-file change.
+- **No GraphQL.** Issue #78 floated a complementary GraphQL layer; that
+  is out of scope for this prototype.
+- **No other domains.** Only `users`. The migration strategy in issue #78
+  explicitly called for this.
+
+## Recommendation for the next step
+
+The pipeline works. The real decision is still upstream:
+
+1. **Licensing.** Pick a path from issue #78 ("License — this needs a
+   decision, not a default"). The prototype doesn't force that decision
+   because its source spec is hand-authored, but every additional
+   domain beyond `users` that uses the Canvas-emitted spec will. Don't
+   fan out until this is decided.
+2. **Pagination helper extraction.** Before adding a second domain,
+   extract `paginateViaLinkHeader` into a shared utility. Right now
+   there's one copy in `CanvasHttpClient` and one in
+   `GeneratedUsersModule`. Two is tolerable; three is a bug.
+3. **Type-world decision.** Before adding a second domain, decide
+   whether to keep `src/canvas/types.ts` or delete it in favor of
+   generated types. The answer affects the shape of every subsequent
+   generated module.
+
+Only after (1), (2), and (3) is the fan-out to additional domains a
+mechanical task.
+
+## How to try it locally
+
+```sh
+pnpm install
+pnpm canvas:spec:generate   # regenerate types
+pnpm test                   # full suite including parity tests
+```
+
+To use the generated client from application code:
+
+```ts
+import { CanvasClient } from 'canvas-lms-mcp/canvas'
+
+const client = new CanvasClient({
+  token: process.env.CANVAS_API_TOKEN!,
+  baseUrl: process.env.CANVAS_BASE_URL!,
+  useGeneratedClient: ['users'],   // opt in, one domain at a time
+})
+
+const students = await client.users.listStudents(1234)
+```

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "dev": "tsup --watch",
     "build": "tsup",
     "generate:manifests": "tsx scripts/generate-manifests.ts",
+    "canvas:spec:generate": "tsx scripts/canvas-spec/generate.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint src/ tests/ && prettier --check src/ tests/",
@@ -80,6 +81,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "openapi-fetch": "^0.17.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -91,11 +93,13 @@
     "eslint": "^10.2.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
+    "openapi-typescript": "^7.13.0",
     "prettier": "^3.8.2",
-    "tsx": "^4.20.6",
     "tsup": "^8.5.1",
+    "tsx": "^4.20.6",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.1",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.4",
+    "yaml": "^2.8.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
+      openapi-fetch:
+        specifier: ^0.17.0
+        version: 0.17.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -42,12 +45,15 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.5.5
         version: 5.5.5(eslint-config-prettier@10.1.8(eslint@10.2.0))(eslint@10.2.0)(prettier@3.8.2)
+      openapi-typescript:
+        specifier: ^7.13.0
+        version: 7.13.0(typescript@6.0.2)
       prettier:
         specifier: ^3.8.2
         version: 3.8.2
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.9)(tsx@4.21.0)(typescript@6.0.2)
+        version: 8.5.1(postcss@8.5.9)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.3)
       tsx:
         specifier: ^4.20.6
         version: 4.21.0
@@ -59,9 +65,16 @@ importers:
         version: 8.58.1(eslint@10.2.0)(typescript@6.0.2)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
 
 packages:
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -345,6 +358,16 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@redocly/ajv@8.11.2':
+    resolution: {integrity: sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==}
+
+  '@redocly/config@0.22.0':
+    resolution: {integrity: sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==}
+
+  '@redocly/openapi-core@1.34.12':
+    resolution: {integrity: sha512-b32XWsz6enN6K4bx8xWsqUaXTJR/DnYT3lL1CzDYzIYKw243NNlz6fexmr71q/U4HrEcMoJGBvwAfcxOb8ymQw==}
+    engines: {node: '>=18.17.0', npm: '>=9.5.0'}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
@@ -698,6 +721,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -712,8 +739,15 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -722,6 +756,9 @@ packages:
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -729,6 +766,9 @@ packages:
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -760,9 +800,15 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  colorette@1.4.0:
+    resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1055,6 +1101,10 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -1070,6 +1120,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  index-to-position@1.2.0:
+    resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
+    engines: {node: '>=18'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -1115,8 +1169,19 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
+  js-levenshtein@1.1.6:
+    resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
+    engines: {node: '>=0.10.0'}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -1259,6 +1324,10 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
@@ -1298,6 +1367,18 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  openapi-fetch@0.17.0:
+    resolution: {integrity: sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==}
+
+  openapi-typescript-helpers@0.1.0:
+    resolution: {integrity: sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==}
+
+  openapi-typescript@7.13.0:
+    resolution: {integrity: sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.x
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1309,6 +1390,10 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  parse-json@8.3.0:
+    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
+    engines: {node: '>=18'}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -1345,6 +1430,10 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
@@ -1499,6 +1588,10 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -1580,6 +1673,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
@@ -1605,6 +1702,9 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  uri-js-replace@1.0.1:
+    resolution: {integrity: sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -1714,6 +1814,18 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  yaml-ast-parser@0.0.43:
+    resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -1727,6 +1839,12 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -1847,7 +1965,7 @@ snapshots:
   '@eslint/config-array@0.23.5':
     dependencies:
       '@eslint/object-schema': 3.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
@@ -1932,6 +2050,29 @@ snapshots:
   '@oxc-project/types@0.124.0': {}
 
   '@pkgr/core@0.2.9': {}
+
+  '@redocly/ajv@8.11.2':
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js-replace: 1.0.1
+
+  '@redocly/config@0.22.0': {}
+
+  '@redocly/openapi-core@1.34.12(supports-color@10.2.2)':
+    dependencies:
+      '@redocly/ajv': 8.11.2
+      '@redocly/config': 0.22.0
+      colorette: 1.4.0
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      js-levenshtein: 1.1.6
+      js-yaml: 4.1.1
+      minimatch: 5.1.9
+      pluralize: 8.0.0
+      yaml-ast-parser: 0.0.43
+    transitivePeerDependencies:
+      - supports-color
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     optional: true
@@ -2105,7 +2246,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.58.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       eslint: 10.2.0
       typescript: 6.0.2
     transitivePeerDependencies:
@@ -2115,7 +2256,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@6.0.2)
       '@typescript-eslint/types': 8.58.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
@@ -2134,7 +2275,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@6.0.2)
       '@typescript-eslint/utils': 8.58.1(eslint@10.2.0)(typescript@6.0.2)
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       eslint: 10.2.0
       ts-api-utils: 2.5.0(typescript@6.0.2)
       typescript: 6.0.2
@@ -2149,7 +2290,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@6.0.2)
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/visitor-keys': 8.58.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.16
@@ -2186,7 +2327,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0))
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -2197,13 +2338,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -2240,6 +2381,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -2258,7 +2401,11 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-colors@4.1.3: {}
+
   any-promise@1.3.0: {}
+
+  argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
 
@@ -2268,13 +2415,15 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -2283,6 +2432,10 @@ snapshots:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.5:
     dependencies:
@@ -2309,9 +2462,13 @@ snapshots:
 
   chai@6.2.2: {}
 
+  change-case@5.4.4: {}
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  colorette@1.4.0: {}
 
   commander@4.1.1: {}
 
@@ -2340,9 +2497,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   deep-is@0.1.4: {}
 
@@ -2441,7 +2600,7 @@ snapshots:
       '@types/estree': 1.0.8
       ajv: 6.14.0
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -2507,7 +2666,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -2552,7 +2711,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -2636,6 +2795,13 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  https-proxy-agent@7.0.6(supports-color@10.2.2):
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -2645,6 +2811,8 @@ snapshots:
   ignore@7.0.5: {}
 
   imurmurhash@0.1.4: {}
+
+  index-to-position@1.2.0: {}
 
   inherits@2.0.4: {}
 
@@ -2679,7 +2847,15 @@ snapshots:
 
   joycon@3.1.1: {}
 
+  js-levenshtein@1.1.6: {}
+
   js-tokens@10.0.0: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
 
   json-buffer@3.0.1: {}
 
@@ -2789,6 +2965,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.5
 
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
   mlly@1.8.2:
     dependencies:
       acorn: 8.16.0
@@ -2824,6 +3004,22 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  openapi-fetch@0.17.0:
+    dependencies:
+      openapi-typescript-helpers: 0.1.0
+
+  openapi-typescript-helpers@0.1.0: {}
+
+  openapi-typescript@7.13.0(typescript@6.0.2):
+    dependencies:
+      '@redocly/openapi-core': 1.34.12(supports-color@10.2.2)
+      ansi-colors: 4.1.3
+      change-case: 5.4.4
+      parse-json: 8.3.0
+      supports-color: 10.2.2
+      typescript: 6.0.2
+      yargs-parser: 21.1.1
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -2840,6 +3036,12 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  parse-json@8.3.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      index-to-position: 1.2.0
+      type-fest: 4.41.0
 
   parseurl@1.3.3: {}
 
@@ -2865,12 +3067,15 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.9)(tsx@4.21.0):
+  pluralize@8.0.0: {}
+
+  postcss-load-config@6.0.1(postcss@8.5.9)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       postcss: 8.5.9
       tsx: 4.21.0
+      yaml: 2.8.3
 
   postcss@8.5.9:
     dependencies:
@@ -2968,7 +3173,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -2982,7 +3187,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -3063,6 +3268,8 @@ snapshots:
       tinyglobby: 0.2.16
       ts-interface-checker: 0.1.13
 
+  supports-color@10.2.2: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -3105,18 +3312,18 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  tsup@8.5.1(postcss@8.5.9)(tsx@4.21.0)(typescript@6.0.2):
+  tsup@8.5.1(postcss@8.5.9)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       esbuild: 0.27.7
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.9)(tsx@4.21.0)
+      postcss-load-config: 6.0.1(postcss@8.5.9)(tsx@4.21.0)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.60.1
       source-map: 0.7.6
@@ -3144,6 +3351,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-fest@4.41.0: {}
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
@@ -3169,13 +3378,15 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  uri-js-replace@1.0.1: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
   vary@1.1.2: {}
 
-  vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0):
+  vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -3187,11 +3398,12 @@ snapshots:
       esbuild: 0.27.7
       fsevents: 2.3.3
       tsx: 4.21.0
+      yaml: 2.8.3
 
-  vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)):
+  vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -3208,7 +3420,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
@@ -3228,6 +3440,12 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  yaml-ast-parser@0.0.43: {}
+
+  yaml@2.8.3: {}
+
+  yargs-parser@21.1.1: {}
 
   yocto-queue@0.1.0: {}
 

--- a/scripts/canvas-spec/generate.ts
+++ b/scripts/canvas-spec/generate.ts
@@ -1,0 +1,144 @@
+#!/usr/bin/env tsx
+/**
+ * Canvas OpenAPI → TypeScript types generation pipeline (prototype).
+ *
+ * Pulls spec/canvas/prototype.yaml, merges every overlay in
+ * spec/canvas/overrides/*.yaml on top of it, and runs openapi-typescript
+ * to emit src/canvas/generated/types.ts.
+ *
+ * Keep this script small. When the migration fans out beyond `users`,
+ * switch the merge step to `@redocly/cli bundle` (it's already a
+ * transitive dep of openapi-typescript). For one domain it's overkill.
+ */
+import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parse as parseYaml } from 'yaml'
+import openapiTS, { astToString } from 'openapi-typescript'
+import prettier from 'prettier'
+
+const __filename = fileURLToPath(import.meta.url)
+const repoRoot = resolve(dirname(__filename), '..', '..')
+
+const SPEC_PATH = join(repoRoot, 'spec', 'canvas', 'prototype.yaml')
+const OVERRIDES_DIR = join(repoRoot, 'spec', 'canvas', 'overrides')
+const OUTPUT_PATH = join(repoRoot, 'src', 'canvas', 'generated', 'types.ts')
+
+const BANNER = `/**
+ * GENERATED FILE — DO NOT EDIT.
+ *
+ * This file is produced by scripts/canvas-spec/generate.ts from the
+ * hand-authored prototype spec in spec/canvas/prototype.yaml, with
+ * overlays from spec/canvas/overrides/*.yaml applied on top.
+ *
+ * To regenerate:
+ *
+ *   pnpm canvas:spec:generate
+ *
+ * The generated types stay license-clean because the source spec is
+ * hand-authored from public Canvas API documentation. When the license
+ * decision from issue #78 is resolved and the full Canvas spec is wired
+ * in as the source, this banner should be revisited.
+ */
+
+/* prettier-ignore */
+`
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Deep-merge two OpenAPI fragments.
+ *
+ * - Plain objects merge recursively.
+ * - Arrays of objects at the `parameters` key merge by `name + in`
+ *   (so an overlay can patch a single parameter without listing them all).
+ * - All other arrays replace wholesale, which is what enum overlays want.
+ */
+function mergeSpec<T>(base: T, overlay: unknown): T {
+  if (!isPlainObject(base) || !isPlainObject(overlay)) {
+    return (overlay ?? base) as T
+  }
+  const result: Record<string, unknown> = { ...base }
+  for (const [key, overlayValue] of Object.entries(overlay)) {
+    const baseValue = (base as Record<string, unknown>)[key]
+    if (key === 'parameters' && Array.isArray(baseValue) && Array.isArray(overlayValue)) {
+      result[key] = mergeParameterArray(baseValue, overlayValue)
+      continue
+    }
+    if (isPlainObject(baseValue) && isPlainObject(overlayValue)) {
+      result[key] = mergeSpec(baseValue, overlayValue)
+      continue
+    }
+    result[key] = overlayValue
+  }
+  return result as T
+}
+
+function mergeParameterArray(
+  base: unknown[],
+  overlay: unknown[],
+): unknown[] {
+  const identity = (p: unknown): string | null => {
+    if (!isPlainObject(p)) return null
+    const name = typeof p.name === 'string' ? p.name : null
+    const location = typeof p.in === 'string' ? p.in : null
+    if (!name || !location) return null
+    return `${location}:${name}`
+  }
+  const result: unknown[] = [...base]
+  for (const overlayParam of overlay) {
+    const id = identity(overlayParam)
+    if (!id) {
+      result.push(overlayParam)
+      continue
+    }
+    const idx = result.findIndex((p) => identity(p) === id)
+    if (idx === -1) {
+      result.push(overlayParam)
+    } else {
+      result[idx] = mergeSpec(result[idx], overlayParam)
+    }
+  }
+  return result
+}
+
+function loadYaml(path: string): unknown {
+  return parseYaml(readFileSync(path, 'utf8'))
+}
+
+function loadOverlays(dir: string): unknown[] {
+  if (!existsSync(dir)) return []
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'))
+    .sort()
+    .map((f) => loadYaml(join(dir, f)))
+}
+
+async function main() {
+  const source = loadYaml(SPEC_PATH)
+  const overlays = loadOverlays(OVERRIDES_DIR)
+  const merged = overlays.reduce((acc, overlay) => mergeSpec(acc, overlay), source)
+
+  const ast = await openapiTS(merged as Parameters<typeof openapiTS>[0], {
+    immutable: true,
+  })
+  const raw = BANNER + astToString(ast) + '\n'
+
+  const prettierConfig = (await prettier.resolveConfig(OUTPUT_PATH)) ?? {}
+  const contents = await prettier.format(raw, { ...prettierConfig, parser: 'typescript' })
+
+  mkdirSync(dirname(OUTPUT_PATH), { recursive: true })
+  writeFileSync(OUTPUT_PATH, contents, 'utf8')
+
+  const overlayCount = overlays.length
+  console.log(
+    `Generated ${OUTPUT_PATH} (${overlayCount} overlay${overlayCount === 1 ? '' : 's'} applied).`,
+  )
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/spec/canvas/README.md
+++ b/spec/canvas/README.md
@@ -1,0 +1,91 @@
+# Canvas OpenAPI spec pipeline (prototype)
+
+This directory contains the scoped prototype for the generated-client pipeline
+proposed in GitHub issue [#78](https://github.com/bruchris/canvas-lms-mcp/issues/78).
+
+## What this is
+
+A license-clean, end-to-end demonstration of:
+
+1. A source OpenAPI 3.1 spec fragment
+2. An overlay layer that patches known issues (tightens response shapes,
+   adds enum values, fixes field types) without editing the source
+3. A merge step that composes source + overlays into a single bundled spec
+4. Type generation with `openapi-typescript`
+5. A runtime client layer built on `openapi-fetch`
+
+Right now the pipeline covers **one domain only (`users`)**. The goal is to
+prove the plumbing works and surface the real costs and constraints before
+the licensing decision and before fanning out to every Canvas domain.
+
+## What this is NOT
+
+- NOT the Canvas-derived OpenAPI output from `rake doc:openapi`. Canvas LMS
+  is AGPL-3.0 licensed. Vendoring AGPL-derived specs or generated output
+  into this MIT repo needs an explicit licensing decision (see issue #78,
+  "License — this needs a decision, not a default"). The prototype spec
+  here is **hand-authored from public Canvas API docs**, so the pipeline
+  itself doesn't depend on any licensing outcome — it will work equally
+  well once a license-clean full spec source is chosen.
+- NOT the final spec source. When the license path is decided, the source
+  file is expected to be replaced with whatever the chosen upstream
+  produces (Canvas rake output, community spec, etc.), and the overlays
+  remain in place on top of it.
+
+## Files
+
+```
+spec/canvas/
+  README.md              -- this file
+  prototype.yaml         -- hand-authored OpenAPI 3.1 for users endpoints
+  overrides/
+    users.yaml           -- overlay patches demonstrating the pattern
+```
+
+## Pipeline scripts
+
+From the repo root:
+
+```
+pnpm canvas:spec:generate
+```
+
+runs `scripts/canvas-spec/generate.ts`, which:
+
+1. Reads `spec/canvas/prototype.yaml`
+2. Applies overlays from `spec/canvas/overrides/*.yaml`
+3. Runs `openapi-typescript` against the merged spec
+4. Writes the result to `src/canvas/generated/types.ts`
+
+The generated file is checked in with a `// GENERATED` banner. It stays
+license-clean because it's derived from the hand-authored prototype spec.
+
+## Overlay pattern
+
+`overrides/users.yaml` demonstrates the two kinds of patches the full
+migration will need (see issue #78, "Patch strategy — overlays beat
+post-gen codemods"):
+
+- **Narrow an enum.** `CourseUserInclude` in the source spec might be a
+  subset of what Canvas actually accepts; the overlay adds the missing
+  values without touching the source.
+- **Tighten a response shape.** Works around
+  [instructure/canvas-lms#2583](https://github.com/instructure/canvas-lms/issues/2583)
+  where the Canvas-emitted spec returns `unknown`/`object` instead of
+  typed shapes for many endpoints.
+
+The merge is a simple deep-merge in the generation script — no Redocly
+dependency needed at this scale. When the migration fans out to more
+domains, switching to `@redocly/cli bundle` is a one-script change.
+
+## What's not in the spec (stays hand-written)
+
+Per issue #78:
+
+- **Link-header pagination.** OpenAPI can't express it. The generated
+  users client uses the same Link-header loop as the hand-written client.
+- **`include[]`-conditional response shapes.** OpenAPI can't express "if
+  `include[]` contains X, field Y appears." The generated client exposes
+  everything the overlay types; narrowing happens at the tool layer if
+  needed.
+- **Bearer auth injection.** One line of middleware, not a spec concern.

--- a/spec/canvas/overrides/users.yaml
+++ b/spec/canvas/overrides/users.yaml
@@ -1,0 +1,37 @@
+# Overlay patches for users endpoints.
+#
+# The merge step in scripts/canvas-spec/generate.ts performs a deep merge:
+# any key set here overrides the same key in spec/canvas/prototype.yaml.
+# Arrays of scalars replace (not concatenate) to make it easy to
+# narrow/expand enums precisely. Arrays of objects inside `parameters`
+# match by `name + in` and merge field-by-field.
+#
+# Demonstrates two patterns from issue #78:
+#  1. Add the `uuid` value to the account-users `include[]` enum that the
+#     hand-authored source omitted. In the full migration this pattern also
+#     fixes places where Canvas's spec undercounts the actual enum.
+#  2. Add `primary_email` to the User schema, mimicking the response-shape
+#     tightening that issue #78 calls out (workaround for
+#     instructure/canvas-lms#2583). In the full migration this also
+#     narrows loose `unknown` response types for endpoints the MCP uses.
+
+components:
+  schemas:
+    User:
+      properties:
+        primary_email:
+          type: string
+
+paths:
+  /api/v1/accounts/{account_id}/users:
+    get:
+      parameters:
+        - name: include[]
+          in: query
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum: [email, last_login, avatar_url, time_zone, uuid]

--- a/spec/canvas/prototype.yaml
+++ b/spec/canvas/prototype.yaml
@@ -1,0 +1,344 @@
+openapi: 3.1.0
+info:
+  title: Canvas LMS REST API (users prototype slice)
+  version: 'prototype-0.1.0'
+  description: |
+    Hand-authored OpenAPI 3.1 fragment covering only the Canvas users
+    endpoints exercised by the canvas-lms-mcp prototype for GitHub issue #78.
+    This is intentionally narrow — not a full Canvas spec. See
+    `spec/canvas/README.md` for why this is hand-authored rather than pulled
+    from Canvas's `rake doc:openapi`.
+servers:
+  - url: '{canvasBaseUrl}'
+    variables:
+      canvasBaseUrl:
+        default: https://canvas.instructure.com
+        description: Canvas instance base URL (without `/api/v1`).
+security:
+  - bearerAuth: []
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+  parameters:
+    PerPage:
+      name: per_page
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+  schemas:
+    User:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        sortable_name:
+          type: string
+        short_name:
+          type: string
+        sis_user_id:
+          type: [string, 'null']
+        integration_id:
+          type: [string, 'null']
+        sis_import_id:
+          type: [integer, 'null']
+        login_id:
+          type: string
+        avatar_url:
+          type: string
+        enrollments:
+          type: array
+          items:
+            $ref: '#/components/schemas/Enrollment'
+        email:
+          type: string
+        locale:
+          type: [string, 'null']
+        last_login:
+          type: [string, 'null']
+          format: date-time
+        time_zone:
+          type: string
+        bio:
+          type: [string, 'null']
+    UserProfile:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        short_name:
+          type: string
+        sortable_name:
+          type: string
+        title:
+          type: [string, 'null']
+        bio:
+          type: [string, 'null']
+        primary_email:
+          type: string
+        login_id:
+          type: string
+        sis_user_id:
+          type: [string, 'null']
+        lti_user_id:
+          type: [string, 'null']
+        avatar_url:
+          type: string
+        calendar:
+          type: object
+          properties:
+            ics:
+              type: string
+        time_zone:
+          type: string
+        locale:
+          type: string
+    Enrollment:
+      type: object
+      required:
+        - id
+        - course_id
+        - type
+      properties:
+        id:
+          type: integer
+        course_id:
+          type: integer
+        type:
+          type: string
+        role:
+          type: string
+        enrollment_state:
+          type: string
+    UpcomingEvent:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          oneOf:
+            - type: integer
+            - type: string
+        title:
+          type: string
+        start_at:
+          type: [string, 'null']
+          format: date-time
+        end_at:
+          type: [string, 'null']
+          format: date-time
+        type:
+          type: string
+        html_url:
+          type: string
+        assignment:
+          type: object
+paths:
+  /api/v1/users/{id}:
+    get:
+      operationId: showUser
+      summary: Get a single user
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            oneOf:
+              - type: integer
+              - type: string
+      responses:
+        '200':
+          description: User
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+  /api/v1/users/self/profile:
+    get:
+      operationId: showSelfProfile
+      summary: Get current user profile
+      responses:
+        '200':
+          description: UserProfile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserProfile'
+  /api/v1/users/self/upcoming_events:
+    get:
+      operationId: listSelfUpcomingEvents
+      summary: List current user upcoming events
+      parameters:
+        - name: type
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [Assignment, Event]
+      responses:
+        '200':
+          description: List of upcoming events
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UpcomingEvent'
+  /api/v1/courses/{course_id}/users:
+    get:
+      operationId: listCourseUsers
+      summary: List users enrolled in a course
+      parameters:
+        - name: course_id
+          in: path
+          required: true
+          schema:
+            oneOf:
+              - type: integer
+              - type: string
+        - $ref: '#/components/parameters/PerPage'
+        - name: search_term
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [username, email, sis_id, integration_id, last_login]
+        - name: order
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [asc, desc]
+        - name: enrollment_role_id
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: user_id
+          in: query
+          required: false
+          schema:
+            oneOf:
+              - type: integer
+              - type: string
+        - name: enrollment_type[]
+          in: query
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum: [student, teacher, ta, observer, designer]
+        - name: enrollment_state[]
+          in: query
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum: [active, invited, rejected, completed, inactive]
+        - name: include[]
+          in: query
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - email
+                - enrollments
+                - locked
+                - avatar_url
+                - test_student
+                - bio
+                - custom_links
+                - current_grading_period_scores
+        - name: user_ids[]
+          in: query
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              oneOf:
+                - type: integer
+                - type: string
+      responses:
+        '200':
+          description: List of users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+  /api/v1/accounts/{account_id}/users:
+    get:
+      operationId: listAccountUsers
+      summary: List/search users in an account
+      parameters:
+        - name: account_id
+          in: path
+          required: true
+          schema:
+            oneOf:
+              - type: integer
+              - type: string
+        - $ref: '#/components/parameters/PerPage'
+        - name: search_term
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [username, email, sis_id, integration_id, last_login]
+        - name: order
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [asc, desc]
+        - name: include[]
+          in: query
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum: [email, last_login, avatar_url, time_zone]
+      responses:
+        '200':
+          description: List of users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'

--- a/src/canvas/generated/types.ts
+++ b/src/canvas/generated/types.ts
@@ -1,0 +1,329 @@
+/**
+ * GENERATED FILE — DO NOT EDIT.
+ *
+ * This file is produced by scripts/canvas-spec/generate.ts from the
+ * hand-authored prototype spec in spec/canvas/prototype.yaml, with
+ * overlays from spec/canvas/overrides/*.yaml applied on top.
+ *
+ * To regenerate:
+ *
+ *   pnpm canvas:spec:generate
+ *
+ * The generated types stay license-clean because the source spec is
+ * hand-authored from public Canvas API documentation. When the license
+ * decision from issue #78 is resolved and the full Canvas spec is wired
+ * in as the source, this banner should be revisited.
+ */
+
+/* prettier-ignore */
+export interface paths {
+    readonly "/api/v1/users/{id}": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /** Get a single user */
+        readonly get: operations["showUser"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/v1/users/self/profile": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /** Get current user profile */
+        readonly get: operations["showSelfProfile"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/v1/users/self/upcoming_events": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /** List current user upcoming events */
+        readonly get: operations["listSelfUpcomingEvents"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/v1/courses/{course_id}/users": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /** List users enrolled in a course */
+        readonly get: operations["listCourseUsers"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/v1/accounts/{account_id}/users": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /** List/search users in an account */
+        readonly get: operations["listAccountUsers"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+}
+export type webhooks = Record<string, never>
+export interface components {
+  schemas: {
+    readonly User: {
+      /** Format: int64 */
+      readonly id: number
+      readonly name?: string
+      readonly sortable_name?: string
+      readonly short_name?: string
+      readonly sis_user_id?: string | null
+      readonly integration_id?: string | null
+      readonly sis_import_id?: number | null
+      readonly login_id?: string
+      readonly avatar_url?: string
+      readonly enrollments?: readonly components['schemas']['Enrollment'][]
+      readonly email?: string
+      readonly locale?: string | null
+      /** Format: date-time */
+      readonly last_login?: string | null
+      readonly time_zone?: string
+      readonly bio?: string | null
+      readonly primary_email?: string
+    }
+    readonly UserProfile: {
+      /** Format: int64 */
+      readonly id: number
+      readonly name?: string
+      readonly short_name?: string
+      readonly sortable_name?: string
+      readonly title?: string | null
+      readonly bio?: string | null
+      readonly primary_email?: string
+      readonly login_id?: string
+      readonly sis_user_id?: string | null
+      readonly lti_user_id?: string | null
+      readonly avatar_url?: string
+      readonly calendar?: {
+        readonly ics?: string
+      }
+      readonly time_zone?: string
+      readonly locale?: string
+    }
+    readonly Enrollment: {
+      readonly id: number
+      readonly course_id: number
+      readonly type: string
+      readonly role?: string
+      readonly enrollment_state?: string
+    }
+    readonly UpcomingEvent: {
+      readonly id: number | string
+      readonly title?: string
+      /** Format: date-time */
+      readonly start_at?: string | null
+      /** Format: date-time */
+      readonly end_at?: string | null
+      readonly type?: string
+      readonly html_url?: string
+      readonly assignment?: Record<string, never>
+    }
+  }
+  responses: never
+  parameters: {
+    readonly PerPage: number
+  }
+  requestBodies: never
+  headers: never
+  pathItems: never
+}
+export type $defs = Record<string, never>
+export interface operations {
+  readonly showUser: {
+    readonly parameters: {
+      readonly query?: never
+      readonly header?: never
+      readonly path: {
+        readonly id: number | string
+      }
+      readonly cookie?: never
+    }
+    readonly requestBody?: never
+    readonly responses: {
+      /** @description User */
+      readonly 200: {
+        headers: {
+          readonly [name: string]: unknown
+        }
+        content: {
+          readonly 'application/json': components['schemas']['User']
+        }
+      }
+    }
+  }
+  readonly showSelfProfile: {
+    readonly parameters: {
+      readonly query?: never
+      readonly header?: never
+      readonly path?: never
+      readonly cookie?: never
+    }
+    readonly requestBody?: never
+    readonly responses: {
+      /** @description UserProfile */
+      readonly 200: {
+        headers: {
+          readonly [name: string]: unknown
+        }
+        content: {
+          readonly 'application/json': components['schemas']['UserProfile']
+        }
+      }
+    }
+  }
+  readonly listSelfUpcomingEvents: {
+    readonly parameters: {
+      readonly query?: {
+        readonly type?: 'Assignment' | 'Event'
+      }
+      readonly header?: never
+      readonly path?: never
+      readonly cookie?: never
+    }
+    readonly requestBody?: never
+    readonly responses: {
+      /** @description List of upcoming events */
+      readonly 200: {
+        headers: {
+          readonly [name: string]: unknown
+        }
+        content: {
+          readonly 'application/json': readonly components['schemas']['UpcomingEvent'][]
+        }
+      }
+    }
+  }
+  readonly listCourseUsers: {
+    readonly parameters: {
+      readonly query?: {
+        readonly per_page?: components['parameters']['PerPage']
+        readonly search_term?: string
+        readonly sort?: 'username' | 'email' | 'sis_id' | 'integration_id' | 'last_login'
+        readonly order?: 'asc' | 'desc'
+        readonly enrollment_role_id?: number
+        readonly user_id?: number | string
+        readonly 'enrollment_type[]'?: readonly (
+          | 'student'
+          | 'teacher'
+          | 'ta'
+          | 'observer'
+          | 'designer'
+        )[]
+        readonly 'enrollment_state[]'?: readonly (
+          | 'active'
+          | 'invited'
+          | 'rejected'
+          | 'completed'
+          | 'inactive'
+        )[]
+        readonly 'include[]'?: readonly (
+          | 'email'
+          | 'enrollments'
+          | 'locked'
+          | 'avatar_url'
+          | 'test_student'
+          | 'bio'
+          | 'custom_links'
+          | 'current_grading_period_scores'
+        )[]
+        readonly 'user_ids[]'?: readonly (number | string)[]
+      }
+      readonly header?: never
+      readonly path: {
+        readonly course_id: number | string
+      }
+      readonly cookie?: never
+    }
+    readonly requestBody?: never
+    readonly responses: {
+      /** @description List of users */
+      readonly 200: {
+        headers: {
+          readonly [name: string]: unknown
+        }
+        content: {
+          readonly 'application/json': readonly components['schemas']['User'][]
+        }
+      }
+    }
+  }
+  readonly listAccountUsers: {
+    readonly parameters: {
+      readonly query?: {
+        readonly per_page?: components['parameters']['PerPage']
+        readonly search_term?: string
+        readonly sort?: 'username' | 'email' | 'sis_id' | 'integration_id' | 'last_login'
+        readonly order?: 'asc' | 'desc'
+        readonly 'include[]'?: readonly (
+          | 'email'
+          | 'last_login'
+          | 'avatar_url'
+          | 'time_zone'
+          | 'uuid'
+        )[]
+      }
+      readonly header?: never
+      readonly path: {
+        readonly account_id: number | string
+      }
+      readonly cookie?: never
+    }
+    readonly requestBody?: never
+    readonly responses: {
+      /** @description List of users */
+      readonly 200: {
+        headers: {
+          readonly [name: string]: unknown
+        }
+        content: {
+          readonly 'application/json': readonly components['schemas']['User'][]
+        }
+      }
+    }
+  }
+}

--- a/src/canvas/generated/users-client.ts
+++ b/src/canvas/generated/users-client.ts
@@ -1,0 +1,227 @@
+/**
+ * Generated-client users module (prototype for GitHub issue #78).
+ *
+ * Demonstrates swapping the hand-written `UsersModule` with a thin layer
+ * on top of `openapi-fetch` + generated types. The public shape matches
+ * `UsersModule` exactly so that `CanvasClient` can select either
+ * implementation behind a feature flag without downstream tools knowing.
+ *
+ * Two things that cannot live in the OpenAPI spec (per issue #78) are
+ * handled here:
+ *
+ *  1. Bearer auth injection -- a one-line openapi-fetch middleware.
+ *  2. Link-header pagination -- a small manual loop. openapi-fetch drives
+ *     the first request with full type-checking; subsequent pages are
+ *     fetched directly since Canvas returns absolute URLs in the Link
+ *     header that don't fit openapi-fetch's path-templated API surface.
+ */
+import createClient, { type Middleware } from 'openapi-fetch'
+import { CanvasApiError } from '../client'
+import type {
+  CanvasClientConfig,
+  CanvasErrorResponse,
+  CanvasUpcomingEvent,
+  CanvasUser,
+  CanvasUserProfile,
+} from '../types'
+import type {
+  CourseUserEnrollmentType,
+  CourseUserEnrollmentState,
+  CourseUserInclude,
+  ListCourseUsersOptions,
+  SearchUserInclude,
+  SearchUsersOptions,
+  UserSort,
+  UsersModuleApi,
+} from '../users'
+import type { paths } from './types'
+
+const DEFAULT_MAX_PAGINATION_PAGES = 1000
+const USER_AGENT = 'canvas-lms-mcp/1.0'
+const DEFAULT_PER_PAGE = 100
+
+type OpenApiClient = ReturnType<typeof createClient<paths>>
+
+export class GeneratedUsersModule implements UsersModuleApi {
+  private client: OpenApiClient
+  private token: string
+  private baseUrl: string
+  private maxPaginationPages: number
+
+  constructor(config: CanvasClientConfig) {
+    this.token = config.token
+    this.baseUrl = config.baseUrl.replace(/\/+$/, '')
+    this.maxPaginationPages = config.maxPaginationPages ?? DEFAULT_MAX_PAGINATION_PAGES
+
+    const token = this.token
+    const authMiddleware: Middleware = {
+      onRequest({ request }) {
+        request.headers.set('Authorization', `Bearer ${token}`)
+        request.headers.set('User-Agent', USER_AGENT)
+        return request
+      },
+    }
+
+    this.client = createClient<paths>({ baseUrl: this.baseUrl })
+    this.client.use(authMiddleware)
+  }
+
+  async listStudents(courseId: number): Promise<CanvasUser[]> {
+    return this.paginate<CanvasUser>(`/api/v1/courses/${courseId}/users`, {
+      'enrollment_type[]': ['student'],
+    })
+  }
+
+  async get(userId: number): Promise<CanvasUser> {
+    const endpoint = `/api/v1/users/${userId}`
+    const { data, error, response } = await this.client.GET('/api/v1/users/{id}', {
+      params: { path: { id: userId } },
+    })
+    if (error || !response.ok) {
+      throw await toCanvasError(response, endpoint, error)
+    }
+    return data as CanvasUser
+  }
+
+  async getProfile(): Promise<CanvasUserProfile> {
+    const endpoint = '/api/v1/users/self/profile'
+    const { data, error, response } = await this.client.GET('/api/v1/users/self/profile')
+    if (error || !response.ok) {
+      throw await toCanvasError(response, endpoint, error)
+    }
+    return data as CanvasUserProfile
+  }
+
+  async searchUsers(
+    accountId: number,
+    searchTerm: string,
+    opts: SearchUsersOptions = {},
+  ): Promise<CanvasUser[]> {
+    const query: Record<string, unknown> = { search_term: searchTerm }
+    if (opts.sort) query.sort = opts.sort
+    if (opts.order) query.order = opts.order
+    if (opts.include && opts.include.length > 0) query['include[]'] = opts.include
+    return this.paginate<CanvasUser>(`/api/v1/accounts/${accountId}/users`, query)
+  }
+
+  async listCourseUsers(
+    courseId: number,
+    opts: ListCourseUsersOptions = {},
+  ): Promise<CanvasUser[]> {
+    const query: Record<string, unknown> = {}
+    if (opts.enrollment_type !== undefined) {
+      query['enrollment_type[]'] = Array.isArray(opts.enrollment_type)
+        ? opts.enrollment_type
+        : [opts.enrollment_type]
+    }
+    if (opts.enrollment_state && opts.enrollment_state.length > 0) {
+      query['enrollment_state[]'] = opts.enrollment_state
+    }
+    if (opts.include && opts.include.length > 0) query['include[]'] = opts.include
+    if (opts.user_ids && opts.user_ids.length > 0) query['user_ids[]'] = opts.user_ids
+    if (opts.enrollment_role_id !== undefined) query.enrollment_role_id = opts.enrollment_role_id
+    if (opts.user_id !== undefined) query.user_id = opts.user_id
+    if (opts.search_term) query.search_term = opts.search_term
+    if (opts.sort) query.sort = opts.sort
+    if (opts.order) query.order = opts.order
+    return this.paginate<CanvasUser>(`/api/v1/courses/${courseId}/users`, query)
+  }
+
+  async getUpcomingAssignments(): Promise<CanvasUpcomingEvent[]> {
+    const endpoint = '/api/v1/users/self/upcoming_events'
+    const { data, error, response } = await this.client.GET('/api/v1/users/self/upcoming_events', {
+      params: { query: { type: 'Assignment' } },
+    })
+    if (error || !response.ok) {
+      throw await toCanvasError(response, endpoint, error)
+    }
+    return (data as CanvasUpcomingEvent[]) ?? []
+  }
+
+  /**
+   * Paginated GET with manual Link-header handling. The first page uses
+   * openapi-fetch's typed surface; subsequent pages use raw fetch since
+   * Canvas returns absolute URLs in the Link header that don't map onto
+   * path templates.
+   */
+  private async paginate<T>(endpoint: string, query: Record<string, unknown>): Promise<T[]> {
+    const firstUrl = buildUrl(this.baseUrl, endpoint, query)
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.token}`,
+      'User-Agent': USER_AGENT,
+    }
+
+    const results: T[] = []
+    let nextUrl: string | null = firstUrl
+    let pages = 0
+
+    while (nextUrl && pages < this.maxPaginationPages) {
+      const response = await fetch(nextUrl, { headers })
+      if (!response.ok) {
+        throw await toCanvasError(response, endpoint, undefined)
+      }
+      const page = (await response.json()) as T[]
+      results.push(...page)
+      pages++
+      nextUrl = parseNextLink(response.headers.get('Link'))
+    }
+    return results
+  }
+}
+
+function buildUrl(baseUrl: string, endpoint: string, query: Record<string, unknown>): string {
+  const url = new URL(`${baseUrl}${endpoint}`)
+  if (!url.searchParams.has('per_page')) {
+    url.searchParams.set('per_page', String(DEFAULT_PER_PAGE))
+  }
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === null) continue
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item === undefined || item === null) continue
+        url.searchParams.append(key, String(item))
+      }
+    } else {
+      url.searchParams.set(key, String(value))
+    }
+  }
+  return url.toString()
+}
+
+function parseNextLink(linkHeader: string | null): string | null {
+  if (!linkHeader) return null
+  const match = linkHeader.match(/<([^>]+)>;\s*rel="next"/)
+  return match?.[1] ?? null
+}
+
+async function toCanvasError(
+  response: Response,
+  endpoint: string,
+  openapiError: unknown,
+): Promise<CanvasApiError> {
+  let body: CanvasErrorResponse = {}
+  if (openapiError && typeof openapiError === 'object') {
+    body = openapiError as CanvasErrorResponse
+  } else if (!response.bodyUsed) {
+    try {
+      body = (await response.clone().json()) as CanvasErrorResponse
+    } catch {
+      body = {}
+    }
+  }
+  const message =
+    body.errors?.[0]?.message ?? body.message ?? `Canvas API error: ${response.status}`
+  return new CanvasApiError(message, response.status, endpoint)
+}
+
+// Re-export the types already defined in src/canvas/users.ts so that
+// consumers of the generated module get an identical surface.
+export type {
+  CourseUserEnrollmentType,
+  CourseUserEnrollmentState,
+  CourseUserInclude,
+  ListCourseUsersOptions,
+  SearchUserInclude,
+  SearchUsersOptions,
+  UserSort,
+}

--- a/src/canvas/index.ts
+++ b/src/canvas/index.ts
@@ -1,12 +1,13 @@
 import { CanvasHttpClient } from './client'
-import type { CanvasClientConfig } from './types'
+import type { CanvasClientConfig, GeneratedClientDomain } from './types'
 import { CoursesModule } from './courses'
 import { AssignmentsModule } from './assignments'
 import { SubmissionsModule } from './submissions'
 import { RubricsModule } from './rubrics'
 import { QuizzesModule } from './quizzes'
 import { FilesModule } from './files'
-import { UsersModule } from './users'
+import { UsersModule, type UsersModuleApi } from './users'
+import { GeneratedUsersModule } from './generated/users-client'
 import { GroupsModule } from './groups'
 import { EnrollmentsModule } from './enrollments'
 import { DiscussionsModule } from './discussions'
@@ -29,7 +30,7 @@ export class CanvasClient {
   rubrics: RubricsModule
   quizzes: QuizzesModule
   files: FilesModule
-  users: UsersModule
+  users: UsersModuleApi
   groups: GroupsModule
   enrollments: EnrollmentsModule
   discussions: DiscussionsModule
@@ -52,7 +53,9 @@ export class CanvasClient {
     this.rubrics = new RubricsModule(this.client)
     this.quizzes = new QuizzesModule(this.client)
     this.files = new FilesModule(this.client)
-    this.users = new UsersModule(this.client)
+    this.users = isGeneratedEnabled(config.useGeneratedClient, 'users')
+      ? new GeneratedUsersModule(config)
+      : new UsersModule(this.client)
     this.groups = new GroupsModule(this.client)
     this.enrollments = new EnrollmentsModule(this.client)
     this.discussions = new DiscussionsModule(this.client)
@@ -69,6 +72,16 @@ export class CanvasClient {
   }
 }
 
+function isGeneratedEnabled(
+  flag: CanvasClientConfig['useGeneratedClient'],
+  domain: GeneratedClientDomain,
+): boolean {
+  if (flag === true) return true
+  if (Array.isArray(flag)) return (flag as readonly GeneratedClientDomain[]).includes(domain)
+  return false
+}
+
+export { GeneratedUsersModule } from './generated/users-client'
 export { CanvasHttpClient, CanvasApiError } from './client'
 export type { CanvasRequestOptions } from './client'
 export { appendCanvasQuery, toCanvasQuery } from './query'

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -4,7 +4,16 @@ export interface CanvasClientConfig {
   token: string
   baseUrl: string
   maxPaginationPages?: number
+  /**
+   * Enable the prototype generated-client implementation for selected
+   * domains (see GitHub issue #78). Currently only `users` is wired up;
+   * pass `true` as a shorthand for all supported domains, or an explicit
+   * list. Default: hand-written modules are used everywhere.
+   */
+  useGeneratedClient?: boolean | readonly GeneratedClientDomain[]
 }
+
+export type GeneratedClientDomain = 'users'
 
 // --- Error ---
 

--- a/src/canvas/users.ts
+++ b/src/canvas/users.ts
@@ -39,7 +39,25 @@ export interface SearchUsersOptions {
   include?: ReadonlyArray<SearchUserInclude>
 }
 
-export class UsersModule {
+/**
+ * Public interface for the users module. Lets `CanvasClient` swap between
+ * the hand-written `UsersModule` and the prototype generated-client
+ * implementation (see GitHub issue #78) without tool callers caring.
+ */
+export interface UsersModuleApi {
+  listStudents(courseId: number): Promise<CanvasUser[]>
+  get(userId: number): Promise<CanvasUser>
+  getProfile(): Promise<CanvasUserProfile>
+  searchUsers(
+    accountId: number,
+    searchTerm: string,
+    opts?: SearchUsersOptions,
+  ): Promise<CanvasUser[]>
+  listCourseUsers(courseId: number, opts?: ListCourseUsersOptions): Promise<CanvasUser[]>
+  getUpcomingAssignments(): Promise<CanvasUpcomingEvent[]>
+}
+
+export class UsersModule implements UsersModuleApi {
   constructor(private client: CanvasHttpClient) {}
 
   async listStudents(courseId: number): Promise<CanvasUser[]> {

--- a/tests/canvas/facade.test.ts
+++ b/tests/canvas/facade.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from 'vitest'
-import { CanvasClient, CanvasHttpClient, CanvasApiError } from '../../src/canvas/index'
+import {
+  CanvasClient,
+  CanvasHttpClient,
+  CanvasApiError,
+  GeneratedUsersModule,
+} from '../../src/canvas/index'
 import { CoursesModule } from '../../src/canvas/courses'
 import { GradebookHistoryModule } from '../../src/canvas/gradebook-history'
+import { UsersModule } from '../../src/canvas/users'
 
 describe('CanvasClient facade', () => {
   it('creates a CanvasClient with courses module', () => {
@@ -36,5 +42,41 @@ describe('CanvasClient facade', () => {
     const error = new CanvasApiError('test', 404, '/api/v1/courses')
     expect(error).toBeInstanceOf(Error)
     expect(error).toBeInstanceOf(CanvasApiError)
+  })
+
+  it('uses the hand-written UsersModule by default', () => {
+    const client = new CanvasClient({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+    })
+    expect(client.users).toBeInstanceOf(UsersModule)
+    expect(client.users).not.toBeInstanceOf(GeneratedUsersModule)
+  })
+
+  it('uses GeneratedUsersModule when useGeneratedClient=true', () => {
+    const client = new CanvasClient({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+      useGeneratedClient: true,
+    })
+    expect(client.users).toBeInstanceOf(GeneratedUsersModule)
+  })
+
+  it('uses GeneratedUsersModule when useGeneratedClient=["users"]', () => {
+    const client = new CanvasClient({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+      useGeneratedClient: ['users'],
+    })
+    expect(client.users).toBeInstanceOf(GeneratedUsersModule)
+  })
+
+  it('falls back to hand-written module when flag list omits users', () => {
+    const client = new CanvasClient({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+      useGeneratedClient: [],
+    })
+    expect(client.users).toBeInstanceOf(UsersModule)
   })
 })

--- a/tests/canvas/generated-users.test.ts
+++ b/tests/canvas/generated-users.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { GeneratedUsersModule } from '../../src/canvas/generated/users-client'
+import { CanvasApiError } from '../../src/canvas/client'
+
+type FetchMock = ReturnType<typeof vi.fn>
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json', ...(init.headers ?? {}) },
+    ...init,
+  })
+}
+
+describe('GeneratedUsersModule', () => {
+  let fetchMock: FetchMock
+  let users: GeneratedUsersModule
+  let originalFetch: typeof fetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    users = new GeneratedUsersModule({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+    })
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  function lastCallUrl(): URL {
+    expect(fetchMock).toHaveBeenCalled()
+    const call = fetchMock.mock.calls.at(-1)!
+    const arg = call[0] as string | URL | Request
+    const raw = typeof arg === 'string' ? arg : arg instanceof URL ? arg.toString() : arg.url
+    return new URL(raw)
+  }
+
+  function lastCallHeaders(): Headers {
+    expect(fetchMock).toHaveBeenCalled()
+    const call = fetchMock.mock.calls.at(-1)!
+    const arg = call[0]
+    if (arg instanceof Request) return arg.headers
+    const init = call[1] as RequestInit | undefined
+    return new Headers(init?.headers ?? [])
+  }
+
+  describe('auth + base URL', () => {
+    it('sends Bearer token and custom User-Agent on every request', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ id: 1, name: 'Alice' }))
+      await users.get(1)
+      const headers = lastCallHeaders()
+      expect(headers.get('Authorization')).toBe('Bearer test-token')
+      expect(headers.get('User-Agent')).toMatch(/canvas-lms-mcp/)
+    })
+
+    it('resolves requests against the configured base URL', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ id: 1 }))
+      await users.get(1)
+      expect(lastCallUrl().origin).toBe('https://canvas.example.com')
+      expect(lastCallUrl().pathname).toBe('/api/v1/users/1')
+    })
+  })
+
+  describe('single-request endpoints', () => {
+    it('gets a single user', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ id: 1, name: 'Alice' }))
+      const result = await users.get(1)
+      expect(result).toMatchObject({ id: 1, name: 'Alice' })
+      expect(lastCallUrl().pathname).toBe('/api/v1/users/1')
+    })
+
+    it('gets current user profile', async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ id: 1, name: 'Alice', primary_email: 'alice@example.com' }),
+      )
+      const result = await users.getProfile()
+      expect(result).toMatchObject({ id: 1, primary_email: 'alice@example.com' })
+      expect(lastCallUrl().pathname).toBe('/api/v1/users/self/profile')
+    })
+
+    it('fetches upcoming assignments filtered by type=Assignment', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse([{ id: 1, title: 'HW1' }]))
+      const result = await users.getUpcomingAssignments()
+      expect(result).toEqual([{ id: 1, title: 'HW1' }])
+      const url = lastCallUrl()
+      expect(url.pathname).toBe('/api/v1/users/self/upcoming_events')
+      expect(url.searchParams.get('type')).toBe('Assignment')
+    })
+  })
+
+  describe('listStudents', () => {
+    it('lists students for a course with enrollment_type[]=student', async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse([
+          { id: 1, name: 'Alice' },
+          { id: 2, name: 'Bob' },
+        ]),
+      )
+      const result = await users.listStudents(100)
+      expect(result).toHaveLength(2)
+      const url = lastCallUrl()
+      expect(url.pathname).toBe('/api/v1/courses/100/users')
+      expect(url.searchParams.getAll('enrollment_type[]')).toEqual(['student'])
+    })
+  })
+
+  describe('searchUsers', () => {
+    it('searches users in an account with just a search_term', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse([{ id: 1 }]))
+      const result = await users.searchUsers(1, 'alice')
+      expect(result).toHaveLength(1)
+      const url = lastCallUrl()
+      expect(url.pathname).toBe('/api/v1/accounts/1/users')
+      expect(url.searchParams.get('search_term')).toBe('alice')
+      expect(url.searchParams.has('sort')).toBe(false)
+    })
+
+    it('forwards sort, order, include[]', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse([]))
+      await users.searchUsers(1, 'alice', {
+        sort: 'username',
+        order: 'asc',
+        include: ['email', 'last_login'],
+      })
+      const url = lastCallUrl()
+      expect(url.searchParams.get('sort')).toBe('username')
+      expect(url.searchParams.get('order')).toBe('asc')
+      expect(url.searchParams.getAll('include[]')).toEqual(['email', 'last_login'])
+    })
+  })
+
+  describe('listCourseUsers', () => {
+    it('lists without filters', async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse([
+          { id: 1, name: 'Alice' },
+          { id: 2, name: 'Bob' },
+        ]),
+      )
+      const result = await users.listCourseUsers(100)
+      expect(result).toHaveLength(2)
+      const url = lastCallUrl()
+      expect(url.pathname).toBe('/api/v1/courses/100/users')
+      // No filter params should be sent at all
+      expect(url.searchParams.has('enrollment_type[]')).toBe(false)
+      expect(url.searchParams.has('include[]')).toBe(false)
+      expect(url.searchParams.has('search_term')).toBe(false)
+    })
+
+    it('wraps a single-string enrollment_type as an array', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse([]))
+      await users.listCourseUsers(100, { enrollment_type: 'ta' })
+      const url = lastCallUrl()
+      expect(url.searchParams.getAll('enrollment_type[]')).toEqual(['ta'])
+    })
+
+    it('forwards include, enrollment_state, user_ids, search_term, sort, order, enrollment_role_id', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse([]))
+      await users.listCourseUsers(100, {
+        enrollment_type: ['student'],
+        enrollment_state: ['active', 'invited'],
+        include: ['email', 'enrollments'],
+        user_ids: [10, 'sis_user_id:abc'],
+        search_term: 'alice',
+        sort: 'last_login',
+        order: 'desc',
+        enrollment_role_id: 42,
+      })
+      const url = lastCallUrl()
+      expect(url.searchParams.getAll('enrollment_type[]')).toEqual(['student'])
+      expect(url.searchParams.getAll('enrollment_state[]')).toEqual(['active', 'invited'])
+      expect(url.searchParams.getAll('include[]')).toEqual(['email', 'enrollments'])
+      expect(url.searchParams.getAll('user_ids[]')).toEqual(['10', 'sis_user_id:abc'])
+      expect(url.searchParams.get('search_term')).toBe('alice')
+      expect(url.searchParams.get('sort')).toBe('last_login')
+      expect(url.searchParams.get('order')).toBe('desc')
+      expect(url.searchParams.get('enrollment_role_id')).toBe('42')
+    })
+
+    it('drops empty arrays so Canvas does not receive empty include[]', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse([]))
+      await users.listCourseUsers(100, {
+        include: [],
+        enrollment_state: [],
+        user_ids: [],
+      })
+      const url = lastCallUrl()
+      expect(url.searchParams.has('include[]')).toBe(false)
+      expect(url.searchParams.has('enrollment_state[]')).toBe(false)
+      expect(url.searchParams.has('user_ids[]')).toBe(false)
+    })
+  })
+
+  describe('Link-header pagination', () => {
+    it('follows rel="next" until exhausted and concatenates pages', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse([{ id: 1 }, { id: 2 }], {
+            headers: {
+              Link: '<https://canvas.example.com/api/v1/courses/100/users?page=2&per_page=100>; rel="next"',
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse([{ id: 3 }, { id: 4 }], {
+            headers: {
+              Link: '<https://canvas.example.com/api/v1/courses/100/users?page=3&per_page=100>; rel="next"',
+            },
+          }),
+        )
+        .mockResolvedValueOnce(jsonResponse([{ id: 5 }]))
+
+      const result = await users.listCourseUsers(100)
+      expect(result.map((u) => u.id)).toEqual([1, 2, 3, 4, 5])
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+
+      // Each subsequent request must carry the Bearer token too
+      for (const call of fetchMock.mock.calls) {
+        const headers = new Headers((call[1] as RequestInit | undefined)?.headers ?? [])
+        expect(headers.get('Authorization')).toBe('Bearer test-token')
+      }
+    })
+
+    it('stops paginating when Link has no rel="next"', async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse([{ id: 1 }], {
+          headers: {
+            Link: '<https://canvas.example.com/api/v1/courses/100/users?page=1>; rel="first", <https://canvas.example.com/api/v1/courses/100/users?page=1>; rel="last"',
+          },
+        }),
+      )
+      const result = await users.listCourseUsers(100)
+      expect(result).toHaveLength(1)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('respects maxPaginationPages cap', async () => {
+      const capped = new GeneratedUsersModule({
+        token: 'test-token',
+        baseUrl: 'https://canvas.example.com',
+        maxPaginationPages: 2,
+      })
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse([{ id: 1 }], {
+            headers: {
+              Link: '<https://canvas.example.com/api/v1/courses/100/users?page=2>; rel="next"',
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse([{ id: 2 }], {
+            headers: {
+              Link: '<https://canvas.example.com/api/v1/courses/100/users?page=3>; rel="next"',
+            },
+          }),
+        )
+      const result = await capped.listCourseUsers(100)
+      expect(result.map((u) => u.id)).toEqual([1, 2])
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('sets per_page=100 by default on paginated endpoints', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse([]))
+      await users.listCourseUsers(100)
+      expect(lastCallUrl().searchParams.get('per_page')).toBe('100')
+    })
+  })
+
+  describe('error handling', () => {
+    it('throws CanvasApiError on non-2xx with endpoint and status preserved', async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ errors: [{ message: 'Forbidden' }] }), {
+          status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      await expect(users.get(99)).rejects.toMatchObject({
+        name: 'CanvasApiError',
+        status: 403,
+        endpoint: '/api/v1/users/99',
+        message: 'Forbidden',
+      })
+    })
+
+    it('throws CanvasApiError with the expected message when body has no errors field', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('', { status: 500 }))
+      await expect(users.get(99)).rejects.toBeInstanceOf(CanvasApiError)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

First execution slice of GitHub issue #78 (`feat: auto-generate the Canvas REST client from an OpenAPI spec`). Scoped per Paperclip task BRU-590 — prove the generated-client pipeline works end-to-end on one domain (`users`) without breaking the MCP tool surface and without forcing the licensing decision.

Closes: part of #78 (research + prototype only — full migration is a separate follow-up).

## What changed

**Pipeline**
- `spec/canvas/prototype.yaml` — hand-authored OpenAPI 3.1 for users endpoints. Deliberately not derived from Canvas source so the prototype stays license-clean.
- `spec/canvas/overrides/users.yaml` — overlay demo patching both a response schema (adds `primary_email` to `User`) and a query enum (adds `uuid` to account-users `include[]`). Exercises both of the patch patterns issue #78 calls for.
- `scripts/canvas-spec/generate.ts` — deep-merge + `openapi-typescript` + prettier. Run via `pnpm canvas:spec:generate`.

**Runtime**
- `openapi-fetch` (~6 kB, zero runtime deps) for typed single requests + Bearer/User-Agent middleware.
- Link-header pagination stays hand-written (per issue #78) — openapi-fetch types the first page, raw `fetch` follows Canvas's absolute `rel="next"` URLs.

**Integration**
- New `UsersModuleApi` interface extracted from `UsersModule` so `CanvasClient.users` can hold either implementation.
- New `useGeneratedClient` config field on `CanvasClientConfig` (`true`, `false`, or a domain allowlist). **Default is `false`** — hand-written modules continue to be used everywhere; no behavior change unless opted in.

**Tests**
- 604/604 passing.
- New `tests/canvas/generated-users.test.ts` — wire-level parity coverage (Bearer, repeated-key `include[]`, Link-header pagination, `maxPaginationPages` cap, empty-array pruning, `CanvasApiError` mapping).
- `tests/canvas/facade.test.ts` — feature-flag selection coverage.

**Docs**
- `docs/generated-client-prototype.md` — findings, costs surfaced, and recommendations.
- `spec/canvas/README.md` — pipeline overview and license-posture rationale.

## Why the spec is hand-authored (licensing)

Canvas LMS is AGPL-3.0. Its `rake doc:openapi` output is AGPL-derived. Issue #78 explicitly calls for a **license decision before merging generated artifacts** sourced from Canvas. The prototype sidesteps this by hand-authoring the source spec from public Canvas API documentation — the pipeline works identically when the license decision eventually points to a Canvas-derived source.

## Recommendation for next step (also in docs/generated-client-prototype.md)

Three decisions to resolve **before fanning out to a second domain**:
1. **Licensing.** Pick a path from issue #78.
2. **Pagination helper.** Extract `paginateViaLinkHeader` into a shared utility (right now `CanvasHttpClient` and `GeneratedUsersModule` each carry their own copy — two is tolerable, three is a bug).
3. **Type-world unification.** Decide whether `src/canvas/types.ts` stays or is replaced by generated types. Affects every subsequent generated module.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 604/604 pass (including 18 new parity tests + 4 new facade tests)
- [x] `pnpm build` — clean
- [x] `pnpm canvas:spec:generate` — regenerates deterministically with overlay verified in output
- [ ] Spot-check against a real Canvas instance with `useGeneratedClient: ['users']` — left for reviewer/QA, since the prototype is unit-tested at the fetch layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)