### PR TITLE
test: add delegation tests for remaining outcome tools

### DIFF
--- a/tests/tools/outcomes.test.ts
+++ b/tests/tools/outcomes.test.ts
@@ -149,4 +149,61 @@ describe('outcomeTools', () => {
       add_defaults: true,
     })
   })
+
+  it('delegates list_outcome_groups to the outcomes module', async () => {
+    const canvas = buildMockCanvas()
+    const tool = outcomeTools(canvas).find((t) => t.name === 'list_outcome_groups')!
+    await tool.handler({ context_type: 'account', context_id: 7 })
+    expect(canvas.outcomes.listOutcomeGroups).toHaveBeenCalledWith('account', 7)
+  })
+
+  it('delegates get_outcome_group to the outcomes module', async () => {
+    const canvas = buildMockCanvas()
+    const tool = outcomeTools(canvas).find((t) => t.name === 'get_outcome_group')!
+    await tool.handler({ context_type: 'course', context_id: 42, outcome_group_id: 15 })
+    expect(canvas.outcomes.getOutcomeGroup).toHaveBeenCalledWith('course', 42, 15)
+  })
+
+  it('delegates list_outcome_group_outcomes with optional style', async () => {
+    const canvas = buildMockCanvas()
+    const tool = outcomeTools(canvas).find((t) => t.name === 'list_outcome_group_outcomes')!
+    await tool.handler({ context_type: 'course', context_id: 42, outcome_group_id: 15, outcome_style: 'full' })
+    expect(canvas.outcomes.listGroupOutcomes).toHaveBeenCalledWith('course', 42, 15, {
+      outcome_style: 'full',
+    })
+  })
+
+  it('delegates list_outcome_group_subgroups to the outcomes module', async () => {
+    const canvas = buildMockCanvas()
+    const tool = outcomeTools(canvas).find((t) => t.name === 'list_outcome_group_subgroups')!
+    await tool.handler({ context_type: 'account', context_id: 3, outcome_group_id: 8 })
+    expect(canvas.outcomes.listGroupSubgroups).toHaveBeenCalledWith('account', 3, 8)
+  })
+
+  it('delegates get_outcome_alignments with optional filters', async () => {
+    const canvas = buildMockCanvas()
+    const tool = outcomeTools(canvas).find((t) => t.name === 'get_outcome_alignments')!
+    await tool.handler({ course_id: 42, student_id: 10, assignment_id: 5 })
+    expect(canvas.outcomes.getOutcomeAlignments).toHaveBeenCalledWith(42, {
+      student_id: 10,
+      assignment_id: 5,
+    })
+  })
+
+  it('delegates get_outcome_contributing_scores with optional filters', async () => {
+    const canvas = buildMockCanvas()
+    const tool = outcomeTools(canvas).find((t) => t.name === 'get_outcome_contributing_scores')!
+    await tool.handler({
+      course_id: 42,
+      outcome_id: 7,
+      user_ids: [10, 'sis_user_id:xyz'],
+      only_assignment_alignments: true,
+      show_unpublished_assignments: false,
+    })
+    expect(canvas.outcomes.getOutcomeContributingScores).toHaveBeenCalledWith(42, 7, {
+      user_ids: [10, 'sis_user_id:xyz'],
+      only_assignment_alignments: true,
+      show_unpublished_assignments: false,
+    })
+  })
 })

--- a/tests/tools/outcomes.test.ts
+++ b/tests/tools/outcomes.test.ts
@@ -167,7 +167,12 @@ describe('outcomeTools', () => {
   it('delegates list_outcome_group_outcomes with optional style', async () => {
     const canvas = buildMockCanvas()
     const tool = outcomeTools(canvas).find((t) => t.name === 'list_outcome_group_outcomes')!
-    await tool.handler({ context_type: 'course', context_id: 42, outcome_group_id: 15, outcome_style: 'full' })
+    await tool.handler({
+      context_type: 'course',
+      context_id: 42,
+      outcome_group_id: 15,
+      outcome_style: 'full',
+    })
     expect(canvas.outcomes.listGroupOutcomes).toHaveBeenCalledWith('course', 42, 15, {
       outcome_style: 'full',
     })


### PR DESCRIPTION
## Summary

- Adds delegation tests for the 6 untested outcome tools in `tests/tools/outcomes.test.ts`: `list_outcome_groups`, `get_outcome_group`, `list_outcome_group_outcomes`, `list_outcome_group_subgroups`, `get_outcome_alignments`, and `get_outcome_contributing_scores`
- Brings `src/tools/outcomes.ts` from 53.84% to full delegation coverage, matching all other tool modules
- No production code changes — tests only

## Test plan

- [x] All 610 tests pass (`pnpm test`)
- [x] TypeScript strict check passes (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Each new test stubs the matching `canvas.outcomes.*` method, calls `tool.handler()` with realistic params, and asserts the correct delegation

Closes [BRU-625](/BRU/issues/BRU-625)

🤖 Generated with [Claude Code](https://claude.com/claude-code)