### PR TITLE
feat: add Canvas agent skills bundle (skills.sh launch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,22 @@ The MCP endpoint is `http://localhost:3001/mcp`. Per-request credentials can be 
 
 </details>
 
+## Agent Skills
+
+Install reusable Canvas workflows into Claude Code, Cursor, GitHub Copilot, Cline, and 40+ other AI agents:
+
+```bash
+npx skills add bruchris/canvas-lms-mcp
+```
+
+| Skill | Description |
+|-------|-------------|
+| `canvas-at-risk-students` | Surface students with missing assignments or declining grades and send targeted outreach |
+| `canvas-gradebook-audit` | Inspect the full grade-change audit trail — who changed what grade, when, and by how much |
+| `canvas-outcome-tracker` | Track learning outcome mastery and class-wide proficiency for accreditation and program review |
+
+Skills are markdown workflow files (no extra dependencies). They work with the MCP server you already have installed. See the [`skills/` directory](./skills/) for the full list.
+
 ## Example Prompts
 
 Once configured, try these prompts with your AI client:

--- a/skills/canvas-at-risk-students/SKILL.md
+++ b/skills/canvas-at-risk-students/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: canvas-at-risk-students
+description: Identify at-risk Canvas students and send targeted outreach. Surfaces students with missing assignments, low grades, or declining submission patterns — then lets you message them directly. Trigger phrases include "at-risk students", "struggling students", "who's falling behind", "students to check in with", or "missing submissions".
+---
+
+# Canvas At-Risk Students
+
+Identify students who are falling behind and reach out to them without leaving your agent session.
+
+## Prerequisites
+
+- Canvas MCP server must be running and connected.
+- You must have instructor or TA role in the target course.
+- Student names are visible in output — only run this in a private or educator-only session.
+
+## Steps
+
+### 1. Identify the Target Course
+
+Ask the user which course to check. Accept a course name, course code, or Canvas ID.
+
+If unclear, call `list_courses` to let the user select from their active courses.
+
+### 2. Retrieve Enrolled Students
+
+Call `list_course_enrollments` with `type=StudentEnrollment` and `state=active` to get the active student roster. Note the student user IDs — you will need them for individual lookups.
+
+### 3. Collect Submission Data
+
+Call `list_assignments` to get all assignments with due dates in the **past 4 weeks**. For each assignment:
+
+1. Call `list_submissions` filtered to that assignment.
+2. Flag any student whose submission `workflow_state` is `unsubmitted` or whose score is missing.
+
+Build a per-student tally: missing assignment count and submitted-on-time count.
+
+### 4. Classify by Risk Tier
+
+| Tier | Criteria |
+|------|----------|
+| **Critical** | 3 or more missing assignments in the past 4 weeks |
+| **Needs attention** | 1–2 missing assignments, or a `get_student_analytics` score trend showing decline |
+| **On track** | All assignments submitted |
+
+For students in Critical or Needs Attention tiers, call `get_student_analytics` (with their user ID and the course ID) to confirm the pattern and surface their current grade.
+
+### 5. Present the At-Risk List
+
+Show a table:
+
+| Student | Missing Assignments | Current Grade | Risk Tier |
+|---------|--------------------|--------------:|-----------|
+| …       | …                  | …             | Critical  |
+
+Ask the instructor: "Would you like to send a check-in message to any of these students?"
+
+### 6. Send Outreach (Optional)
+
+For each student the instructor wants to contact, call `send_conversation` with:
+
+- `recipients`: the student's Canvas user ID (from the enrollment list)
+- `subject`: a brief subject line (suggest a default, let instructor edit)
+- `body`: a supportive check-in message (draft one, let instructor approve before sending)
+
+Confirm each message before sending. Report which students were contacted.
+
+## Output Format
+
+```
+At-Risk Students — [Course Name]  (checked [date range])
+
+CRITICAL (3+ missing)
+• Jane Smith — missing 4 of 5 assignments, current grade 41%
+  → Message sent ✓
+
+NEEDS ATTENTION (1–2 missing)
+• Alex Doe — missing 1 assignment, grade trending from 78% → 68%
+  → Instructor chose to skip
+
+ON TRACK: 24 students
+```
+
+## Notes
+
+- This skill does not grade or modify any submissions — it is read-only except for the optional outreach step.
+- Use `send_conversation` only after explicit instructor confirmation per student.
+- For large courses (100+ students), process assignments in batches to stay within Canvas rate limits.

--- a/skills/canvas-gradebook-audit/SKILL.md
+++ b/skills/canvas-gradebook-audit/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: canvas-gradebook-audit
+description: Audit gradebook changes and grade edit history in Canvas. Surfaces who changed which grades, when, and by how much — across a date range or for a specific student. Unique to canvas-lms-mcp (no competitor exposes gradebook history). Trigger phrases include "grade audit", "who changed this grade", "gradebook history", "grade edits", "check for grade changes", or "grade integrity".
+---
+
+# Canvas Gradebook Audit
+
+Inspect the full audit trail of grade changes in a Canvas course. Useful for grade integrity checks, accreditation reviews, and catching accidental bulk edits.
+
+## Prerequisites
+
+- Canvas MCP server must be running and connected.
+- You must have instructor or admin role — grade history is restricted to privileged roles.
+- Canvas must have gradebook history enabled on the instance (most institutions do).
+
+## Steps
+
+### 1. Identify the Target Course
+
+Ask the user which course to audit. Accept a course name, code, or Canvas ID.
+
+If unclear, call `list_courses` to let them select.
+
+### 2. Choose Audit Scope
+
+Ask the user one of:
+- **Date range**: "Audit grade changes between [start date] and [end date]"
+- **Assignment focus**: "Show all grade edits for a specific assignment"
+- **Student focus**: "Show all grade edits for a specific student"
+
+Default to the **past 30 days** if no range is given.
+
+### 3. Retrieve History Days
+
+Call `list_gradebook_history_days` with the course ID. This returns a list of calendar days that had grade activity, with a summary count per day.
+
+Filter to the user's requested date range.
+
+### 4. Drill Into Each Day
+
+For each day with activity, call `get_gradebook_history_day` with the course ID and the date string. This returns the graders who made changes and the assignments they touched.
+
+Build a running summary:
+- Grader name
+- Number of submissions edited
+- Assignments affected
+
+### 5. Inspect Individual Edits (When Requested)
+
+If the user wants to see the specific before/after values for a submission, call `list_gradebook_history_submissions` with the course ID, grader ID, assignment ID, and date. This returns per-student grade change records with old score, new score, and timestamp.
+
+For a full chronological feed without filtering by grader, use `get_gradebook_history_feed` with the course ID (and optionally assignment ID or student ID).
+
+### 6. Present the Audit Report
+
+```
+Gradebook Audit — [Course Name]
+Period: [start date] → [end date]
+
+SUMMARY
+Total days with grade activity: 7
+Total grade edits: 143
+Graders active: 3
+
+BREAKDOWN BY GRADER
+• Prof. Martinez — 98 edits across 4 assignments (Apr 10–18)
+• TA Chen — 42 edits across 2 assignments (Apr 12–14)
+• System (auto-grade) — 3 edits (Apr 20)
+
+NOTABLE CHANGES
+• Assignment "Midterm Essay" — 12 students had scores changed on Apr 14
+  Old avg: 71.2  →  New avg: 78.4  (grader: TA Chen)
+
+• Student "Alex Doe" — grade changed 3 times on Apr 18 (possible error)
+```
+
+Ask the instructor if they want to export details or investigate any specific entry further.
+
+## Notes
+
+- This skill is **read-only** — it audits but does not modify grades.
+- Gradebook history is append-only in Canvas; this skill surfaces the official audit log.
+- For courses with thousands of submissions, use date range narrowing to stay within API rate limits.
+- The four gradebook history tools used here (`list_gradebook_history_days`, `get_gradebook_history_day`, `list_gradebook_history_submissions`, `get_gradebook_history_feed`) are unique to canvas-lms-mcp and not available in other Canvas MCP servers.

--- a/skills/canvas-outcome-tracker/SKILL.md
+++ b/skills/canvas-outcome-tracker/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: canvas-outcome-tracker
+description: Track student mastery of learning outcomes in Canvas. Shows outcome rollups by student, mastery distribution across the class, and which outcomes have the lowest proficiency rates. Built for accreditation reviews, program assessment, and advising. Trigger phrases include "outcome tracker", "learning outcomes", "mastery data", "accreditation report", "outcome mastery", or "who hasn't mastered".
+---
+
+# Canvas Outcome Tracker
+
+Surface learning outcome mastery data across a course — by outcome, by student, or by group — to support program assessment and accreditation reporting.
+
+## Prerequisites
+
+- Canvas MCP server must be running and connected.
+- You must have instructor or admin role in the target course.
+- The course must have outcomes aligned to assignments (contact your Canvas admin if outcomes are not visible).
+
+## Steps
+
+### 1. Identify the Target Course
+
+Ask the user which course to analyse. Accept a course name, code, or Canvas ID.
+
+If unclear, call `list_courses` to let them select.
+
+### 2. Load the Outcome Structure
+
+Call `get_root_outcome_group` to get the top-level outcome group for the course. Then call `list_outcome_groups` to retrieve all outcome groups in the course.
+
+For each group, call `list_outcome_group_outcomes` to enumerate the individual outcomes. Build a flat list:
+- Outcome ID
+- Outcome title
+- Mastery points threshold
+
+Ask the user if they want to focus on a specific outcome group or review all outcomes.
+
+### 3. Choose Report Type
+
+Offer three modes:
+
+| Mode | Description |
+|------|-------------|
+| **Class overview** | Mastery distribution for all outcomes at once |
+| **Per-student rollup** | Which outcomes each student has or hasn't mastered |
+| **Single outcome deep-dive** | All students' results for one outcome |
+
+### 4A. Class Overview — Mastery Distribution
+
+For each outcome, call `get_outcome_mastery_distribution` with the course ID and outcome ID. This returns the count of students at each mastery level (exceeds / meets / approaching / not yet).
+
+Summarise as a ranked table, lowest mastery first:
+
+```
+Outcome Mastery Distribution — [Course Name]
+
+LOWEST MASTERY (action needed)
+• "Critical Analysis" — 38% not yet mastered (19/50 students)
+• "APA Citation" — 24% not yet mastered (12/50 students)
+
+MEETING EXPECTATIONS
+• "Thesis Construction" — 82% mastered
+• "Research Synthesis" — 79% mastered
+```
+
+### 4B. Per-Student Rollup
+
+Call `get_outcome_rollups` with the course ID. This returns each student's rolled-up mastery status per outcome.
+
+Format as a matrix or highlight students with 3+ unmastered outcomes as high-priority advising targets.
+
+### 4C. Single Outcome Deep-Dive
+
+Call `get_outcome_results` with the course ID and outcome ID to retrieve individual student result records — score, alignment source, and mastery status.
+
+Call `get_outcome_contributing_scores` for the detailed score breakdown per student if the user wants to see which assignments contributed to mastery.
+
+### 5. Present Actionable Recommendations
+
+Based on the data, suggest:
+- Outcomes to reteach or remediate
+- Students to flag for advising (multiple unmastered outcomes)
+- Alignment gaps (outcomes with zero results — may not be linked to assignments)
+
+Ask if the instructor wants to export the data or drill further into any outcome.
+
+## Output Format
+
+```
+Outcome Tracker — [Course Name]
+
+SUMMARY
+Total outcomes tracked: 12
+Students at or above mastery on all outcomes: 31/50 (62%)
+Outcomes needing attention (< 70% mastery): 3
+
+AT-RISK STUDENTS (3+ unmastered outcomes)
+• Jordan Lee — 5 unmastered outcomes
+• Sam Park — 4 unmastered outcomes
+
+OUTCOME HEALTH SNAPSHOT
+✗ Critical Analysis        38% mastered  ← reteach recommended
+✗ APA Citation            64% mastered
+✗ Thesis Construction     68% mastered
+✓ Research Synthesis      79% mastered
+✓ Source Evaluation       84% mastered
+```
+
+## Notes
+
+- This skill is fully **read-only** — it reports mastery data but does not modify outcomes or grades.
+- Outcome results are only available for outcomes that have been aligned to graded assignments. Unaligned outcomes will show zero results.
+- For accreditation exports, gather the output from `get_outcome_rollups` and `get_outcome_mastery_distribution` — these map directly to standard program assessment formats.
+- `get_outcome_contributing_scores` provides the most granular data and may be slow on large courses; use it selectively.


### PR DESCRIPTION
## Summary

- Adds three SKILL.md workflow files under `skills/` installable via `npx skills add bruchris/canvas-lms-mcp` across 45+ AI agents (Claude Code, Cursor, GitHub Copilot, Cline, Codex, etc.)
- `canvas-at-risk-students` — flags students with missing assignments or low grades, sends outreach via `send_conversation`
- `canvas-gradebook-audit` — full grade-change audit trail using our 4 exclusive `gradebook_history_*` tools
- `canvas-outcome-tracker` — mastery rollups and class-wide proficiency distribution using our 12 outcomes tools
- Adds "Agent Skills" section to README with install command and skill table

## Why these three

Both `canvas-gradebook-audit` and `canvas-outcome-tracker` use tool domains that no competitor MCP server exposes — strong differentiation from vishalsachdev/canvas-mcp. `canvas-at-risk-students` completes the educator trifecta.

## No code changes

Skills are pure markdown. All Canvas MCP tools referenced already exist and are tested.

## Test plan

- [x] `pnpm build` — clean (207ms)
- [x] `pnpm test` — 582/582 passing
- [x] `pnpm lint` — clean
- [x] Verified all tool names against `src/tools/` source (no invented names; `send_conversation` used, not `create_conversation`)
- [x] No FERPA/`ENABLE_DATA_ANONYMIZATION` language copied from competitor — we don't have that env var

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)