### PR TITLE
docs(tools): add permanence notes to delete-tool descriptions

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -144,7 +144,7 @@
     {
       "name": "delete_assignment",
       "domain": "assignments",
-      "description": "Delete an assignment from a course.",
+      "description": "Delete an assignment from a course. This action is permanent.",
       "annotations": {
         "destructiveHint": true,
         "idempotentHint": true,
@@ -582,7 +582,7 @@
     {
       "name": "remove_enrollment",
       "domain": "enrollments",
-      "description": "Remove or conclude an enrollment from a course.",
+      "description": "Remove or conclude an enrollment from a course. The 'delete' task is permanent; 'conclude' and 'deactivate' are reversible.",
       "annotations": {
         "destructiveHint": true,
         "openWorldHint": true
@@ -666,7 +666,7 @@
     {
       "name": "delete_discussion",
       "domain": "discussions",
-      "description": "Delete a discussion topic from a course.",
+      "description": "Delete a discussion topic from a course. This action is permanent.",
       "annotations": {
         "destructiveHint": true,
         "openWorldHint": true
@@ -798,7 +798,7 @@
     {
       "name": "delete_page",
       "domain": "pages",
-      "description": "Delete a wiki page from a course.",
+      "description": "Delete a wiki page from a course. This action is permanent.",
       "annotations": {
         "destructiveHint": true,
         "openWorldHint": true
@@ -930,7 +930,7 @@
     {
       "name": "delete_peer_review",
       "domain": "peer_reviews",
-      "description": "Remove a peer review assignment from a submission.",
+      "description": "Remove a peer review assignment from a submission. This action is permanent.",
       "annotations": {
         "destructiveHint": true,
         "openWorldHint": true

--- a/src/tools/assignments.ts
+++ b/src/tools/assignments.ts
@@ -294,7 +294,7 @@ export function assignmentTools(canvas: CanvasClient): ToolDefinition[] {
     },
     {
       name: 'delete_assignment',
-      description: 'Delete an assignment from a course.',
+      description: 'Delete an assignment from a course. This action is permanent.',
       inputSchema: {
         course_id: z.number().describe('The Canvas course ID'),
         assignment_id: z.number().describe('The Canvas assignment ID to delete'),

--- a/src/tools/discussions.ts
+++ b/src/tools/discussions.ts
@@ -137,7 +137,7 @@ export function discussionTools(canvas: CanvasClient): ToolDefinition[] {
     },
     {
       name: 'delete_discussion',
-      description: 'Delete a discussion topic from a course.',
+      description: 'Delete a discussion topic from a course. This action is permanent.',
       inputSchema: {
         course_id: z.number().describe('The Canvas course ID'),
         topic_id: z.number().describe('The Canvas discussion topic ID to delete'),

--- a/src/tools/enrollments.ts
+++ b/src/tools/enrollments.ts
@@ -178,7 +178,8 @@ export function enrollmentTools(canvas: CanvasClient): ToolDefinition[] {
     },
     {
       name: 'remove_enrollment',
-      description: 'Remove or conclude an enrollment from a course.',
+      description:
+        "Remove or conclude an enrollment from a course. The 'delete' task is permanent; 'conclude' and 'deactivate' are reversible.",
       inputSchema: {
         course_id: z.number().describe('The Canvas course ID'),
         enrollment_id: z.number().describe('The enrollment ID to remove'),

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -94,7 +94,7 @@ export function pageTools(canvas: CanvasClient): ToolDefinition[] {
     },
     {
       name: 'delete_page',
-      description: 'Delete a wiki page from a course.',
+      description: 'Delete a wiki page from a course. This action is permanent.',
       inputSchema: {
         course_id: z.number().describe('The Canvas course ID'),
         page_url: z.string().describe('The page URL slug to delete'),

--- a/src/tools/peer-reviews.ts
+++ b/src/tools/peer-reviews.ts
@@ -63,7 +63,7 @@ export function peerReviewTools(canvas: CanvasClient): ToolDefinition[] {
     },
     {
       name: 'delete_peer_review',
-      description: 'Remove a peer review assignment from a submission.',
+      description: 'Remove a peer review assignment from a submission. This action is permanent.',
       inputSchema: {
         course_id: z.number().describe('The Canvas course ID'),
         assignment_id: z.number().describe('The Canvas assignment ID'),


### PR DESCRIPTION
## Summary

- Adds `This action is permanent.` to `delete_assignment`, `delete_discussion`, `delete_page`, and `delete_peer_review` descriptions
- Adds a nuanced note to `remove_enrollment` clarifying that `'delete'` is permanent while `'conclude'` and `'deactivate'` are reversible
- Mirrors the existing permanence note already on `delete_file` and the pattern used by vishalsachdev/canvas-mcp v1.3.0 (#96)
- No handler, schema, or annotation changes — description text only

Closes BRU-911

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean
- [ ] Confirm descriptions appear correctly in an MCP host tool list

🤖 Generated with [Claude Code](https://claude.com/claude-code)