### PR TITLE
feat(skills): add Batch 3 Canvas skill files (peer-review-tracker, admin-roster)

### DIFF
--- a/skills/canvas-admin-roster/SKILL.md
+++ b/skills/canvas-admin-roster/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: canvas-admin-roster
+description: Admin skill for walking the Canvas account hierarchy: list accounts and sub-accounts, see courses and users under each, look up which canned reports are available, and enroll or remove users from a specific course — one action at a time. Trigger phrases include "admin roster", "list accounts", "sub accounts", "account users", "users in this account", "enroll a user", "remove an enrollment", "account reports", or "what accounts can I see".
+---
+
+# Canvas Admin Roster
+
+Admin-audience skill for inspecting the Canvas account tree and making targeted enrollment changes. Walks `list_accounts → list_sub_accounts → list_account_courses / list_account_users` so the agent paces itself instead of dumping the whole institution at once. Write paths (`enroll_user`, `remove_enrollment`) are explicitly gated by per-action confirmation and are clearly separated from the read paths.
+
+## Prerequisites
+
+- Canvas MCP server must be running and connected.
+- **Admin Canvas token required.** A teacher or TA token will return empty results from `list_accounts` and 401/403 from `list_sub_accounts`, `list_account_courses`, `list_account_users`, and `get_account_reports`. If the user does not have an admin token, stop at Step 1 and tell them this skill needs an admin role on the relevant account.
+- `enroll_user` and `remove_enrollment` additionally require permission to manage enrollments on the target course. A "subaccount admin" role may be able to read the account but not modify enrollments — the skill will surface a 403 if that happens.
+- Many admin endpoints expose institution-wide data. Only run this skill in a private session.
+
+## Steps
+
+### 1. Discover the Accounts You Can See
+
+Call `list_accounts`. This returns every account the authenticated admin has access to — in many institutions this is just the root account, but multi-tenant Canvas deployments can return several.
+
+If the response is empty, the token does not have admin scope. Stop here and tell the user.
+
+Show the user the accounts with their `id`, `name`, and `parent_account_id`:
+
+```
+ACCOUNTS YOU CAN ADMIN
+• [1]  Root Account (Big State University)
+• [42] College of Engineering          parent: 1
+• [43] College of Liberal Arts         parent: 1
+```
+
+### 2. Walk the Sub-Account Tree
+
+Ask the user which account to drill into, or default to the root account.
+
+For the chosen account, call `list_sub_accounts` with that `account_id`. **This is shallow — it returns direct children only, not the full descendant tree.** If the user wants to walk further down, repeat `list_sub_accounts` on each child sub-account they pick. Do not recurse the whole tree by default — large institutions can have hundreds of sub-accounts and you will burn quota.
+
+```
+SUB-ACCOUNTS UNDER [42] College of Engineering
+• [120] Department of Computer Science    parent: 42
+• [121] Department of Mechanical Eng.     parent: 42
+• [122] Department of Electrical Eng.     parent: 42
+```
+
+If the user wants metadata for a specific account (settings, default time zone, sis identifier, etc.), call `get_account` with that `account_id` and surface the fields they asked for.
+
+### 3. Inspect Courses Under an Account
+
+For the chosen account, call `list_account_courses` with the `account_id`. Optional `search_term` narrows by course name or course code.
+
+The result is paginated under the hood. Present a count first ("Found 187 courses in [account]"), then offer:
+
+| Mode | When to use |
+|------|-------------|
+| **Filter by name** | Re-call with a `search_term` (e.g. "CS 101") |
+| **Show first N** | Display the first 25 by default; offer to page further only if asked |
+| **Group by sub-account** | Group locally; do not re-query per sub-account |
+
+For very large accounts (1000+ courses), tell the user: filter by `search_term` first. Pulling the full list works but is slow and crowds the agent's context.
+
+### 4. Inspect Users in an Account
+
+For the chosen account, call `list_account_users` with the `account_id`. Optional `search_term` searches name, email, and login ID.
+
+Users can have many enrollments across many courses; this endpoint returns each user once with account-level metadata, **not** their enrollments. Combine with Step 6 (course enrollments) if the user asks "what is this person enrolled in".
+
+```
+USERS IN [120] CS Department  (search: "park")
+• [88321] Jordan Park        login: jpark         email: jpark@bsu.edu
+• [88455] Min Park           login: minpark       email: minpark@bsu.edu
+```
+
+### 5. Discover Available Reports for an Account
+
+Call `get_account_reports` with the `account_id`. **This returns the list of report types Canvas can run for this account, plus metadata about the most recent instance of each — it does NOT start a new report and there is no polling endpoint exposed by this MCP server.** Common report types include `course_storage_csv`, `provisioning_csv`, `student_assignment_outcome_map_csv`, and several SIS exports — exact set varies by Canvas instance.
+
+For each report row, show:
+- `report` (the report type identifier)
+- `title` (human-readable name)
+- `last_run` (timestamp of the most recent execution, if any)
+- `parameters` (any defaults the report exposes)
+
+Then tell the user explicitly:
+
+> "These are the report types available to you. To actually run one of these reports, use the Canvas web UI under **Admin → [Account] → Settings → Reports**. canvas-lms-mcp does not expose a `start_report` / `get_report_status` tool surface, so the run must happen in the UI and you can come back here once the export is downloadable."
+
+Do not invent a polling loop. Do not pretend to "wait for the report" — there is nothing to poll.
+
+### 6. List Enrollments in a Specific Course
+
+`list_account_users` does **not** include enrollment lists. To see who is enrolled in a particular course, call `list_course_enrollments` with the `course_id` (you'll have it from Step 3). Filter by `type` and `state` as needed:
+
+- `type=['StudentEnrollment']` for students
+- `type=['TeacherEnrollment','TaEnrollment']` for instructional staff
+- `state=['active']` to skip pending invites and concluded enrollments
+
+A note about `list_enrollments` (singular, no `course_` prefix): that tool returns the **authenticated user's own enrollments** — `/api/v1/users/self/enrollments`. It is useful for checking "what courses am I admin/teacher in?" but it is **not** a way to look up some other user's enrollment list. There is no tool in this MCP server that fetches arbitrary-user enrollments across courses; you would have to walk `list_account_courses` and `list_course_enrollments` per course, which is expensive.
+
+### 7. Enroll a User in a Course (Write — Confirmed Per Action)
+
+**Requires explicit user confirmation before each call.**
+
+When the admin wants to add an enrollment:
+
+1. Confirm the target course (course ID from Step 3).
+2. Confirm the target user (user ID from Step 4 or external lookup).
+3. Confirm the enrollment type:
+   - `StudentEnrollment` — student
+   - `TeacherEnrollment` — teacher
+   - `TaEnrollment` — TA
+   - `DesignerEnrollment` — learning designer
+   - `ObserverEnrollment` — observer (e.g., parent)
+4. Optionally confirm the initial `enrollment_state`: `active` (immediately enrolled), `invited` (default — sends Canvas invitation), or `inactive`.
+5. Show the admin a single-line preview:
+
+   > "Enroll user [Name] (id [n]) into [Course Name] (id [c]) as [Type], state=[State]? (yes/no)"
+
+6. Only after confirmation: call `enroll_user` with `course_id`, `user_id`, `type`, and `enrollment_state` if specified.
+7. Report the new enrollment row, including `enrollment_id` (needed for Step 8 if the admin later wants to revoke it).
+
+**Never batch.** If the admin wants to enroll five users, repeat steps 1–7 five times with five separate confirmations. Do not collapse them into one prompt.
+
+### 8. Remove an Enrollment from a Course (Write — Confirmed Per Action)
+
+**Requires explicit user confirmation before each call.** This is destructive: depending on the `task`, it can permanently delete the enrollment record.
+
+1. Identify the `enrollment_id` to remove (from `list_course_enrollments` output, **not** the user_id — the tool takes `enrollment_id`).
+2. Pick the `task`:
+   - `conclude` — soft-end the enrollment, preserves grades and submissions for the user
+   - `delete` — hard-delete the enrollment row (user loses access immediately; submissions remain in the course but are detached from this enrollment)
+   - `deactivate` — set the enrollment to `inactive` (user keeps record but loses course access until reactivated)
+3. Show the admin a single-line preview, naming the user and the chosen task:
+
+   > "[Task] enrollment [enrollment_id] for [User Name] in [Course Name]? This [conclude/delete/deactivate]s the enrollment. (yes/no)"
+
+4. Only after confirmation: call `remove_enrollment` with `course_id`, `enrollment_id`, and `task`.
+5. Report `✓ [Task]d enrollment [enrollment_id]`.
+
+If the admin asks to "remove a user", default to `conclude` unless they explicitly request `delete`. `conclude` is reversible by re-enrolling the user; `delete` may not be.
+
+## Output Format
+
+```
+Admin Roster — Big State University
+
+ACCOUNT TREE
+• [1]   Root Account
+  • [42]  College of Engineering           187 courses, 4,021 users
+    • [120] Computer Science              52 courses
+    • [121] Mechanical Engineering        38 courses
+  • [43]  College of Liberal Arts          243 courses, 3,108 users
+
+WRITES THIS SESSION
+• Enrolled  Casey Chen → CS 101 (StudentEnrollment, active)        ✓ id 991204
+• Concluded Pat Kim    → CS 200 (enrollment 887211, task=conclude) ✓
+• Reports for [42]: 6 types available — see web UI to run
+```
+
+## Notes
+
+- **Account hierarchy is walked one level at a time.** `list_sub_accounts` returns direct children only. There is no `get_account_tree` aggregator; resist the urge to recurse the whole tree by default.
+- **`get_account_reports` is discovery-only.** It lists report types available to the account and the most recent instance of each, but this MCP server exposes no `start_report`, no `get_report_status`, and no `download_report`. To actually run a report, the admin uses the Canvas web UI. State this plainly when the user asks "can you run the [foo] report".
+- **`list_enrollments` is self-scoped.** It returns the authenticated admin's own enrollments. It is **not** a way to look up another user's enrollment list. Use `list_course_enrollments` per course instead, or `list_account_users` for account-level user discovery.
+- **`remove_enrollment` takes `enrollment_id`, not `user_id`.** A user with three enrollments in the same course (e.g., Student, Observer, TA in different sections) has three distinct enrollment rows. Pick the right one from `list_course_enrollments` output before calling `remove_enrollment`.
+- **Default `enroll_user` state is `invited`.** The user receives a Canvas invitation and must accept before they show up as `active`. If the admin wants immediate access, pass `enrollment_state: 'active'` explicitly.
+- **Privacy.** `list_account_users` and `list_account_courses` can return institution-wide PII. Treat this output the same as a payroll export — do not paste into shared chats or screen-share without redacting.
+- **Quotas.** A "show me everything" request against a large account (100k+ users, 10k+ courses) will paginate through hundreds of pages. Always offer the `search_term` filter first and ask the admin to narrow before pulling the full list.
+- **Permission errors.** A 403 from `list_sub_accounts`, `list_account_users`, or `get_account_reports` means the admin role does not have access to that specific sub-account, even if `list_accounts` returned the parent. Surface the 403 verbatim — do not silently retry.

--- a/skills/canvas-peer-review-tracker/SKILL.md
+++ b/skills/canvas-peer-review-tracker/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: canvas-peer-review-tracker
+description: Educator skill for tracking peer-review assignments in Canvas. Lists who has been asked to review whom, who has submitted versus who is still pending, and lets you assign new reviewers or send reminder messages — one student at a time. Trigger phrases include "peer reviews", "who hasn't done their peer review", "peer review status", "assign a peer reviewer", "remind students about peer reviews", or "peer review tracker".
+---
+
+# Canvas Peer Review Tracker
+
+Educator workflow for the peer-review surface canvas-lms-mcp actually exposes: list assignments, see who is pending, optionally create new peer-review assignments, and optionally send a reminder via Canvas Conversations. **One student at a time, with confirmation before every write.**
+
+## What this skill does NOT do
+
+canvas-lms-mcp ships **4 peer-review tools** today (`list_peer_reviews`, `get_submission_peer_reviews`, `create_peer_review`, `delete_peer_review`). It does not yet expose any of the analytics, reminder-campaign, or quality-scoring endpoints competing servers ship. This skill stays inside the surface we have. Do **not** fabricate calls to:
+
+1. **Completion-rate analytics** — there is no `get_peer_review_completion_analytics`. Completion percentages must be computed locally from the `list_peer_reviews` results, not retrieved as a server-side metric.
+2. **Comment-quality scoring** — there is no `analyze_peer_review_quality` and no way to read the comments students wrote on peer reviews. Do not attempt to "rate" peer review feedback.
+3. **Problematic-review detection** — there is no `identify_problematic_peer_reviews`. The skill cannot flag low-effort reviews automatically; it can only show which reviews are still incomplete.
+4. **Peer review comments** — there is no `get_peer_review_comments`. The skill can show that a review is `assigned` or `completed` (the `workflow_state` from `list_peer_reviews`), not the comment body.
+5. **Follow-up lists / dataset export** — there is no `get_peer_review_followup_list` and no `extract_peer_review_dataset`. The "who needs reminding" list is built locally from `workflow_state=assigned`.
+6. **Bulk reminder campaigns** — there is no `send_peer_review_reminders` or `send_peer_review_followup_campaign`. Reminders go through `send_conversation` **one recipient at a time**, with the same per-student confirmation pattern as `canvas-at-risk-students`.
+7. **Auto-generated reports** — there is no `generate_peer_review_report` or `generate_peer_review_feedback_report`. Any summary is built by this skill at presentation time; it is not a Canvas artefact.
+
+If a user asks for any of those, name the gap explicitly and stop. Do not invent tool calls.
+
+## Prerequisites
+
+- Canvas MCP server must be running and connected.
+- You must have instructor or TA role in the target course.
+- The assignment must have peer review enabled (`peer_reviews: true` on the assignment).
+- Student names appear in output — only run this in a private or educator-only session.
+- Reminder messages (Step 5) require Canvas Conversations to be enabled for the course.
+
+## Steps
+
+### 1. Identify the Target Course and Assignment
+
+Ask the educator which course and which peer-reviewed assignment to look at.
+
+If unclear, call `list_assignments` for the course and surface assignments with peer review enabled. Confirm the choice before continuing — peer-review status data is per assignment, so picking the wrong one wastes the rest of the walk.
+
+### 2. Pull the Peer Review Roster
+
+Call `list_peer_reviews` with the course ID and assignment ID. The response is one row per assignment of (reviewer, submission-being-reviewed) with a `workflow_state` of `assigned` or `completed` and the `user_id` of the reviewer.
+
+Compute locally:
+
+| Bucket | Meaning |
+|--------|---------|
+| **Completed** | `workflow_state == completed` |
+| **Pending** | `workflow_state == assigned` |
+| **Total assignments** | Sum of completed + pending |
+| **Completion rate** | `completed / total` (computed here, not fetched) |
+
+Note: this list is keyed by reviewer-and-submission. A single student can appear multiple times if they were assigned more than one peer to review.
+
+### 3. Resolve Names
+
+`list_peer_reviews` returns user IDs only. Call `list_course_enrollments` with `type=['StudentEnrollment']` and `state=['active']` once and build a `user_id → name` map for the rest of the session. **Do not re-query enrollments for every reviewer** — one call up front, lookup locally afterwards.
+
+### 4. Present the Tracker
+
+```
+Peer Review Tracker — [Course] › [Assignment]
+Total assignments: 60   Completed: 41 (68%)   Pending: 19
+
+PENDING REVIEWS  (19)
+• Alex Doe (id: 12345)        — review of submission 8821 (assigned 4 days ago)
+• Jordan Park (id: 12346)     — review of submission 8822 (assigned 4 days ago)
+• Sam Lee (id: 12347)         — review of submissions 8823 and 8825
+
+COMPLETED  (41)
+• [Summary list — collapse by default unless asked]
+```
+
+Group the pending list by reviewer so the educator sees "who has 2+ outstanding reviews" at a glance. **Do not** display anything that would require fetching review comments — those are not available through this tool surface.
+
+### 5. Send a Reminder (Optional, One Recipient at a Time)
+
+If the educator wants to remind pending reviewers, repeat 5a–5c **once per reviewer**. Do not batch.
+
+#### 5a. Draft the Message
+
+Show the educator a default subject line and body, e.g.:
+
+> Subject: Reminder — peer review for [Assignment] is still pending
+> Body: Hi [Name], this is a reminder that your peer review for [Assignment] in [Course] hasn't been submitted yet. The review window is still open — let me know if you're running into any issues. Thanks!
+
+Let the educator edit before each send.
+
+#### 5b. Confirm Per Reviewer
+
+Ask, exactly once per reviewer:
+
+> "Send this reminder to [Name] (user id [n])? (yes / edit / skip)"
+
+Do not proceed until the educator confirms. **Never confirm once and then send to multiple students.**
+
+#### 5c. Send
+
+After confirmation, call `send_conversation` with:
+- `recipients`: array containing the single reviewer's user ID **as a string** (the tool requires `string[]`, not numbers)
+- `subject`: the confirmed subject
+- `body`: the confirmed body
+
+Report `✓ Sent to [Name]` and move to the next reviewer.
+
+### 6. Assign a New Peer Reviewer (Optional)
+
+If the educator wants to add a missing peer-review assignment (e.g., a student joined late and was not auto-assigned a partner):
+
+1. Call `list_submissions` for the assignment so the educator can pick the submission to be reviewed.
+2. Identify the student you want to assign as the reviewer (by name, then look up the user ID from the enrollment map built in Step 3).
+3. Show the educator: "Assign [Reviewer Name] to peer-review submission [n] (by [Author Name])? (yes/no)"
+4. Only after confirmation: call `create_peer_review` with `course_id`, `assignment_id`, `submission_id`, and `user_id` (the reviewer).
+5. Report the new peer-review row. Re-run Step 2 if the educator wants the updated tracker.
+
+### 7. Inspect a Single Submission's Peer Reviews (Optional)
+
+If the educator wants to see every peer review tied to one specific submission (e.g., "what reviews were assigned for Jane Smith's paper?"):
+
+1. Call `list_submissions` and find the submission ID for Jane Smith.
+2. Call `get_submission` if the educator wants context about the submission itself.
+3. Call `get_submission_peer_reviews` with `course_id`, `assignment_id`, `submission_id`. This returns every reviewer assigned to that single submission with their workflow state.
+
+This is useful when triaging "did this student's paper get reviewed by anyone?" — it is the inverse view of Step 2 (which is reviewer-centric).
+
+## Output Format
+
+```
+Peer Review Tracker — [Course Name] › [Assignment Name]
+
+OVERVIEW
+Total assignments:  60
+Completed:          41 (68%)
+Pending:            19
+
+PENDING (grouped by reviewer)
+• Alex Doe              — 1 pending  (submission 8821)
+• Jordan Park           — 1 pending  (submission 8822)
+• Sam Lee               — 2 pending  (submissions 8823, 8825)
+
+REMINDERS THIS SESSION
+• Alex Doe       → message sent ✓
+• Jordan Park    → educator chose to skip
+• Sam Lee        → message sent ✓
+
+NEW ASSIGNMENTS THIS SESSION
+• Casey Chen → reviewing submission 8830 (Pat Kim)  ✓ created
+```
+
+## Notes
+
+- **Read-only by default.** Steps 1–4 do not modify any Canvas data. Write paths (`create_peer_review`, `send_conversation`) live in Steps 5 and 6 only, each gated by per-student confirmation.
+- **One reviewer at a time for reminders.** `send_conversation` accepts an array of recipients but the skill deliberately sends one recipient per call so the educator can audit and skip individuals. Do not collapse multiple reviewers into a single bulk send.
+- **`send_conversation` recipients are strings, not numbers.** The tool's `recipients` parameter is `string[]`. Convert user IDs with `String(id)` before sending.
+- **Completion percentage is computed locally.** Canvas does not return a server-side completion metric through this tool surface. The `(completed / total)` value comes from counting the `list_peer_reviews` rows yourself — do not invent another source.
+- **Workflow states are limited to `assigned` and `completed`.** There is no `in_progress` or `late` state surfaced through `list_peer_reviews`. "Late" is a local interpretation of `assigned` past the assignment's `peer_reviews_due_at` date, if set.
+- **Reviewer self-references.** Canvas occasionally returns peer-review rows where the reviewer ID equals the submission author's user ID (a misconfigured assignment). Surface these to the educator as "self-review — verify configuration" rather than counting them in the completion stats.
+- **No comment access.** This skill cannot show what a reviewer wrote. It can only confirm that a review is marked `completed`. If the educator needs to read peer-review comments, point them at the Canvas web UI.
+- **Reminder cadence.** Canvas does not deduplicate Conversation messages. Sending two reminders in quick succession will deliver two messages — track which reviewers were already pinged this session and warn the educator before re-sending.


### PR DESCRIPTION
## Summary

Adds two workflow-heavy `SKILL.md` files completing **Batch 3** of the canvas-lms-mcp skills catalog expansion. Source of truth: [`docs/superpowers/plans/2026-05-01-skills-expansion.md`](docs/superpowers/plans/2026-05-01-skills-expansion.md) §3 candidates 10–11, §4 Batch 3.

- **`canvas-peer-review-tracker`** (educator) — peer-review status tracker with optional `create_peer_review` and per-student `send_conversation` reminders. Explicit "What this skill does NOT do" section enumerates 7 missing competitor capabilities (completion-rate analytics, comment-quality scoring, problematic-review detection, peer-review comments, follow-up/dataset export, bulk reminder campaigns, auto-generated reports) so agents don't invent calls.
- **`canvas-admin-roster`** (admin — first admin-audience skill) — walks the Canvas account hierarchy via `list_accounts` → `list_sub_accounts` → `list_account_courses` / `list_account_users`, with confirmed per-action `enroll_user` / `remove_enrollment` write paths. Honest that `get_account_reports` is discovery-only (this MCP server exposes no `start_report` / `get_report_status`; new reports must be run from the Canvas web UI). Clarifies that `list_enrollments` returns the authenticated admin's own enrollments, not arbitrary users'.

Closes [BRU-806](https://canvas-lms-mcp.example/BRU/issues/BRU-806). Parent: BRU-800.

## Verification

- [x] All 16 cited tool names verified to exist in `src/tools/*.ts` on `origin/main`
- [x] Both skills follow the structure of `skills/canvas-at-risk-students/SKILL.md` and the Batch 1/2 outputs (frontmatter, Prerequisites, numbered Steps, Output format code fence, Notes)
- [x] Description leads with audience word: "Educator skill…" / "Admin skill…"
- [x] `Trigger phrases include …` sentence present in both
- [x] Read-only steps come first in both skills; every write step is gated by per-action user confirmation (matching the `canvas-at-risk-students` outreach pattern)
- [x] No `designer` value introduced in tooling metadata (admin-roster uses `admin`; the audience word in description text is the only place audience varies)
- [x] No `src/` changes; no skills.sh changes
- [x] No revisions to the 3 v1.9.0 skills (deferred per plan §1.4)

## Honest scoping notes (per task description)

`canvas-peer-review-tracker` calls out that we have **4 of competitor's 11 peer-review tools** and lists the 7 capability gaps explicitly. Phrased as a workflow tracker, not an analytics suite.

`canvas-admin-roster` declares the admin-token requirement up top. The account-reports section explicitly states that `get_account_reports` does not start or poll a report — verified by reading `src/canvas/accounts.ts` (it hits `/api/v1/accounts/{id}/reports`, which lists report types, not run status). Tells the user to use the Canvas UI to actually run a report.

## Test plan

- [ ] QA: read both `SKILL.md` files end-to-end
- [ ] QA: grep every backticked tool name against `src/tools/*.ts` to confirm no fabricated names (the missing-tool callouts are explicitly labelled as "we do NOT have")
- [ ] QA: verify frontmatter (`name` matches directory name, `description` leads with audience word, `Trigger phrases include …` present)
- [ ] QA: verify write-path confirmation pattern matches `canvas-at-risk-students` (per-action, never batched)
- [ ] CTO: final review

🤖 Generated with [Claude Code](https://claude.com/claude-code)