### PR TITLE
fix: read User-Agent and MCP server version from package.json

### DIFF
--- a/src/canvas/client.ts
+++ b/src/canvas/client.ts
@@ -1,3 +1,4 @@
+import { version } from '../../package.json'
 import { appendCanvasQuery, type CanvasQueryParams } from './query'
 import type { CanvasClientConfig, CanvasErrorResponse } from './types'
 
@@ -14,7 +15,7 @@ export class CanvasApiError extends Error {
 }
 
 const DEFAULT_MAX_PAGINATION_PAGES = 1000
-const USER_AGENT = 'canvas-lms-mcp/1.0'
+const USER_AGENT = `canvas-lms-mcp/${version}`
 
 export interface CanvasRequestOptions extends RequestInit {
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,4 @@
+import { version } from '../package.json'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { CanvasClient } from './canvas'
 import { registerAllTools } from './tools'
@@ -21,7 +22,7 @@ export function createCanvasMCPServer(config: CanvasMCPServerConfig): CanvasMCPS
 
   const server = new McpServer({
     name: 'canvas-lms-mcp',
-    version: '1.0.0',
+    version,
   })
 
   registerAllTools(server, canvas)

--- a/tests/canvas/client.test.ts
+++ b/tests/canvas/client.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { version } from '../../package.json'
 import { CanvasHttpClient, CanvasApiError } from '../../src/canvas/client'
 
 describe('CanvasHttpClient', () => {
@@ -32,7 +33,7 @@ describe('CanvasHttpClient', () => {
         expect.objectContaining({
           headers: expect.objectContaining({
             Authorization: 'Bearer test-token',
-            'User-Agent': 'canvas-lms-mcp/1.0',
+            'User-Agent': `canvas-lms-mcp/${version}`,
           }),
         }),
       )


### PR DESCRIPTION
## Summary

- Replaces hardcoded `canvas-lms-mcp/1.0` in the `User-Agent` header with `canvas-lms-mcp/${version}` sourced from `package.json`
- Also fixes the hardcoded `version: '1.0.0'` in the MCP server constructor in `src/server.ts` — same issue, same fix
- Updates the `client.test.ts` assertion to import the version from `package.json` so the test stays in sync automatically

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — all 610 tests pass
- [x] `pnpm build` — ESM + CJS build succeeds

Closes BRU-691

🤖 Generated with [Claude Code](https://claude.com/claude-code)