### PR TITLE
feat: publish TypeScript declarations (.d.ts) with npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,20 +4,25 @@
   "mcpName": "io.github.bruchris/canvas-lms-mcp",
   "description": "TypeScript MCP 1.x server for Canvas LMS — 104 tools across Canvas courses, assignments, grades, gradebook history, quizzes, outcomes, discussions, admin workflows, and more.",
   "type": "module",
+  "types": "./dist/server.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/server.d.ts",
       "import": "./dist/server.js",
       "require": "./dist/server.cjs"
     },
     "./stdio": {
+      "types": "./dist/stdio.d.ts",
       "import": "./dist/stdio.js",
       "require": "./dist/stdio.cjs"
     },
     "./http": {
+      "types": "./dist/http.d.ts",
       "import": "./dist/http.js",
       "require": "./dist/http.cjs"
     },
     "./canvas": {
+      "types": "./dist/canvas/index.d.ts",
       "import": "./dist/canvas/index.js",
       "require": "./dist/canvas/index.cjs"
     }
@@ -31,7 +36,7 @@
   ],
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
+    "build": "tsup && tsc -p tsconfig.build.json",
     "generate:manifests": "tsx scripts/generate-manifests.ts",
     "canvas:spec:generate": "tsx scripts/canvas-spec/generate.ts",
     "test": "vitest run",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true
+  }
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     'canvas/index': 'src/canvas/index.ts',
   },
   format: ['esm', 'cjs'],
-  dts: false, // TODO: enable once tsup supports TypeScript 6 DTS generation
+  dts: false,
   clean: true,
   splitting: true,
   sourcemap: true,


### PR DESCRIPTION
## Summary

- Adds `tsconfig.build.json` (extends base, adds `emitDeclarationOnly: true`) as a dedicated declaration emit step
- Updates `build` script to `tsup && tsc -p tsconfig.build.json` — tsup handles JS/CJS bundles, tsc handles `.d.ts`
- Adds `types` condition to all four exports map entries (`.`, `./stdio`, `./http`, `./canvas`) and a top-level `types` field for pre-exports-map consumers
- Removes stale TODO comment from `tsup.config.ts`

**Why not `dts: true` in tsup?** tsup 8.5.1's DTS worker internally sets `baseUrl`, which TypeScript 6 treats as an error (`TS5101`). The `tsc --emitDeclarationOnly` path avoids this and produces declarations that match the entry point structure exactly.

**Tarball includes:**
- `dist/server.d.ts`, `dist/stdio.d.ts`, `dist/http.d.ts`, `dist/cli.d.ts`, `dist/canvas/index.d.ts` (and maps)
- All supporting module `.d.ts` files under `dist/canvas/`, `dist/tools/`, etc.

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 604 tests pass
- [x] `pnpm build` — tsup + tsc both succeed cleanly
- [x] `pnpm pack` — tarball contains `.d.ts` for all entry points

Closes [BRU-624](/BRU/issues/BRU-624)

🤖 Generated with [Claude Code](https://claude.com/claude-code)