### PR TITLE
fix(users): read User-Agent version from package.json in generated client

### DIFF
--- a/src/canvas/generated/users-client.ts
+++ b/src/canvas/generated/users-client.ts
@@ -16,6 +16,7 @@
  *     header that don't fit openapi-fetch's path-templated API surface.
  */
 import createClient, { type Middleware } from 'openapi-fetch'
+import { version } from '../../../package.json'
 import { CanvasApiError } from '../client'
 import type {
   CanvasClientConfig,
@@ -37,7 +38,7 @@ import type {
 import type { paths } from './types'
 
 const DEFAULT_MAX_PAGINATION_PAGES = 1000
-const USER_AGENT = 'canvas-lms-mcp/1.0'
+const USER_AGENT = `canvas-lms-mcp/${version}`
 const DEFAULT_PER_PAGE = 100
 
 type OpenApiClient = ReturnType<typeof createClient<paths>>

--- a/tests/canvas/generated-users.test.ts
+++ b/tests/canvas/generated-users.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { version } from '../../package.json'
 import { GeneratedUsersModule } from '../../src/canvas/generated/users-client'
 import { CanvasApiError } from '../../src/canvas/client'
 
@@ -54,7 +55,7 @@ describe('GeneratedUsersModule', () => {
       await users.get(1)
       const headers = lastCallHeaders()
       expect(headers.get('Authorization')).toBe('Bearer test-token')
-      expect(headers.get('User-Agent')).toMatch(/canvas-lms-mcp/)
+      expect(headers.get('User-Agent')).toBe(`canvas-lms-mcp/${version}`)
     })
 
     it('resolves requests against the configured base URL', async () => {


### PR DESCRIPTION
## Summary

- Fixes a regression introduced after PR #86: `src/canvas/generated/users-client.ts` was left with a hardcoded `'canvas-lms-mcp/1.0'` User-Agent string
- Now imports `version` from `../../../package.json` and uses `` `canvas-lms-mcp/${version}` `` — identical pattern to `client.ts`
- Closes BRU-794

## Root Cause

PR #86 (`fix: read User-Agent and MCP server version from package.json`) updated `client.ts` but the generated users client (`src/canvas/generated/users-client.ts`) was not updated at the same time.

## Test Plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 623 tests, 57 files, all pass
- [x] `pnpm build` — ESM + CJS builds succeed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)