### PR TITLE
feat(skills): Batch 2 — discussion, quiz, pulse, syllabus SKILL.md files (BRU-805)

### DIFF
--- a/skills/canvas-course-pulse/SKILL.md
+++ b/skills/canvas-course-pulse/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: canvas-course-pulse
+description: Educator skill for tracking week-over-week course health trends in Canvas. Surfaces assignment performance trends, login activity, engagement gaps, and struggling students across a longer time horizon than a daily check. Trigger phrases include "course pulse", "course health", "course trends", "week-over-week performance", "how is the course going", "engagement trends", "who isn't logging in", or "course activity over time".
+---
+
+# Canvas Course Pulse
+
+Educator skill for a longer-horizon view of course health: assignment performance trends, login patterns, engagement gaps, and student activity — across a week or more of data.
+
+**Use this skill for trend analysis over days or weeks. For today's immediate check (submission rates, upcoming deadlines, grade distribution this morning), use `canvas-morning-check` instead.**
+
+## Prerequisites
+
+- Canvas MCP server must be running and connected.
+- You must have instructor or admin role in the target course.
+- Analytics data requires the course to have active student enrollments and at least one graded activity.
+- Student names and engagement data are visible in output — only run this in a private or educator-only session.
+
+## Steps
+
+### 1. Identify the Target Course
+
+Ask the user which course to analyse. Accept a course name, course code, or Canvas ID.
+
+If unclear, call `list_course_enrollments` with the course ID to confirm the course exists and has enrolled students.
+
+### 2. Choose a Focus Area
+
+Offer three pulse views or ask the user what they want to know:
+
+| View | What it answers |
+|------|-----------------|
+| **Assignment trends** | Which assignments have low completion or low average scores? How has performance trended? |
+| **Engagement & login activity** | Who is logging in regularly? Who has gone quiet? What's happening in the activity stream? |
+| **Per-student deep-dive** | How is a specific student tracking across assignments, grades, and participation? |
+
+You can combine views in a single report.
+
+### 3A. Assignment Performance Trends
+
+1. Call `get_course_analytics` with the course ID. This returns aggregate assignment-level data: submission counts, score averages, and on-time vs late rates per assignment.
+2. Call `list_assignments` with the course ID to get assignment titles, due dates, and point values (for context the analytics data may not include).
+
+Cross-reference to build a trend table, ordering by due date:
+
+```
+Assignment Trends — [Course Name]  (last 4 weeks)
+
+Assignment                    Submitted   Avg Score   On Time
+"Week 1 Reflection"           47/50 (94%) 88%         92%
+"Reading Quiz 2"              46/50 (92%) 81%         89%
+"Group Project Draft"         44/50 (88%) 74%         71%  ← slipping
+"Week 3 Reflection"           39/50 (78%) 68%         58%  ← needs attention
+"Midterm Essay"               41/50 (82%) 72%         63%
+```
+
+Flag assignments where submission rate has dropped more than 10 percentage points from the course average, or where the on-time rate is below 65%.
+
+### 3B. Engagement and Login Activity
+
+1. Call `get_course_activity_stream` with the course ID. This returns the recent activity feed: discussion posts, assignment submissions, grade postings, and other course events.
+2. Call `list_course_enrollments` with the course ID and `type=StudentEnrollment` to get the enrolled student list with last-activity timestamps.
+
+Identify students who have not had any course activity in the past 7 days. For courses with 50+ students, narrow to the bottom quartile by last-activity date rather than listing all students.
+
+Present a summary:
+
+```
+Engagement Pulse — [Course Name]
+
+RECENT ACTIVITY (last 7 days)
+Total events: 312
+  Discussion posts: 87
+  Assignment submissions: 134
+  Grade views: 58
+  Other: 33
+
+ACTIVE STUDENTS: 43/50 this week
+
+DISENGAGED STUDENTS (no activity in 7+ days)
+• Student A — last seen 12 days ago
+• Student B — last seen 9 days ago
+• Student C — last seen 8 days ago
+• … (3 more — ask to see full list)
+```
+
+Ask the instructor if they want to reach out to disengaged students or investigate further.
+
+### 3C. Per-Student Deep-Dive
+
+1. Call `get_student_analytics` with the course ID and the student's user ID. This returns the student's per-assignment scores, submission behaviour, and participation data.
+
+Present a compact per-student pulse:
+
+```
+Student Pulse — Student A — [Course Name]
+
+Assignments submitted: 7/9 (78%)
+Current grade: 71%
+Trend: down from 81% four weeks ago
+
+SUBMISSION HISTORY
+• "Week 1 Reflection"   ✓  submitted on time   88%
+• "Reading Quiz 2"      ✓  submitted on time   76%
+• "Group Project Draft" ✓  submitted 2 days late  62%
+• "Week 3 Reflection"   ✗  not submitted        —
+• "Midterm Essay"       ✓  submitted on time   71%
+```
+
+Flag if the student's grade is trending downward (more than 8 points over the past 3 assignments) or if they have 2+ missing submissions.
+
+### 4. Summarise and Suggest Next Steps
+
+After presenting the requested views, offer concrete next steps:
+
+- **For struggling assignments**: "Would you like to review submissions for [assignment name] to understand why scores are low?"
+- **For disengaged students**: "Would you like to send a check-in message to students who haven't logged in this week?" (Use `canvas-at-risk-students` for full outreach workflow.)
+- **For a declining student**: "Would you like to send [student name] a direct message through Canvas?"
+
+## Output Format
+
+```
+Course Pulse — [Course Name]  (analysed [date])
+
+ASSIGNMENT TRENDS
+Submission rate this week: 82%  (↓ from 91% two weeks ago)
+Average score trend: 74%  (↓ from 81%)
+Assignments needing attention: 2
+
+ENGAGEMENT
+Active students this week: 43/50
+Disengaged (7+ day gap): 7 students
+
+SUGGESTED ACTIONS
+• Review "Week 3 Reflection" submissions — lowest completion (78%) and scores (68%)
+• Check in with 7 disengaged students — 3 are also below 70% grade
+• Student A has missed 2 assignments and grade is trending down 10 pts
+```
+
+## Notes
+
+- This skill is **read-only** — it surfaces analytics and engagement data without modifying any Canvas content.
+- **Scope vs `canvas-morning-check`**: `canvas-morning-check` is a same-day health check (today's submission rates, this morning's grade distribution). This skill analyses trends over days or weeks — use it for mid-course adjustments, not for daily ops.
+- `get_course_analytics` returns aggregate data per assignment, not per-student scores. For individual student trajectories, use `get_student_analytics` (Step 3C).
+- For courses with 100+ students, `get_course_activity_stream` may return a large event list. Summarise by event type and highlight disengagement signals rather than listing all events.
+- Login activity and "last seen" data comes from enrollment timestamps. Canvas does not always update these in real time; treat "last activity" as approximate.

--- a/skills/canvas-discussion-facilitator/SKILL.md
+++ b/skills/canvas-discussion-facilitator/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: canvas-discussion-facilitator
+description: Educator skill for browsing, reading, replying to, and creating Canvas discussion topics. Surfaces active threads, unread entries, and announcement activity — then lets you post replies or create new topics without leaving your agent session. Trigger phrases include "discussion board", "course discussions", "reply to discussion", "create a discussion", "what's in the discussion forum", "check announcements", or "post to discussion".
+---
+
+# Canvas Discussion Facilitator
+
+Educator skill for managing course discussion boards: browse topics, read threaded entries, post replies, create new topics, and monitor announcement activity — all from your agent session.
+
+## Prerequisites
+
+- Canvas MCP server must be running and connected.
+- You must have instructor, TA, or student role in the target course (read access). Creating or updating topics requires instructor or TA role.
+- Student names and post content are visible in output — only run this in a private or educator-only session when reviewing discussion entries.
+
+## Tool naming note
+
+`get_discussion` in canvas-lms-mcp returns the full topic details **and inline discussion entries** in a single call. There is no separate `list_discussion_entries` tool — all thread content comes through `get_discussion`. If you search for `list_discussion_entries` you will not find it; use `get_discussion` instead.
+
+## Steps
+
+### 1. Identify the Target Course
+
+Ask the user which course's discussions to work with. Accept a course name, course code, or Canvas ID.
+
+If unclear, call `list_discussions` with the course ID — it will fail with a 404 if the course ID is wrong, which surfaces the issue early.
+
+### 2. Choose a Mode
+
+Ask the user what they want to do:
+
+| Mode | When to use |
+|------|-------------|
+| **Browse topics** | See all active discussion topics at a glance |
+| **Read a thread** | Read the entries in a specific topic |
+| **Check announcements** | View instructor announcements |
+| **Post a reply** | Add an entry to an existing discussion |
+| **Create a topic** | Open a new discussion topic |
+
+### 3A. Browse Topics
+
+Call `list_discussions` with the course ID. This returns all discussion topics in the course with their title, type (`discussion_topic` or `announcement`), reply count, unread count, and posting status.
+
+Present a summary table:
+
+```
+Discussions — [Course Name]
+
+OPEN TOPICS
+• "Week 3 Reflection" — 34 replies, 5 unread, posted by Prof. Lee
+• "Reading Questions Ch. 4" — 12 replies, 0 unread, posted by TA Park
+• "Introduce Yourself" — 28 replies, 0 unread
+
+CLOSED / LOCKED
+• "Week 1 Check-in" — 19 replies (locked)
+```
+
+Ask the user if they want to read a specific topic.
+
+### 3B. Read a Thread
+
+Call `get_discussion` with the course ID and topic ID. The response includes the topic metadata **and all discussion entries inline** — you do not need a separate entries call.
+
+Summarise the thread:
+- Topic title, author, and posted date
+- Number of entries and unread count
+- The most recent 5 entries (or all entries if ≤ 10), showing author, timestamp, and a preview of the message body
+
+If entries are long, offer to show the full text of a specific entry on request.
+
+### 3C. Check Announcements
+
+Call `list_announcements` with the course ID. This returns announcements as a separate list from discussion topics.
+
+Present the most recent 5 announcements:
+
+```
+Announcements — [Course Name]
+
+• [Apr 28] "Final Project Rubric Posted" — Prof. Martinez
+• [Apr 22] "Office Hours Change This Week" — Prof. Martinez
+• [Apr 15] "Midterm Grades Released" — Prof. Martinez
+```
+
+### 3D. Post a Reply
+
+**Requires explicit user confirmation before posting.**
+
+1. Identify the target topic (Steps 1–3B if not already done).
+2. Draft the reply message with the user. Show them the draft and ask "Post this reply to [topic title]? (yes/no)".
+3. Only after confirmation: call `post_discussion_entry` with the course ID, topic ID, and message body.
+4. Report the posted entry ID and timestamp.
+
+### 3E. Create a Topic
+
+**Requires explicit user confirmation before creating.**
+
+1. Collect from the user:
+   - Title (required)
+   - Message body (optional — can be empty for a blank prompt-style topic)
+   - Whether the topic is threaded vs. side-comment style (defaults to threaded)
+   - Whether to post now or as a delayed-post
+
+2. Show the full topic draft and ask "Create this discussion topic in [course name]? (yes/no)".
+3. Only after confirmation: call `create_discussion` with the course ID, title, message, and discussion type.
+4. Report the new topic ID and URL.
+
+### 3F. Update a Topic (Instructors Only)
+
+**Requires explicit user confirmation before updating.**
+
+To edit an existing topic's title, message, or settings (lock/unlock, publish/unpublish):
+
+1. Identify the topic to update via Steps 3A–3B.
+2. Show the user the current values and proposed changes.
+3. Only after confirmation: call `update_discussion` with the course ID, topic ID, and updated fields.
+4. Report the updated topic ID.
+
+## Output Format
+
+```
+Discussion Facilitator — [Course Name]
+
+TOPIC: "Week 3 Reflection"
+Posted: Apr 20 by Prof. Lee  |  Type: Threaded  |  Replies: 34  |  Unread: 5
+
+RECENT ENTRIES
+• Alex Doe (Apr 27, 9:14 AM)
+  "I found the reading on constructivism really compelling because it reframes
+   how I think about student-driven learning..."
+
+• Jordan Park (Apr 26, 11:02 PM)
+  "Totally agree with Sam — the Vygotsky section was the most relevant for
+   my practicum..."
+
+• Sam Lee (Apr 26, 3:30 PM)
+  "The zone of proximal development framework maps really well onto the
+   collaborative assignments we've been doing in class."
+
+[31 more entries — ask to see more or a specific entry]
+```
+
+## Notes
+
+- **Read-only by default** — browsing topics and reading threads does not modify any Canvas data.
+- Write operations (`post_discussion_entry`, `create_discussion`, `update_discussion`) require explicit user confirmation before each call.
+- `get_discussion` returns inline entries — there is no separate `list_discussion_entries` tool in canvas-lms-mcp. Do not search for one.
+- For courses with very active discussions (100+ entries per topic), the inline entry list from `get_discussion` may be long; summarise and offer to show full text on request rather than dumping the entire thread.
+- Announcements are a separate feed from discussion topics — use `list_announcements` for instructor announcements, `list_discussions` for student discussion topics.

--- a/skills/canvas-quiz-review/SKILL.md
+++ b/skills/canvas-quiz-review/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: canvas-quiz-review
+description: Educator skill for reviewing Canvas quiz performance and regrading individual question scores. Surfaces struggling questions, low-scoring students, and per-student answer breakdowns — then lets you adjust scores for specific questions without leaving your agent session. Unique to canvas-lms-mcp (no other Canvas MCP server exposes quiz tools). Trigger phrases include "quiz review", "quiz results", "struggling quiz questions", "quiz scores", "regrade a quiz question", "quiz performance", or "student quiz answers".
+---
+
+# Canvas Quiz Review
+
+Educator skill for analysing quiz performance, investigating per-student answers, and regrading individual question scores — all from your agent session.
+
+**canvas-lms-mcp is the only Canvas MCP server with quiz tools.** No other Canvas MCP server exposes `list_quizzes`, `get_quiz`, or `score_quiz_question`. This skill is a unique differentiator.
+
+## Prerequisites
+
+- Canvas MCP server must be running and connected.
+- You must have instructor or TA role in the target course.
+- Student answers and scores are visible in output — only run this in a private or educator-only session.
+- Regrading (`score_quiz_question`) requires instructor role. TA role may be restricted depending on institution settings.
+
+## Steps
+
+### 1. Identify the Target Course
+
+Ask the user which course to work with. Accept a course name, course code, or Canvas ID.
+
+### 2. Select a Quiz
+
+Call `list_quizzes` with the course ID. This returns all quizzes with their title, question count, point total, due date, and time limit.
+
+Present a summary and let the user select:
+
+```
+Quizzes — [Course Name]
+
+• "Midterm Quiz" — 25 questions, 50 pts, due Mar 15, time limit: 60 min
+• "Week 4 Check-in" — 10 questions, 20 pts, due Apr 5, no time limit
+• "Final Exam Quiz" — 50 questions, 100 pts, due May 1, time limit: 120 min
+```
+
+### 3. Choose a Mode
+
+| Mode | When to use |
+|------|-------------|
+| **Quiz overview** | See score distribution and flag struggling questions |
+| **Per-student answers** | Review one student's answer sheet |
+| **Regrade a question** | Adjust the score for one question on one submission |
+
+### 4A. Quiz Overview — Score Distribution and Struggling Questions
+
+1. Call `get_quiz` with the course ID and quiz ID. Note the question count and total points.
+2. Call `list_quiz_submissions` with the course ID and quiz ID. This returns all submissions with each student's score, attempt count, and workflow state.
+3. Call `list_quiz_questions` with the course ID and quiz ID to get each question's title, type, and point value.
+
+Compute per-question statistics from submissions where possible (if scores are included in the submission response). Identify questions where the class average is below 60% of possible points.
+
+Present the overview:
+
+```
+Quiz Overview — "Midterm Quiz" — [Course Name]
+
+SCORE DISTRIBUTION
+Class average: 38.4 / 50 pts (76.8%)
+Highest: 50 pts  |  Lowest: 21 pts
+Submitted: 47/50 students  |  In progress: 0  |  Not started: 3
+
+QUESTIONS TO REVIEW (< 60% class average)
+• Q7 "Explain the difference between RAM and ROM" — avg 1.2/4 pts (30%)
+• Q12 "Which sorting algorithm is O(n log n)?" — avg 0.6/2 pts (30%)
+• Q19 "Describe REST constraints" — avg 2.1/5 pts (42%)
+
+LOW-SCORING STUDENTS (< 70% of total points)
+• Student A — 29/50 pts (58%)
+• Student B — 31/50 pts (62%)
+• Student C — 33/50 pts (66%)
+```
+
+Ask if the instructor wants to review per-student answers or regrade a question.
+
+### 4B. Per-Student Answers
+
+1. Identify the student's submission from `list_quiz_submissions` output.
+2. Call `get_quiz_submission_answers` with the quiz submission ID. This returns the student's answer for each question, the correct answer (for auto-graded types), and whether they received credit.
+
+Present the answer sheet:
+
+```
+Answer Sheet — "Midterm Quiz" — Student A (submission #1847)
+Score: 29/50 pts (58%)
+
+Q1 "What does CPU stand for?" — Multiple choice
+  Answered: "Central Processing Unit" ✓  (2/2 pts)
+
+Q7 "Explain the difference between RAM and ROM" — Essay
+  Answered: "RAM is temporary memory that stores running programs.
+             ROM is permanent memory on a chip."
+  Score: 1/4 pts  ← needs review
+
+Q12 "Which sorting algorithm is O(n log n)?" — Multiple choice
+  Answered: "Bubble sort" ✗ (correct: Merge sort)  (0/2 pts)
+```
+
+Ask if any questions should be regraded.
+
+### 4C. Regrade a Question
+
+**Requires explicit user confirmation before adjusting any score.**
+
+Regrading adjusts the score for a single question on a single student's submission. Use this for:
+- Essay questions where the auto-score needs an instructor override
+- Questions with ambiguous wording where multiple answers should receive credit
+
+Workflow:
+1. Identify the submission ID and question ID from the previous steps.
+2. Ask the user: "Set the score for [question title] on [student name]'s submission to [N] points out of [max]? This will update their total quiz score."
+3. Only after confirmation: call `score_quiz_question` with:
+   - `quiz_submission_id`: the submission ID
+   - `quiz_submission_attempt`: the attempt number (from `list_quiz_submissions`)
+   - `questions`: the array of question score objects with the question ID and new score
+4. Report the updated question score and revised submission total.
+
+Repeat for additional questions or students if the instructor needs to batch-regrade.
+
+## Output Format
+
+```
+Quiz Review — "Week 4 Check-in" — [Course Name]
+
+SUMMARY
+Submitted: 44/46 students  |  Avg: 17.2/20 pts (86%)
+Questions needing review: 1
+
+STRUGGLING QUESTION
+• Q3 "Define idempotency" — avg 1.8/4 pts (45%)
+  Top wrong answers: "when a function returns the same value" (×12),
+                    "when a request can be retried safely" (×8, partially correct)
+
+REGRADING
+Q3 on Student B's submission: 1 pt → 3 pts ✓  (updated total: 16/20)
+```
+
+## Notes
+
+- **Read-only by default** — quiz overview and per-student answer review do not modify any Canvas data.
+- `score_quiz_question` is a **write operation** that permanently adjusts a student's quiz score. Always confirm the question, student, and new score before calling it.
+- canvas-lms-mcp is the only Canvas MCP server with quiz tools. If another Canvas MCP server is installed alongside this one, the quiz tools will only be available through canvas-lms-mcp.
+- `get_quiz_submission_answers` requires the quiz submission ID (not the user ID). Retrieve it from the `id` field in `list_quiz_submissions` results.
+- For quizzes with many submissions (100+ students), `list_quiz_submissions` and `list_quiz_questions` may paginate. The MCP server handles pagination automatically.
+- Canvas may not expose per-question scoring breakdowns for all quiz types (e.g., survey quizzes). If per-question data is unavailable, note this to the user.

--- a/skills/canvas-syllabus-coach/SKILL.md
+++ b/skills/canvas-syllabus-coach/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: canvas-syllabus-coach
+description: Learning designer skill for reviewing and improving Canvas course syllabi and front pages. Reads the syllabus and key pages, proposes clarity and completeness improvements, then optionally applies the edits with your confirmation. Trigger phrases include "syllabus review", "improve the syllabus", "syllabus coach", "course front page", "update course description", "review course pages", or "polish the syllabus".
+---
+
+# Canvas Syllabus Coach
+
+Learning designer skill for auditing and improving course syllabi and front pages in Canvas. Reads the current syllabus and course pages, proposes improvements, and optionally applies edits — one confirmed step at a time.
+
+## Prerequisites
+
+- Canvas MCP server must be running and connected.
+- **Read-only review** requires instructor, TA, or designer role.
+- **Applying edits** (`update_course`, `update_page`, `create_page`) requires instructor or designer role with content-editing permissions.
+- Changes to the course syllabus body are permanent and immediately visible to students — review every proposed edit before confirming.
+
+## Steps
+
+### 1. Identify the Target Course
+
+Ask the user which course to work with. Accept a course name, course code, or Canvas ID.
+
+### 2. Read the Current Syllabus
+
+Call `get_course` with the course ID to retrieve course metadata (name, course code, description, default view, and other settings).
+
+Call `get_syllabus` with the course ID to retrieve the syllabus body HTML and the list of syllabus items (assignments and events).
+
+Parse the syllabus HTML into readable sections. Identify which sections are present:
+
+- **Course description** — what the course is about
+- **Learning objectives / outcomes** — what students will be able to do
+- **Required materials** — textbooks, software, subscriptions
+- **Grading policy** — weights and breakdown
+- **Late work / make-up policy** — penalties and exceptions
+- **Communication policy** — response time expectations, preferred contact method
+- **Academic integrity** — plagiarism and AI use policies
+- **Accessibility / accommodation** — disability services contact
+- **Course schedule** — weekly topics or module structure
+
+### 3. Read Key Course Pages (Optional)
+
+If the course has a custom front page, call `list_pages` with the course ID to see all pages. Then call `get_page` with the course ID and the front page URL slug to read its content.
+
+If relevant, read additional pages the user mentions (e.g., "review the resources page").
+
+### 4. Present the Syllabus Review
+
+Summarise what you found and flag gaps:
+
+```
+Syllabus Review — [Course Name]
+
+PRESENT ✓
+• Course description
+• Grading policy (A 93–100%, B 83–92%, C 73–82%, D 60–72%)
+• Required materials (3 items)
+• Course schedule (14 weeks listed)
+
+MISSING OR WEAK ✗
+• Learning objectives — not listed; students cannot see what they are expected to master
+• Late work policy — no mention; students may dispute late penalties
+• Communication policy — no response-time commitment listed
+• Accessibility / accommodation — no disability services reference
+• Academic integrity — grading policy mentions it briefly but no AI-use guidance
+
+SUGGESTED IMPROVEMENTS
+1. Add 3–5 measurable learning objectives to the opening section
+2. Add a "Late Work" policy block (e.g., 10% penalty per day, no submissions after 1 week)
+3. Add a "Communication" section with your preferred contact method and typical response time
+4. Add a one-line accessibility statement with your institution's disability services contact
+5. Expand the academic integrity section to clarify your AI tool policy
+```
+
+Ask the user if they want to apply any of these improvements.
+
+### 5. Draft and Apply Edits
+
+**All edits require explicit user confirmation before being applied.**
+
+Work through improvements one at a time:
+
+#### 5A. Update the Syllabus Body (via `update_course`)
+
+The Canvas syllabus body is part of the course record — update it with `update_course`:
+
+1. Draft the revised syllabus HTML. Show the user a plain-text preview of the proposed changes.
+2. Ask: "Apply these changes to the syllabus for [course name]? (yes/no)"
+3. Only after confirmation: call `update_course` with the course ID and `syllabus_body` set to the revised HTML.
+4. Report: "Syllabus updated. Changes are live and visible to students."
+
+#### 5B. Update a Course Page (via `update_page`)
+
+For changes to an existing page (e.g., the front page or a resources page):
+
+1. Draft the revised page body. Show the user a plain-text preview.
+2. Ask: "Update the [page title] page in [course name] with these changes? (yes/no)"
+3. Only after confirmation: call `update_page` with the course ID, page URL slug, and updated body.
+4. Report the updated page title and publish status.
+
+#### 5C. Create a New Page (via `create_page`)
+
+If the improvement requires a new page (e.g., adding a dedicated "Course Policies" page):
+
+1. Draft the new page content. Show a plain-text preview including the proposed title.
+2. Ask: "Create a new page titled '[title]' in [course name]? (yes/no)"
+3. Only after confirmation: call `create_page` with the course ID, title, and body. Set `published: false` initially so the user can review before students see it.
+4. Report the new page URL slug and note that it is currently unpublished.
+
+Repeat Steps 5A–5C for each improvement the user wants to apply.
+
+## Output Format
+
+```
+Syllabus Coach — [Course Name]
+
+REVIEW COMPLETE
+Sections found: 5/9 standard sections
+Gaps identified: 4
+
+EDITS APPLIED
+• Syllabus body updated — added learning objectives and late work policy ✓
+• Front page updated — added communication and accessibility sections ✓
+• New page created: "Course Policies (Draft)" — unpublished, URL: /pages/course-policies ✓
+
+STILL PENDING (user chose to skip)
+• Academic integrity AI-use section — no changes applied
+```
+
+## Notes
+
+- **Read-only review comes first** — Steps 1–4 do not modify any Canvas data. You can produce a full review report without applying any changes.
+- Every write step (`update_course`, `update_page`, `create_page`) must have explicit user confirmation before execution. Never batch multiple edits into a single unconfirmed call.
+- `update_course` with `syllabus_body` replaces the entire syllabus HTML. Always base the update on the current content retrieved in Step 2 to avoid discarding sections the user has not reviewed.
+- The Canvas syllabus editor stores content as HTML. When drafting improvements, write clean HTML or strip tags for the preview; avoid injecting raw markdown into the `syllabus_body` field.
+- `create_page` defaults pages to `published: false`. Recommend the user review the new page in Canvas before publishing to students.
+- Learning designer roles in Canvas may have different permissions per institution. If a write call returns a 403, report the permission error and suggest the instructor apply the change manually.


### PR DESCRIPTION
## Summary

Adds four SKILL.md files for the Batch 2 skills expansion ([BRU-805](/BRU/issues/BRU-805), parent [BRU-800](/BRU/issues/BRU-800)):

- **`canvas-discussion-facilitator`** — Educator skill for browsing, reading, replying, and creating discussion topics. Calls out that `get_discussion` returns entries inline (no separate `list_discussion_entries` tool), matching the task requirement.
- **`canvas-quiz-review`** — Educator skill for quiz performance analysis and per-question regrading. Differentiator copy included (only Canvas MCP server with quiz tools). `score_quiz_question` requires explicit user confirmation.
- **`canvas-course-pulse`** — Educator skill for week-over-week trend analysis (assignment performance, login/engagement gaps). Complements `canvas-morning-check` (daily ops); this skill is for longer-horizon trends.
- **`canvas-syllabus-coach`** — Learning designer skill. Read-only review comes first. Every write step (`update_course`, `update_page`, `create_page`) requires explicit user confirmation. "Learning designer" appears in description text only — no `designer` value in frontmatter metadata.

## Tool Verification

All tool names verified against `src/tools/*.ts` on `origin/main`:

| Skill | Tools verified |
|-------|---------------|
| canvas-discussion-facilitator | `list_discussions`, `get_discussion`, `list_announcements`, `post_discussion_entry`, `create_discussion`, `update_discussion` |
| canvas-quiz-review | `list_quizzes`, `get_quiz`, `list_quiz_submissions`, `list_quiz_questions`, `get_quiz_submission_answers`, `score_quiz_question` |
| canvas-course-pulse | `get_course_analytics`, `get_course_activity_stream`, `get_student_analytics`, `list_course_enrollments`, `list_assignments` |
| canvas-syllabus-coach | `get_course`, `get_syllabus`, `update_course`, `list_pages`, `get_page`, `update_page`, `create_page` |

## Test plan

- [ ] Each SKILL.md has valid frontmatter (`name`, `description`)
- [ ] Description first sentence names the audience ("Educator skill for...", "Learning designer skill for...")
- [ ] Trigger phrases present in each description
- [ ] Tool calls listed match `src/tools/*.ts` (grep-verified above)
- [ ] Write operations documented as requiring user confirmation
- [ ] `canvas-discussion-facilitator` calls out `get_discussion` inline-entries behaviour
- [ ] `canvas-quiz-review` includes differentiator copy
- [ ] `canvas-course-pulse` references relationship to `canvas-morning-check`
- [ ] `canvas-syllabus-coach` has read-only review section first; no `designer` in frontmatter metadata
- [ ] No centralized metadata file changed (no file overlap with Batch 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)