### PR TITLE
feat(files): add download_file MCP tool to fetch file content

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 105,
+  "toolCount": 106,
   "tools": [
     {
       "name": "health_check",
@@ -396,6 +396,18 @@
         "openWorldHint": true
       },
       "access": "write",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "download_file",
+      "domain": "files",
+      "description": "Download the content of a Canvas file by ID. Text files (plain text, HTML, JSON, XML, JavaScript) are returned as readable text. Binary files (images, PDFs, etc.) are returned as base64-encoded data. Files larger than 10 MB are refused.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
       "primaryAudience": "shared",
       "relatedWorkflows": []
     },

--- a/src/canvas/files.ts
+++ b/src/canvas/files.ts
@@ -1,5 +1,19 @@
 import type { CanvasHttpClient } from './client'
-import type { CanvasFile, CanvasFileUploadInfo, CanvasFolder } from './types'
+import type { CanvasFile, CanvasFileUploadInfo, CanvasFolder, DownloadedFile } from './types'
+
+const MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024 // 10 MB
+
+const TEXT_CONTENT_TYPES = new Set([
+  'application/json',
+  'application/xml',
+  'application/javascript',
+  'application/x-javascript',
+])
+
+function isTextContentType(contentType: string): boolean {
+  const base = (contentType.split(';')[0] ?? '').trim().toLowerCase()
+  return base.startsWith('text/') || TEXT_CONTENT_TYPES.has(base)
+}
 
 export class FilesModule {
   constructor(private client: CanvasHttpClient) {}
@@ -112,6 +126,63 @@ export class FilesModule {
       )
     }
     return parsed as CanvasFile
+  }
+
+  async download(fileId: number, courseId?: number): Promise<DownloadedFile> {
+    const endpoint =
+      courseId != null ? `/api/v1/courses/${courseId}/files/${fileId}` : `/api/v1/files/${fileId}`
+    const meta = await this.client.request<CanvasFile>(endpoint)
+
+    if (meta.size > MAX_DOWNLOAD_BYTES) {
+      throw new Error(
+        `File too large to download (${meta.size.toLocaleString()} bytes; limit is 10 MB)`,
+      )
+    }
+
+    const response = await fetch(meta.url)
+    if (!response.ok) {
+      throw new Error(`Failed to download file content (HTTP ${response.status})`)
+    }
+
+    const contentLengthHeader = response.headers.get('content-length')
+    if (contentLengthHeader != null) {
+      const declared = parseInt(contentLengthHeader, 10)
+      if (!isNaN(declared) && declared > MAX_DOWNLOAD_BYTES) {
+        throw new Error(
+          `File too large to download (${declared.toLocaleString()} bytes declared; limit is 10 MB)`,
+        )
+      }
+    }
+
+    const contentType = (
+      (response.headers.get('content-type') ?? meta.content_type).split(';')[0] ?? ''
+    ).trim()
+    const filename = meta.display_name ?? meta.filename ?? `file-${fileId}`
+    const buffer = await response.arrayBuffer()
+
+    if (buffer.byteLength > MAX_DOWNLOAD_BYTES) {
+      throw new Error(
+        `File too large to download (${buffer.byteLength.toLocaleString()} bytes; limit is 10 MB)`,
+      )
+    }
+
+    if (isTextContentType(contentType)) {
+      return {
+        type: 'text',
+        filename,
+        contentType,
+        size: buffer.byteLength,
+        text: Buffer.from(buffer).toString('utf-8'),
+      }
+    }
+
+    return {
+      type: 'resource',
+      filename,
+      contentType,
+      size: buffer.byteLength,
+      base64: Buffer.from(buffer).toString('base64'),
+    }
   }
 
   async delete(fileId: number): Promise<CanvasFile> {

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -457,6 +457,15 @@ export interface CanvasFileUploadInfo {
   upload_params: Record<string, string>
 }
 
+export interface DownloadedFile {
+  type: 'text' | 'resource'
+  filename: string
+  contentType: string
+  size: number
+  text?: string
+  base64?: string
+}
+
 // --- Users ---
 
 export interface CanvasUser {

--- a/src/tools/files.ts
+++ b/src/tools/files.ts
@@ -93,5 +93,26 @@ export function fileTools(canvas: CanvasClient): ToolDefinition[] {
         return canvas.files.delete(file_id)
       },
     },
+    {
+      name: 'download_file',
+      description:
+        'Download the content of a Canvas file by ID. Text files (plain text, HTML, JSON, XML, JavaScript) are returned as readable text. Binary files (images, PDFs, etc.) are returned as base64-encoded data. Files larger than 10 MB are refused.',
+      inputSchema: {
+        file_id: z.number().describe('The Canvas file ID'),
+        course_id: z
+          .number()
+          .optional()
+          .describe('Optional Canvas course ID to scope the file lookup'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const file_id = params.file_id as number
+        const course_id = params.course_id as number | undefined
+        return canvas.files.download(file_id, course_id)
+      },
+    },
   ]
 }

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(105)
+    expect(manifest.tools).toHaveLength(106)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/files.test.ts
+++ b/tests/files.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { FilesModule } from '../src/canvas/files'
+import type { CanvasHttpClient } from '../src/canvas/client'
+import type { CanvasFile } from '../src/canvas/types'
+
+const BASE_META: CanvasFile = {
+  id: 42,
+  display_name: 'notes.txt',
+  filename: 'notes.txt',
+  content_type: 'text/plain',
+  url: 'https://cdn.example.com/files/42/download?token=abc',
+  size: 12,
+  folder_id: 1,
+}
+
+function makeMockClient(requestImpl: (endpoint: string) => unknown): CanvasHttpClient {
+  return { request: vi.fn().mockImplementation(requestImpl) } as unknown as CanvasHttpClient
+}
+
+function makeResponse(options: {
+  ok?: boolean
+  status?: number
+  contentType?: string
+  contentLength?: string | null
+  body: string | Uint8Array
+}): Response {
+  const {
+    ok = true,
+    status = 200,
+    contentType = 'text/plain',
+    contentLength = null,
+    body,
+  } = options
+  const bodyBytes = typeof body === 'string' ? new TextEncoder().encode(body) : body
+  return {
+    ok,
+    status,
+    headers: {
+      get: (name: string) => {
+        if (name === 'content-type') return contentType
+        if (name === 'content-length') return contentLength
+        return null
+      },
+    },
+    arrayBuffer: async () => bodyBytes.buffer as ArrayBuffer,
+  } as unknown as Response
+}
+
+describe('FilesModule.download', () => {
+  let client: CanvasHttpClient
+  let files: FilesModule
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns text content for text/plain file', async () => {
+    client = makeMockClient(() => ({ ...BASE_META, content_type: 'text/plain', size: 5 }))
+    files = new FilesModule(client)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(makeResponse({ contentType: 'text/plain', body: 'hello' })),
+    )
+
+    const result = await files.download(42)
+
+    expect(result.type).toBe('text')
+    expect(result.text).toBe('hello')
+    expect(result.contentType).toBe('text/plain')
+    expect(result.filename).toBe('notes.txt')
+    expect(result.base64).toBeUndefined()
+  })
+
+  it('uses /api/v1/courses/:courseId/files/:fileId when courseId is provided', async () => {
+    client = makeMockClient(() => ({ ...BASE_META }))
+    files = new FilesModule(client)
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeResponse({ body: 'hi' })))
+
+    await files.download(42, 7)
+
+    expect(client.request).toHaveBeenCalledWith('/api/v1/courses/7/files/42')
+  })
+
+  it('uses /api/v1/files/:fileId when courseId is omitted', async () => {
+    client = makeMockClient(() => ({ ...BASE_META }))
+    files = new FilesModule(client)
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeResponse({ body: 'hi' })))
+
+    await files.download(42)
+
+    expect(client.request).toHaveBeenCalledWith('/api/v1/files/42')
+  })
+
+  it('returns resource with base64 for binary file (application/pdf)', async () => {
+    const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]) // %PDF
+    client = makeMockClient(() => ({ ...BASE_META, content_type: 'application/pdf', size: 4 }))
+    files = new FilesModule(client)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(makeResponse({ contentType: 'application/pdf', body: pdfBytes })),
+    )
+
+    const result = await files.download(42)
+
+    expect(result.type).toBe('resource')
+    expect(result.base64).toBe(Buffer.from(pdfBytes).toString('base64'))
+    expect(result.text).toBeUndefined()
+  })
+
+  it('returns text for application/json', async () => {
+    const json = '{"key":"value"}'
+    client = makeMockClient(() => ({
+      ...BASE_META,
+      content_type: 'application/json',
+      size: json.length,
+    }))
+    files = new FilesModule(client)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(makeResponse({ contentType: 'application/json', body: json })),
+    )
+
+    const result = await files.download(42)
+
+    expect(result.type).toBe('text')
+    expect(result.text).toBe(json)
+  })
+
+  it('returns resource for application/octet-stream (binary fallthrough)', async () => {
+    const bytes = new Uint8Array([0x00, 0xff, 0x10])
+    client = makeMockClient(() => ({
+      ...BASE_META,
+      content_type: 'application/octet-stream',
+      size: 3,
+    }))
+    files = new FilesModule(client)
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(makeResponse({ contentType: 'application/octet-stream', body: bytes })),
+    )
+
+    const result = await files.download(42)
+
+    expect(result.type).toBe('resource')
+    expect(result.base64).toBeDefined()
+  })
+
+  it('rejects file larger than 10 MB based on metadata size', async () => {
+    const oversizedMeta = { ...BASE_META, size: 11 * 1024 * 1024 }
+    client = makeMockClient(() => oversizedMeta)
+    files = new FilesModule(client)
+
+    await expect(files.download(42)).rejects.toThrow('too large')
+  })
+
+  it('rejects file when Content-Length header exceeds 10 MB', async () => {
+    client = makeMockClient(() => ({ ...BASE_META, size: 100 })) // metadata says small
+    files = new FilesModule(client)
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          makeResponse({ contentLength: String(11 * 1024 * 1024), body: 'small' }),
+        ),
+    )
+
+    await expect(files.download(42)).rejects.toThrow('too large')
+  })
+
+  it('throws when the signed download URL returns a non-OK response', async () => {
+    client = makeMockClient(() => ({ ...BASE_META }))
+    files = new FilesModule(client)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(makeResponse({ ok: false, status: 403, body: '' })),
+    )
+
+    await expect(files.download(42)).rejects.toThrow('HTTP 403')
+  })
+
+  it('propagates CanvasApiError from metadata lookup (404)', async () => {
+    const { CanvasApiError } = await import('../src/canvas/client')
+    client = makeMockClient(() => {
+      throw new CanvasApiError('Not Found', 404, '/api/v1/files/99')
+    })
+    files = new FilesModule(client)
+
+    await expect(files.download(99)).rejects.toThrow('Not Found')
+  })
+})

--- a/tests/tools/files.test.ts
+++ b/tests/tools/files.test.ts
@@ -24,6 +24,14 @@ describe('fileTools', () => {
     folders_count: 2,
   }
 
+  const mockDownloadedFile = {
+    type: 'text' as const,
+    filename: 'syllabus.pdf',
+    contentType: 'text/plain',
+    size: 5,
+    text: 'hello',
+  }
+
   function buildMockCanvas(): CanvasClient {
     return {
       files: {
@@ -32,17 +40,25 @@ describe('fileTools', () => {
         get: vi.fn().mockResolvedValue(mockFile),
         upload: vi.fn().mockResolvedValue(mockFile),
         delete: vi.fn().mockResolvedValue(mockFile),
+        download: vi.fn().mockResolvedValue(mockDownloadedFile),
       },
     } as unknown as CanvasClient
   }
 
-  it('returns an array with 5 tool definitions', () => {
-    expect(fileTools(buildMockCanvas())).toHaveLength(5)
+  it('returns an array with 6 tool definitions', () => {
+    expect(fileTools(buildMockCanvas())).toHaveLength(6)
   })
 
   it('exports tools with correct names', () => {
     const names = fileTools(buildMockCanvas()).map((t) => t.name)
-    expect(names).toEqual(['list_files', 'list_folders', 'get_file', 'upload_file', 'delete_file'])
+    expect(names).toEqual([
+      'list_files',
+      'list_folders',
+      'get_file',
+      'upload_file',
+      'delete_file',
+      'download_file',
+    ])
   })
 
   describe('list_files', () => {
@@ -145,6 +161,28 @@ describe('fileTools', () => {
       const result = await tool.handler({ file_id: 99 })
       expect(canvas.files.delete).toHaveBeenCalledWith(99)
       expect(result).toMatchObject({ id: mockFile.id })
+    })
+  })
+
+  describe('download_file', () => {
+    it('has read-only annotations', () => {
+      const tool = fileTools(buildMockCanvas()).find((t) => t.name === 'download_file')!
+      expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+    })
+
+    it('delegates to canvas.files.download with file_id and optional course_id', async () => {
+      const canvas = buildMockCanvas()
+      const tool = fileTools(canvas).find((t) => t.name === 'download_file')!
+      const result = await tool.handler({ file_id: 42, course_id: 7 })
+      expect(canvas.files.download).toHaveBeenCalledWith(42, 7)
+      expect(result).toEqual(mockDownloadedFile)
+    })
+
+    it('passes undefined course_id when not provided', async () => {
+      const canvas = buildMockCanvas()
+      const tool = fileTools(canvas).find((t) => t.name === 'download_file')!
+      await tool.handler({ file_id: 42 })
+      expect(canvas.files.download).toHaveBeenCalledWith(42, undefined)
     })
   })
 })

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -47,6 +47,7 @@ function buildFullMockCanvas(): CanvasClient {
       get: async () => ({}),
       upload: async () => ({}),
       delete: async () => undefined,
+      download: async () => ({}),
     },
     gradebookHistory: {
       listDays: async () => [],
@@ -190,12 +191,13 @@ describe('getAllTools', () => {
     expect(names).toContain('list_quiz_questions')
     expect(names).toContain('get_quiz_submission_answers')
     expect(names).toContain('score_quiz_question')
-    // Files (5)
+    // Files (6)
     expect(names).toContain('list_files')
     expect(names).toContain('list_folders')
     expect(names).toContain('get_file')
     expect(names).toContain('upload_file')
     expect(names).toContain('delete_file')
+    expect(names).toContain('download_file')
     // Gradebook History (4)
     expect(names).toContain('list_gradebook_history_days')
     expect(names).toContain('get_gradebook_history_day')
@@ -286,7 +288,7 @@ describe('getAllTools', () => {
     expect(names).toContain('get_upcoming_events')
     expect(names).toContain('get_missing_submissions')
 
-    expect(tools).toHaveLength(105)
+    expect(tools).toHaveLength(106)
   })
 
   it('all tools have openWorldHint: true', () => {


### PR DESCRIPTION
## Summary

- Adds a `download_file` MCP tool that fetches actual Canvas file content (not just metadata/URL)
- Text-type content (`text/*`, `application/json`, `application/xml`, `application/javascript`) is returned as `{ type: 'text', text: ... }` in the structured envelope
- Binary content is returned as `{ type: 'resource', base64: ... }` so the agent can handle it
- Hard cap of 10 MB enforced at three points: file metadata `size` field, `Content-Length` response header, and post-read buffer length
- `course_id` is optional — without it, uses `/api/v1/files/:id` (global Canvas file endpoint)

## Design note: structured envelope vs raw text

The tool returns a `DownloadedFile` JSON object in all cases (serialized as text by the existing `registerAllTools` wrapper), rather than returning the raw file content as a plain MCP `text` block. This keeps the response self-describing (includes `filename`, `contentType`, `size`, `type`) and avoids the ambiguity of "is this the file or an error message?" — which is important for binary files that must be base64 anyway.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (Prettier + ESLint)
- [x] `pnpm test` — 623/623 tests pass (57 test files)
  - New `tests/files.test.ts` covers: text happy path, course-scoped vs global endpoint, binary base64, application/json as text, application/octet-stream as binary, 10 MB metadata reject, Content-Length reject, non-OK download URL, 404 CanvasApiError propagation
- [x] `pnpm build` — clean ESM + CJS build

🤖 Generated with [Claude Code](https://claude.ai/claude-code)