### PR TITLE
docs(skills): add 5 P0 skill files — batch 1 (BRU-804)

### DIFF
--- a/skills/canvas-course-qc/SKILL.md
+++ b/skills/canvas-course-qc/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: canvas-course-qc
+description: Learning designer quality-control checklist for Canvas courses. Walks modules, pages, assignments, and rubrics to surface structural issues — broken item sequences, missing rubrics, empty modules, unpublished content — before a course goes live. Trigger phrases include "course QC", "course quality check", "review course structure", "pre-launch audit", "check course content", or "canvas course review".
+---
+
+# Canvas Course QC
+
+Systematically walk a Canvas course from top to bottom — syllabus, modules, pages, assignments, and rubrics — and produce a prioritised list of issues to fix before publication.
+
+## Prerequisites
+
+- Canvas MCP server must be running and connected.
+- You must have instructor, designer, or admin role in the target course.
+- The course may be unpublished — this skill reads draft content.
+
+## Steps
+
+### 1. Load Course Metadata
+
+Call `get_course` with the course ID to retrieve:
+- Course name and code
+- Publication status (`workflow_state`: `unpublished`, `available`, `completed`)
+- Start and end dates
+- Default view (modules, syllabus, etc.)
+
+Report the publication status upfront — if the course is already live, note that this is a post-launch audit.
+
+### 2. Check the Syllabus
+
+Call `get_syllabus` for the course. Check:
+- Is the syllabus body non-empty?
+- Does it contain placeholder text (e.g. "TBD", "Coming soon", "Lorem ipsum")?
+- Are expected sections present (course description, grading policy, contact info)?
+
+Flag any missing or placeholder syllabus content.
+
+### 3. Walk the Module Structure
+
+Call `list_modules` for the course to get all modules. For each module:
+
+1. Call `get_module` (with the module ID) to get its publication state, unlock date, and prerequisite chain.
+2. Call `list_module_items` (with the course ID and module ID) to get the full item list.
+
+For each module record:
+- Flag modules that are **empty** (zero items)
+- Flag modules that are **unpublished** if the course is live
+- Flag modules with a **broken prerequisite** (prerequisite module ID not in the module list)
+- Note the item count and item types (page, assignment, quiz, file, external URL)
+
+### 4. Check Pages
+
+From the module items collected in Step 3, identify items of type `Page`. For each page item:
+
+Call `get_page` (with the course ID and page URL or slug from the module item) to retrieve its content and publication state.
+
+Check for:
+- **Unpublished pages** in a published module (students cannot see them)
+- **Empty body** — page with no content
+- **Placeholder text** — same heuristic as the syllabus check
+- **Broken relative links** — look for `href="/courses/` patterns that reference a different course ID
+
+Flag each issue with the module name and page title.
+
+### 5. Check Assignments
+
+Call `list_assignments` for the course. For each assignment:
+
+Call `get_assignment` (with the course ID and assignment ID) to verify:
+- **Submission type** is configured (not `none` unless intentional)
+- **Points possible** is set (not null or zero for graded assignments)
+- **Due date** is set
+- **Rubric** is attached if the assignment description implies criteria-based grading
+
+If `rubric_id` is null on an assignment that appears to require rubric grading (based on its description mentioning criteria or a grading rubric), flag it as a missing rubric.
+
+### 6. Check Rubrics
+
+Call `list_rubrics` for the course to get all course-level rubrics.
+
+For each rubric:
+- Does it have at least two criteria?
+- Do all criteria have point values set?
+- Is it associated with at least one assignment?
+
+Flag rubrics with zero assignment associations (orphaned rubrics — may indicate an assignment link was removed).
+
+### 7. Present the QC Report
+
+Organise findings by severity:
+
+- **Blockers** — issues that will prevent students from accessing content or completing work (unpublished required pages, missing submission type, empty modules in the critical path)
+- **Warnings** — issues that degrade quality but don't block access (placeholder text, missing due dates, missing rubrics on graded work)
+- **Suggestions** — optional improvements (orphaned rubrics, empty optional modules)
+
+Ask the designer if they want to drill into any specific finding or export the full list.
+
+## Output Format
+
+```
+Course QC Report — [Course Name]  ([course code])
+Status: [Published / Unpublished]  |  Modules: [n]  |  Assignments: [n]  |  Pages: [n]
+
+BLOCKERS  ([n] found)
+• Module "[name]" — empty (no items)
+• Page "[title]" in module "[name]" — unpublished (students cannot access)
+• Assignment "[name]" — submission type not configured
+
+WARNINGS  ([n] found)
+• Syllabus — contains placeholder text ("TBD" in section 2)
+• Assignment "[name]" — no due date set
+• Assignment "[name]" — points possible is 0 (intentional?)
+• Assignment "[name]" — no rubric attached (description mentions criteria)
+
+SUGGESTIONS  ([n] found)
+• Rubric "[name]" — not associated with any assignment
+• Module "[name]" — empty (optional module, consider removing or adding a note)
+
+PASSED
+✓ All published pages have content
+✓ All modules have items
+✓ Syllabus is present and non-empty
+```
+
+## Notes
+
+- This skill is fully **read-only** — it audits but does not modify any course content. Use the Canvas web UI or course copy tools to fix issues.
+- There is no `get_course_structure` aggregator in canvas-lms-mcp; this skill explicitly chains `list_modules` → `list_module_items` → `get_page` / `get_assignment`. For large courses (20+ modules), this may take a few minutes.
+- Placeholder text detection is heuristic (looks for common strings). Review flagged items manually — a page titled "TBD Topics" may be intentional.
+- The skill does not check external URLs for liveness (Canvas does not expose link-check results via the API). Flag any items of type `ExternalUrl` for manual verification by the designer.

--- a/skills/canvas-grading-pass/SKILL.md
+++ b/skills/canvas-grading-pass/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: canvas-grading-pass
+description: Educator grading workflow for Canvas. Walks through ungraded submissions one at a time, applying rubric assessments and score comments with explicit confirmation before each write. Trigger phrases include "grade submissions", "start grading", "grading pass", "mark submissions", "grade this assignment", or "rubric grading".
+---
+
+# Canvas Grading Pass
+
+Work through an assignment's ungraded submissions one at a time — viewing the student's work, applying the rubric, entering a score, and adding a comment — with a confirmation gate before each write operation.
+
+## Prerequisites
+
+- Canvas MCP server must be running and connected.
+- You must have instructor or TA role in the target course.
+- The assignment must accept online submissions (file upload, text entry, URL, etc.).
+
+## Steps
+
+### 1. Select the Course and Assignment
+
+Ask the instructor which course and assignment to grade.
+
+If unclear, call `list_courses` to let them choose a course, then call `list_assignments` (with the course ID) to select an assignment. Prefer assignments with `workflow_state=published` and a past due date.
+
+### 2. Load the Rubric (if attached)
+
+Call `list_rubrics` for the course to see available rubrics. If the assignment has an associated rubric (check `rubric_id` in the assignment object from `get_assignment`), call `get_rubric` with that rubric ID to retrieve criteria, rating descriptions, and point values.
+
+Display the rubric criteria to the instructor before grading begins so they have it in view throughout.
+
+### 3. Retrieve Ungraded Submissions
+
+Call `list_submissions` for the course and assignment. Filter to submissions where `workflow_state` is `submitted` (not `graded`). Present the count:
+
+> "Found [n] ungraded submissions for [Assignment]. Grading one at a time."
+
+For assignments with more than 50 students, note: pace your session — Canvas rate-limits write operations. Take a short break between batches of 20–25 submissions if you encounter slowdowns.
+
+### 4. Grade Each Submission (one at a time)
+
+Repeat steps 4a–4d for each ungraded submission. **Do not batch or skip the confirmation gate.**
+
+#### 4a. View the Submission
+
+Call `get_submission` with the course ID, assignment ID, and student user ID. Display:
+- Student name and user ID
+- Submission date and type
+- Submission body, URL, or attachment reference
+- Any existing score or comments
+
+Check `get_rubric_assessment` (with course ID, rubric ID, and submission ID) to see if a partial assessment already exists.
+
+#### 4b. Propose a Score or Rubric Assessment
+
+Based on the rubric (if present) and the instructor's judgment, draft:
+- A rubric assessment: ratings per criterion with point values
+- Or a raw numeric score
+
+Present the proposed grade and ask the instructor:
+
+> "Proposed score: [n]/[max] pts  
+> Rubric: [criterion] → [rating] ([pts])  
+> Add comment: [draft comment]  
+> **Confirm to submit? (yes / edit / skip)**"
+
+Do not proceed until the instructor confirms.
+
+#### 4c. Submit Rubric Assessment (if rubric attached)
+
+After confirmation, call `submit_rubric_assessment` with:
+- `course_id`, `rubric_id`, `rubric_association_id` (from the rubric object)
+- Assessment data: criterion ID → rating ID + points for each criterion
+- `graded_anonymously: false` unless instructor specifies otherwise
+
+#### 4d. Grade and/or Comment
+
+If no rubric is attached (or in addition to the rubric assessment), call `grade_submission` with the numeric score.
+
+If the instructor provided a comment, call `comment_on_submission` with the comment text.
+
+Report: "✓ [Student name] — [score]/[max] pts — comment posted."
+
+### 5. End-of-Session Summary
+
+After all submissions are reviewed (or the instructor stops the session), present:
+
+```
+Grading Session Complete — [Assignment]
+
+Graded this session:  [n]
+Skipped:              [n]
+Remaining ungraded:   [n]
+```
+
+Ask if the instructor wants to continue with any skipped submissions or return later.
+
+## Output Format
+
+```
+Grading Pass — [Course] › [Assignment]
+[n] ungraded  |  [max pts] pts  |  Rubric: [attached / none]
+
+--- Submission 1 of [n] ---
+Student:   [Name]  (ID: [id])
+Submitted: [datetime]
+Type:      [online_text_entry / file / url]
+
+[submission preview or link]
+
+Rubric Assessment (proposed):
+  [Criterion 1]  →  [Rating label]  ([pts] pts)
+  [Criterion 2]  →  [Rating label]  ([pts] pts)
+  Total: [n]/[max] pts
+
+Draft comment: "[comment text]"
+
+Confirm? (yes / edit score / edit comment / skip)
+```
+
+## Notes
+
+- This skill grades **one submission at a time** — there is no bulk grading mode. Every write requires explicit instructor confirmation.
+- `grade_submission` and `submit_rubric_assessment` are **write operations** that modify the Canvas gradebook. They cannot be undone via the MCP server; use the Canvas web UI to correct mistakes.
+- For assignments with more than 50 students, pace the session. If you encounter API errors, wait 30–60 seconds and retry the single failed call — do not retry the entire batch.
+- Anonymous grading: if the assignment has `anonymous_grading: true`, student names will not be visible in submission data. Note this to the instructor before starting.
+- `comment_on_submission` posts a visible comment to the student. Draft carefully and confirm before posting.

--- a/skills/canvas-morning-check/SKILL.md
+++ b/skills/canvas-morning-check/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: canvas-morning-check
+description: Educator morning briefing for Canvas. Surfaces ungraded submissions, participation gaps, upcoming deadlines, and flagged students across all active courses — in under a minute. Trigger phrases include "morning Canvas check", "what needs my attention today", "grading queue", "educator briefing", "what's pending", or "Canvas daily summary".
+---
+
+# Canvas Morning Check
+
+Start the teaching day with a prioritised briefing: what needs grading, who hasn't submitted, which deadlines are coming, and which students may need a nudge — all from a single agent session.
+
+## Prerequisites
+
+- Canvas MCP server must be running and connected.
+- You must have instructor, TA, or admin role in the target courses.
+- **Privacy notice:** student names and submission data are visible in this output. Run this skill only in a private or educator-only session — never in a shared screen or student-facing context. Your institution's Canvas admin token policy governs what data is accessible; you are responsible for handling student information in accordance with FERPA or your local equivalent.
+
+## Steps
+
+### 1. Load Active Courses
+
+Call `list_courses` to retrieve your currently active courses (use `enrollment_type=teacher` if needed to filter to courses where you are the instructor). Alternatively, call `get_dashboard_cards` for a quick overview of courses with pending items.
+
+Note each course ID, name, and enrollment count.
+
+### 2. Check the Grading Queue (per course)
+
+For each active course:
+
+1. Call `list_assignments` to find assignments whose due date has passed and that accept online submissions.
+2. For each such assignment, call `list_submissions` filtered to `workflow_state=submitted` (or `graded=false` if available) to count ungraded submissions.
+
+Build a grading backlog table: course → assignment → ungraded count → due date.
+
+### 3. Check Participation and Missing Submissions
+
+For each course, call `list_course_enrollments` with `type=StudentEnrollment` and `state=active` to get the enrolled student list.
+
+For the most recent assignment with a past due date per course, cross-reference submitted student IDs against the enrollment list to identify students with no submission. Flag those with zero submissions in the past 2 assignments as participation gaps.
+
+### 4. Scan Engagement Trends
+
+For courses flagged with participation issues or declining grades, call `get_course_analytics` (with the course ID) to see aggregated participation and on-time submission rates.
+
+For individual students flagged in Step 3, call `get_student_analytics` (with course ID and student user ID) to confirm declining trends before including them in the action list.
+
+### 5. Check Upcoming Deadlines
+
+From the `list_assignments` data gathered in Step 2, surface any assignments due within the next 48 hours that have not yet been published or that have zero submissions (possibly a reminder is needed for students).
+
+### 6. Present the Morning Briefing
+
+Organise output in this order:
+
+1. Grading queue (highest count first)
+2. Upcoming deadlines needing attention
+3. Students with participation gaps
+4. Any urgent analytics flags
+
+Ask the instructor if they want to drill into any item or take action (messaging students, opening a submission for review).
+
+## Output Format
+
+```
+Morning Check — [Instructor Name]
+[Date]  |  Active courses: [n]
+
+GRADING QUEUE
+• [Course A] — [Assignment]  [n] ungraded  (due [date])
+• [Course B] — [Assignment]  [n] ungraded  (due [date])
+
+UPCOMING DEADLINES (next 48 h)
+• [Course] — [Assignment]  due [datetime]  submissions so far: [n]/[total]
+
+PARTICIPATION GAPS
+• [Course] — [Student Name]  — no submission in last 2 assignments
+• [Course] — [Student Name]  — grade trending down (was 82% → now 67%)
+
+ANALYTICS FLAGS
+• [Course] — on-time submission rate dropped to [n]% this week
+
+All clear on remaining courses.
+```
+
+## Notes
+
+- This skill is **read-only** — it surfaces information but does not grade or message anyone. Use `canvas-at-risk-students` for the outreach step.
+- For courses with large enrolments (100+ students), `list_submissions` may return many pages. Focus on the most recently due assignment per course to keep the briefing concise.
+- `get_student_analytics` may be slow on large courses; call it only for students already flagged in Step 3, not for every student.
+- Gradebook data reflects posted grades only. Unposted grades will not appear in analytics trends.

--- a/skills/canvas-student-todo/SKILL.md
+++ b/skills/canvas-student-todo/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: canvas-student-todo
+description: Student action list for Canvas. Surfaces every incomplete to-do item, missing submission, and upcoming deadline in one prioritised view — no calendar, no context switching. Trigger phrases include "what do I need to do", "my Canvas to-dos", "student to-do list", "what's missing", "catch me up", or "what should I work on".
+---
+
+# Canvas Student To-Do
+
+Get a clear, prioritised list of everything you still need to do in Canvas — missing submissions, open to-dos, and deadlines — without having to check every course separately.
+
+## Prerequisites
+
+- Canvas MCP server must be running and connected.
+- You must be logged in as a student (or have a student token) — this skill uses student-scoped endpoints.
+
+## Steps
+
+### 1. Get the Dashboard Overview
+
+Call `get_dashboard_cards` to get the high-level card view of all enrolled courses. This surfaces which courses have activity and how many items are pending, giving you a quick triage before deeper calls.
+
+Note any courses flagged with unread or to-do indicators.
+
+### 2. Get Canvas To-Do Items
+
+Call `get_todo_items` to retrieve the student's current Canvas to-do list. This includes assignments needing submission, peer reviews to complete, and quizzes with open attempts. Collect each item's:
+
+- Assignment or quiz title
+- Course name
+- Due date
+- Points possible
+
+### 3. Get Missing Submissions
+
+Call `get_missing_submissions` to identify assignments that are past their due date and have no submission. These are higher priority than upcoming items and should be flagged clearly.
+
+### 4. Get Upcoming Events
+
+Call `get_upcoming_events` to surface any scheduled events (class sessions, office hours, exams) in the near future. Include these at the bottom of the list as context for planning effort.
+
+### 5. Get Active Courses for Context
+
+Call `get_my_courses` to confirm the full list of enrolled courses and their names. Use this to cross-reference items from Steps 2–3 against the correct course context.
+
+### 6. Build the Prioritised To-Do List
+
+Sort items in this order:
+
+1. **Missing / overdue submissions** — already late, highest urgency
+2. **Due within 24 hours** — must act today
+3. **Due in 2–7 days** — plan this week
+4. **Upcoming events** — context for time blocking
+
+For each item, show: course, title, due date/time, points, and current submission status.
+
+Ask if the student wants to focus on any specific course or deadline window.
+
+## Output Format
+
+```
+Canvas To-Do — [Student Name]
+Generated [date]
+
+MISSING (past due — act now)
+• [Course] — [Assignment]  (was due [date], [points] pts)
+
+DUE TODAY
+• [Course] — [Assignment]  due [time today], [points] pts
+• [Course] — [Quiz]        due [time today], [points] pts
+
+DUE THIS WEEK
+• [Date] — [Course] — [Assignment]  [points] pts
+• [Date] — [Course] — [Peer review]
+
+UPCOMING EVENTS
+• [Date time] — [Event] ([Course])
+
+SUMMARY
+Courses with open items: [n]
+Total items remaining: [n]
+```
+
+## Notes
+
+- This skill is fully **read-only** — it surfaces what needs to be done but does not submit or modify anything.
+- `get_missing_submissions` returns items that Canvas considers missing based on due date and submission state. Items with a "no submission" type or instructor excusal may appear incorrectly; mention the caveat if the student disputes an item.
+- For the most accurate picture, run this skill at the start of the day or before a study session rather than mid-session, since Canvas caches to-do counts.

--- a/skills/canvas-week-plan/SKILL.md
+++ b/skills/canvas-week-plan/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: canvas-week-plan
+description: Student weekly planner for Canvas. Pulls upcoming assignments, due dates, current grades, pending submissions, and peer review obligations into a single prioritised plan for the week ahead. Trigger phrases include "plan my week", "what's due this week", "weekly Canvas plan", "week ahead", or "upcoming assignments".
+---
+
+# Canvas Week Plan
+
+Build a focused weekly action plan by pulling everything due, missing, or upcoming from Canvas into a single prioritised view.
+
+## Prerequisites
+
+- Canvas MCP server must be running and connected.
+- You must be logged in as a student (or have a student token) — this skill uses student-scoped endpoints.
+
+## Steps
+
+### 1. Load Active Courses
+
+Call `get_my_courses` to retrieve the student's currently enrolled courses. Note each course ID and name — you will need them for per-course lookups.
+
+### 2. Fetch Upcoming Assignments
+
+Call `get_my_upcoming_assignments` to get assignments due within the next 7 days across all courses. Note due dates, point values, and submission types.
+
+### 3. Check the To-Do List
+
+Call `get_todo_items` to retrieve any Canvas-generated action items (assignments needing submission, quizzes needing completion). Merge with the upcoming assignments list, deduplicating by assignment ID.
+
+### 4. Check Upcoming Calendar Events
+
+Call `get_upcoming_events` to surface any class sessions, office hours, or exam blocks scheduled this week. Include these in the timeline alongside assignment due dates.
+
+### 5. Review Recent Submissions and Grades
+
+Call `get_my_grades` to get current grades per course (useful for prioritisation — a course where the grade is borderline deserves more attention this week).
+
+Call `get_my_submissions` for each course where the student has recent activity to check which assignments are submitted, pending review, or returned with feedback.
+
+### 6. Check Peer Review Obligations
+
+For each course ID from Step 1, call `list_peer_reviews` (with the course ID and relevant assignment ID when known) to surface any assigned peer reviews that are due this week but not yet completed.
+
+### 7. Build the Weekly Plan
+
+Compile everything into a prioritised plan:
+
+1. **Overdue / missing** — anything already past its due date with no submission
+2. **Due today or tomorrow** — highest urgency
+3. **Due later this week** — plan the effort required
+4. **Peer reviews due** — easy to forget; flag them explicitly
+5. **Upcoming events** — class sessions and exams to block time for
+
+Ask the student if they want to adjust priorities or go deeper on any item.
+
+## Output Format
+
+```
+Week Plan — [Student Name]  Week of [Mon date] – [Sun date]
+
+OVERDUE (action required)
+• [Course] — [Assignment] — due [date], not submitted
+  → Suggest: submit now or talk to instructor
+
+DUE TODAY / TOMORROW
+• [Course] — [Assignment] — due [datetime], [points] pts
+• [Course] — [Peer review] — due [date] for [peer name]
+
+DUE LATER THIS WEEK
+• [Course] — [Assignment] — due [day], ~[estimated effort]
+• [Course] — [Quiz] — due [day]
+
+UPCOMING EVENTS
+• [Date] [time] — [Event title] ([course])
+
+GRADE SNAPSHOT
+• [Course A] — 88%  (on track)
+• [Course B] — 71%  (borderline — prioritise this week)
+• [Course C] — 94%  (strong)
+```
+
+## Notes
+
+- This skill is fully **read-only** — it surfaces information but does not submit anything on the student's behalf.
+- `list_peer_reviews` requires a course ID and assignment ID. If the student has many courses, focus on courses where the assignment deadline is within 7 days.
+- Grades from `get_my_grades` reflect the current posted grade and may not include unposted scores. Mention this caveat if a course shows an unexpectedly low or missing grade.


### PR DESCRIPTION
## Summary

- Adds 5 new `SKILL.md` files under `skills/` as specified in [BRU-804](/BRU/issues/BRU-804) and the plan doc `docs/superpowers/plans/2026-05-01-skills-expansion.md` (§3 candidates 1–5, §4 Batch 1)
- All tool names verified against `src/tools/*.ts` — no invented tool calls
- Privacy notice included in `canvas-morning-check` per CTO decision (Q3)
- `canvas-grading-pass` is one-submission-at-a-time with confirmation gate before each write; rate-limit note for >50-student assignments included
- `canvas-course-qc` explicitly walks modules → `list_module_items` → `get_page` / `get_assignment` (no aggregator shortcut); read-only
- Audience-prefixed descriptions: student skills lead with "Student …", educator skills lead with "Educator …", designer skill leads with "Learning designer …"

## Skills added

| Skill | Audience | Write? |
|---|---|---|
| `canvas-week-plan` | student | no |
| `canvas-student-todo` | student | no |
| `canvas-morning-check` | educator | no |
| `canvas-grading-pass` | educator | yes (confirmation required) |
| `canvas-course-qc` | designer | no |

## Test plan

- [ ] Read each `SKILL.md` and confirm frontmatter `name` matches directory name
- [ ] Confirm every tool name cited appears in `src/tools/*.ts`
- [ ] Confirm `canvas-morning-check` contains privacy notice
- [ ] Confirm `canvas-grading-pass` has confirmation gate language and rate-limit note
- [ ] Confirm `canvas-course-qc` walks modules → items → pages (no aggregator)
- [ ] CI (typecheck + tests + build) passes — no source changes, only markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)