### PR TITLE
feat: add Canvas agent skills bundle (3 skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ MCP server for [Canvas LMS](https://www.instructure.com/canvas). Read courses, a
 
 104 tools across Canvas courses, assignments, submissions, gradebook history, rubrics, quizzes, files, users, groups, enrollments, discussions, modules, pages, calendar, conversations, peer reviews, accounts, analytics, outcomes, student workflows, dashboard, and health checks. Three deployment modes: stdio, HTTP, and library import.
 
+## Agent Skills
+
+Install pre-built AI agent workflows for common Canvas tasks:
+
+```bash
+npx skills add bruchris/canvas-lms-mcp
+```
+
+Available skills:
+
+- **`canvas-at-risk-students`** — Identify struggling students and send outreach messages. Trigger phrases: "who's falling behind", "at-risk students", "students need help"
+- **`canvas-gradebook-audit`** — Trace grade changes before posting finals. Trigger phrases: "who changed grades", "grade history", "grade integrity check"
+- **`canvas-outcome-tracker`** — Generate outcome mastery and accreditation reports. Trigger phrases: "outcome mastery", "accreditation report", "which outcomes are students failing"
+
+Browse all skills at [skills.sh/bruchris/canvas-lms-mcp](https://skills.sh/bruchris/canvas-lms-mcp).
+
 ## Comparison
 
 | | canvas-lms-mcp | [vishalsachdev/canvas-mcp](https://github.com/vishalsachdev/canvas-mcp) | [DMontgomery40/mcp-canvas-lms](https://github.com/DMontgomery40/mcp-canvas-lms) |

--- a/skills/canvas-at-risk-students/SKILL.md
+++ b/skills/canvas-at-risk-students/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: canvas-at-risk-students
+description: Identify struggling students, find who's falling behind, surface at-risk students in a course, and reach out to students who need help. Uses enrollment data, assignment submissions, and course analytics to produce a prioritized list of students, then optionally sends them a Canvas message via send_conversation.
+---
+
+# Canvas At-Risk Students
+
+Identify students who are struggling and initiate outreach — all without leaving your AI assistant.
+
+## Prerequisites
+
+- Canvas MCP server running and connected
+- Teacher or TA role with course read access
+- Messaging permissions to send Canvas conversations
+
+## Steps
+
+### 1. List your courses
+
+Use `list_courses` to retrieve active courses. If you already know the course ID, skip ahead.
+
+### 2. Pull enrollment and analytics data
+
+Call `list_course_enrollments` with the target course ID to get the full student roster. Then call `get_course_analytics` for an overview of participation and grade distribution.
+
+### 3. Fetch assignment and submission data
+
+Call `list_assignments` to get all assignments in the course, then `list_submissions` for each assignment you want to inspect (e.g., past-due or low-scoring work). Look for:
+- Missing submissions (submission_type = null, late = true)
+- Scores well below the class average
+- Patterns of late or unsubmitted work
+
+### 4. Rank at-risk students
+
+Combine the data above to produce a ranked list. Prioritise students with two or more of:
+- Grade below the course passing threshold
+- Two or more missing submissions
+- Low activity score from `get_student_analytics`
+
+### 5. Review individual analytics (optional)
+
+For students near the threshold, call `get_student_analytics` with the student's user ID to see their detailed participation trend before reaching out.
+
+### 6. Send outreach messages
+
+For each student you want to contact, call `send_conversation` with:
+- `recipients`: the student's Canvas user ID
+- `subject`: a warm, non-alarming subject line (e.g., "Checking in on your progress")
+- `body`: a brief, supportive message
+
+Keep the tone supportive and specific. Reference the assignment or area where you've noticed them struggling.
+
+## MCP Tools Used
+
+| Tool | Purpose |
+|------|---------|
+| `list_courses` | Retrieve active courses to find the right course ID |
+| `get_course` | Confirm course details (name, term, student count) |
+| `list_course_enrollments` | Get the full student roster for the course |
+| `get_course_analytics` | High-level grade distribution and participation overview |
+| `get_student_analytics` | Per-student participation trend for borderline cases |
+| `list_assignments` | Enumerate assignments to check for missing work |
+| `list_submissions` | Get submission status and scores per assignment |
+| `send_conversation` | Send a Canvas inbox message to one or more students |
+
+## Example Prompts
+
+- "Show me which students are struggling in my Biology 101 course."
+- "Who's falling behind in course 12345? List anyone with missing assignments or low grades."
+- "Find at-risk students in my course and draft a check-in message to send to each of them."
+- "Which students haven't submitted the last two assignments?"
+
+## Notes / Error Recovery
+
+- If `get_course_analytics` returns empty, the course may not have enough activity yet. Fall back to `list_submissions` to identify missing work directly.
+- `send_conversation` requires messaging to be enabled on the Canvas instance. A 403 error means the token lacks messaging permissions.
+- Student IDs from `list_course_enrollments` are in the `user_id` field — use those as `recipients` in `send_conversation`.
+- This skill works best mid-term or after a major assignment due date; running it in week 1 will produce sparse data.

--- a/skills/canvas-gradebook-audit/SKILL.md
+++ b/skills/canvas-gradebook-audit/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: canvas-gradebook-audit
+description: Audit grade changes before posting finals, trace who changed grades, review grade history for integrity checks, and produce a grade integrity report. Uses Canvas gradebook history tools that no other MCP server exposes.
+---
+
+# Canvas Gradebook Audit
+
+Trace every grade change in a course before finalising grades — catch accidental edits, flag unusual patterns, and produce a clean audit trail for department review.
+
+## Prerequisites
+
+- Canvas MCP server running and connected
+- Instructor or admin role with grade history access
+- Course ID for the course under review
+
+## Steps
+
+### 1. Survey recent grade activity
+
+Call `list_gradebook_history_days` with the course ID to see which days had grade changes. This gives you a high-level calendar of grading activity — useful for narrowing the audit window.
+
+### 2. Drill into a specific day
+
+For any day that looks unusual (high volume of changes, late-night edits, unexpected date), call `get_gradebook_history_day` with the course ID and date. This returns which graders were active and how many changes they made.
+
+### 3. Pull per-submission history
+
+Call `list_gradebook_history_submissions` for the course (optionally filtered by assignment ID or grader ID) to get the full change log: who graded what, what score was set, and when. Each record includes the grader's name and the previous score.
+
+### 4. Cross-reference assignments
+
+Use `list_assignments` and `get_assignment` to verify that the scores recorded in the history are consistent with the assignment's point total and grading type. Flag any entry where the recorded score exceeds max points.
+
+### 5. Get the real-time feed (optional)
+
+For an ongoing course, call `get_gradebook_history_feed` to stream the most recent changes in chronological order — useful for monitoring active grading sessions.
+
+### 6. Compile the audit report
+
+Summarise your findings:
+- Number of grade changes per grader
+- Assignments with the most revisions
+- Any changes made outside normal grading windows
+- Entries where a grade was lowered after initial submission
+
+## MCP Tools Used
+
+| Tool | Purpose |
+|------|---------|
+| `list_gradebook_history_days` | Calendar view of days with grade activity |
+| `get_gradebook_history_day` | Grader summary for a specific date |
+| `list_gradebook_history_submissions` | Full change log: who changed what score and when |
+| `get_gradebook_history_feed` | Real-time ordered feed of recent grade changes |
+| `list_assignments` | Enumerate assignments to cross-reference scores |
+| `get_assignment` | Confirm point totals and grading type for an assignment |
+
+## Example Prompts
+
+- "Who changed grades in my course in the last two weeks? Show me a summary."
+- "Audit the grade history for course 12345 before I post final grades."
+- "Did anyone lower a student's grade on the midterm after it was initially submitted?"
+- "Generate a grade integrity report for my Economics course."
+- "Show me all grade changes made after midnight this semester."
+
+## Notes / Error Recovery
+
+- Gradebook history is only available on courses where the feature is enabled in your Canvas instance. A 404 on `list_gradebook_history_days` usually means the endpoint is disabled — contact your Canvas admin.
+- `list_gradebook_history_submissions` can return large result sets on active courses. Filter by assignment ID to keep results manageable.
+- Grader IDs in the history map to Canvas user IDs. Use `get_course` or `list_course_enrollments` to resolve names if the history only returns IDs.
+- This skill surfaces what changed, not why. Use it alongside your department's grading policy to decide whether a change warrants follow-up.

--- a/skills/canvas-outcome-tracker/SKILL.md
+++ b/skills/canvas-outcome-tracker/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: canvas-outcome-tracker
+description: Generate an outcome mastery report, track learning outcomes for accreditation, produce an outcomes report for program review, and identify which outcomes students are failing. Covers the full Canvas outcomes hierarchy — groups, standards, rollups, and mastery distributions.
+---
+
+# Canvas Outcome Tracker
+
+Map student mastery across your learning outcomes — produce the accreditation evidence, program-review summaries, and course-level reports your institution needs.
+
+## Prerequisites
+
+- Canvas MCP server running and connected
+- Instructor or admin role with outcome access
+- Course ID (or account ID for institution-wide reports)
+
+## Steps
+
+### 1. Retrieve the outcome hierarchy
+
+Call `get_root_outcome_group` with the course ID to get the top-level outcome group. This is the entry point to the full outcome tree for the course or account.
+
+### 2. Enumerate outcomes in each group
+
+Call `list_outcome_group_outcomes` with the group ID to list the specific learning outcomes inside that group. Repeat for sub-groups as needed. Each outcome record includes the mastery point threshold.
+
+### 3. Pull outcome results
+
+Call `get_outcome_results` with the course ID and optionally an outcome ID to get individual student alignment scores — how each student performed on each outcome across assessed assignments.
+
+### 4. Get rollup summaries
+
+Call `get_outcome_rollups` with the course ID to retrieve aggregated mastery scores per student and per outcome. This is the most compact view for reporting — one row per student, one column per outcome, with a mastery/near mastery/not mastered rating.
+
+### 5. Analyse mastery distribution
+
+Call `get_outcome_mastery_distribution` with the course ID and an outcome ID to see the class-wide distribution: how many students are mastered, near mastery, or not mastered. Repeat for each outcome you want to report on.
+
+### 6. Cross-reference enrollment (optional)
+
+Use `list_course_enrollments` to map student IDs from the rollup data back to names and sections, ensuring your report is human-readable.
+
+### 7. Compile the report
+
+Structure your findings by outcome group or accreditation standard. For each outcome, report:
+- Class mastery rate (% mastered)
+- Distribution breakdown
+- Students below mastery threshold who may need intervention
+
+## MCP Tools Used
+
+| Tool | Purpose |
+|------|---------|
+| `get_root_outcome_group` | Entry point: top-level outcome group for the course or account |
+| `list_outcome_group_outcomes` | Enumerate individual outcomes within a group |
+| `get_outcome_results` | Raw per-student, per-outcome alignment scores |
+| `get_outcome_rollups` | Aggregated mastery rollup: one summary row per student |
+| `get_outcome_mastery_distribution` | Class-wide mastery distribution for a single outcome |
+| `list_course_enrollments` | Resolve student IDs to names for readable reports |
+
+## Example Prompts
+
+- "Generate an outcome mastery report for my course."
+- "Which outcomes are students failing in course 12345?"
+- "Produce an accreditation report showing mastery rates across all learning outcomes."
+- "What percentage of students have mastered the critical thinking outcome?"
+- "Give me a program-review summary of outcome performance for this semester."
+
+## Notes / Error Recovery
+
+- Outcomes must be aligned to assignments in Canvas before `get_outcome_results` returns data. If results are empty, verify that rubric criteria link to outcomes.
+- `get_outcome_rollups` returns a `rollups` array keyed by student ID. If the course has many students, the response may be paginated — the tool handles pagination automatically.
+- `get_outcome_mastery_distribution` requires an outcome ID, not a group ID. Use `list_outcome_group_outcomes` first to get individual outcome IDs.
+- Accreditation bodies typically want course-level rollups, not individual student scores. Use `get_outcome_rollups` with `aggregate_stat=mean` or `median` depending on your institution's reporting standard.


### PR DESCRIPTION
## Summary

- Adds 3 Canvas agent skills under `skills/` for distribution via `npx skills add bruchris/canvas-lms-mcp`
- `canvas-at-risk-students`: identify struggling students and send Canvas outreach messages
- `canvas-gradebook-audit`: trace grade changes before posting finals (uses our unique gradebook-history tools)
- `canvas-outcome-tracker`: learning outcome mastery and accreditation reports (uses 6 outcome tools)
- Updates README with Agent Skills section and install command

## Notes

- Pure markdown SKILL.md files — no code changes, no new deps, no test changes
- All tool names verified against `src/tools/` registry before writing (corrected `get_student_summaries` → `get_student_analytics`, confirmed `send_conversation` not `create_conversation`)
- Skills are out-of-package (GitHub-only) per scoping decision in [BRU-615](/BRU/issues/BRU-615)

## Test plan

- [x] `pnpm typecheck` passes (no TS changes)
- [x] `pnpm test` passes (610 tests, no skill-related code)
- [x] `pnpm build` passes

Closes #88
Closes BRU-698

🤖 Generated with [Claude Code](https://claude.com/claude-code)