### PR TITLE
feat(rubrics): add create_rubric tool with bracket-notation form-data

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 106,
+  "toolCount": 107,
   "tools": [
     {
       "name": "health_check",
@@ -265,6 +265,18 @@
       "relatedWorkflows": [
         "educator-assignment-review"
       ]
+    },
+    {
+      "name": "create_rubric",
+      "domain": "rubrics",
+      "description": "Create a new rubric in a course with criteria and rating levels. Optionally link it to an assignment immediately.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
     },
     {
       "name": "list_quizzes",

--- a/src/canvas/rubrics.ts
+++ b/src/canvas/rubrics.ts
@@ -1,6 +1,28 @@
 import type { CanvasHttpClient } from './client'
 import type { CanvasRubric, CanvasRubricAssessment, CanvasSubmission } from './types'
 
+export interface RubricRatingInput {
+  description: string
+  points: number
+}
+
+export interface RubricCriterionInput {
+  description: string
+  points: number
+  ratings: RubricRatingInput[]
+}
+
+export interface RubricCreateInput {
+  title: string
+  criteria: RubricCriterionInput[]
+}
+
+export interface RubricAssociationInput {
+  assignment_id: number
+  use_for_grading?: boolean
+  purpose?: string
+}
+
 export class RubricsModule {
   constructor(private client: CanvasHttpClient) {}
 
@@ -34,5 +56,43 @@ export class RubricsModule {
         body: JSON.stringify({ rubric_assessment: { data } }),
       },
     )
+  }
+
+  async create(
+    courseId: number,
+    rubric: RubricCreateInput,
+    association?: RubricAssociationInput,
+  ): Promise<CanvasRubric> {
+    const params = new URLSearchParams()
+    params.append('rubric[title]', rubric.title)
+
+    rubric.criteria.forEach((criterion, ci) => {
+      params.append(`rubric[criteria][${ci}][description]`, criterion.description)
+      params.append(`rubric[criteria][${ci}][points]`, String(criterion.points))
+
+      // Sort ratings highest → lowest before encoding
+      const sortedRatings = [...criterion.ratings].sort((a, b) => b.points - a.points)
+      sortedRatings.forEach((rating, ri) => {
+        params.append(`rubric[criteria][${ci}][ratings][${ri}][description]`, rating.description)
+        params.append(`rubric[criteria][${ci}][ratings][${ri}][points]`, String(rating.points))
+      })
+    })
+
+    if (association) {
+      params.append('rubric_association[association_id]', String(association.assignment_id))
+      params.append('rubric_association[association_type]', 'Assignment')
+      if (association.use_for_grading !== undefined) {
+        params.append('rubric_association[use_for_grading]', String(association.use_for_grading))
+      }
+      if (association.purpose) {
+        params.append('rubric_association[purpose]', association.purpose)
+      }
+    }
+
+    return this.client.request<CanvasRubric>(`/api/v1/courses/${courseId}/rubrics`, {
+      method: 'POST',
+      body: params.toString(),
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    })
   }
 }

--- a/src/tools/rubrics.ts
+++ b/src/tools/rubrics.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod'
 import type { CanvasClient } from '../canvas'
+import type {
+  RubricAssociationInput,
+  RubricCriterionInput,
+  RubricCreateInput,
+} from '../canvas/rubrics'
 import type { ToolDefinition } from './types'
 
 export function rubricTools(canvas: CanvasClient): ToolDefinition[] {
@@ -85,6 +90,57 @@ export function rubricTools(canvas: CanvasClient): ToolDefinition[] {
           comments: string
         }>
         return canvas.rubrics.submitAssessment(course_id, association_id, data)
+      },
+    },
+    {
+      name: 'create_rubric',
+      description:
+        'Create a new rubric in a course with criteria and rating levels. Optionally link it to an assignment immediately.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        title: z.string().describe('The rubric title'),
+        criteria: z
+          .array(
+            z.object({
+              description: z.string().describe('Criterion description'),
+              points: z.number().describe('Maximum points for this criterion'),
+              ratings: z
+                .array(
+                  z.object({
+                    description: z.string().describe('Rating level description'),
+                    points: z.number().describe('Points for this rating level'),
+                  }),
+                )
+                .min(2, 'Each criterion must have at least 2 rating levels')
+                .describe('Rating levels for this criterion (highest to lowest)'),
+            }),
+          )
+          .min(1, 'At least one criterion is required')
+          .describe('Rubric criteria'),
+        association: z
+          .object({
+            assignment_id: z.number().describe('Assignment ID to link this rubric to'),
+            use_for_grading: z
+              .boolean()
+              .optional()
+              .describe('Whether to use this rubric for grading'),
+            purpose: z.string().optional().describe('Purpose of the association (e.g., "grading")'),
+          })
+          .optional()
+          .describe('Optional assignment association'),
+      },
+      annotations: {
+        destructiveHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const course_id = params.course_id as number
+        const rubric: RubricCreateInput = {
+          title: params.title as string,
+          criteria: params.criteria as RubricCriterionInput[],
+        }
+        const association = params.association as RubricAssociationInput | undefined
+        return canvas.rubrics.create(course_id, rubric, association)
       },
     },
   ]

--- a/tests/canvas/rubrics.test.ts
+++ b/tests/canvas/rubrics.test.ts
@@ -64,4 +64,123 @@ describe('RubricsModule', () => {
       },
     )
   })
+
+  describe('create', () => {
+    const mockCreatedRubric = {
+      id: 42,
+      title: 'Essay Rubric',
+      points_possible: 17,
+      data: [],
+    }
+
+    it('POSTs bracket-notation form-data to the rubrics endpoint', async () => {
+      vi.spyOn(client, 'request').mockResolvedValueOnce(mockCreatedRubric)
+
+      await rubrics.create(100, {
+        title: 'Essay Rubric',
+        criteria: [
+          {
+            description: 'Content Quality',
+            points: 10,
+            ratings: [
+              { description: 'Excellent', points: 10 },
+              { description: 'Good', points: 7 },
+            ],
+          },
+        ],
+      })
+
+      const [endpoint, options] = vi.mocked(client.request).mock.calls[0]
+      expect(endpoint).toBe('/api/v1/courses/100/rubrics')
+      expect(options?.method).toBe('POST')
+      expect(options?.headers).toMatchObject({
+        'Content-Type': 'application/x-www-form-urlencoded',
+      })
+
+      const body = new URLSearchParams(options?.body as string)
+      expect(body.get('rubric[title]')).toBe('Essay Rubric')
+      expect(body.get('rubric[criteria][0][description]')).toBe('Content Quality')
+      expect(body.get('rubric[criteria][0][points]')).toBe('10')
+      expect(body.get('rubric[criteria][0][ratings][0][description]')).toBe('Excellent')
+      expect(body.get('rubric[criteria][0][ratings][0][points]')).toBe('10')
+      expect(body.get('rubric[criteria][0][ratings][1][description]')).toBe('Good')
+      expect(body.get('rubric[criteria][0][ratings][1][points]')).toBe('7')
+    })
+
+    it('sorts ratings highest to lowest before encoding', async () => {
+      vi.spyOn(client, 'request').mockResolvedValueOnce(mockCreatedRubric)
+
+      await rubrics.create(100, {
+        title: 'Sorted Rubric',
+        criteria: [
+          {
+            description: 'Writing',
+            points: 10,
+            ratings: [
+              { description: 'Poor', points: 2 },
+              { description: 'Excellent', points: 10 },
+              { description: 'Good', points: 7 },
+            ],
+          },
+        ],
+      })
+
+      const [, options] = vi.mocked(client.request).mock.calls[0]
+      const body = new URLSearchParams(options?.body as string)
+      expect(body.get('rubric[criteria][0][ratings][0][points]')).toBe('10')
+      expect(body.get('rubric[criteria][0][ratings][1][points]')).toBe('7')
+      expect(body.get('rubric[criteria][0][ratings][2][points]')).toBe('2')
+    })
+
+    it('includes rubric_association keys when association is provided', async () => {
+      vi.spyOn(client, 'request').mockResolvedValueOnce(mockCreatedRubric)
+
+      await rubrics.create(
+        100,
+        {
+          title: 'Linked Rubric',
+          criteria: [
+            {
+              description: 'Thesis',
+              points: 10,
+              ratings: [
+                { description: 'Excellent', points: 10 },
+                { description: 'Poor', points: 0 },
+              ],
+            },
+          ],
+        },
+        { assignment_id: 55, use_for_grading: true, purpose: 'grading' },
+      )
+
+      const [, options] = vi.mocked(client.request).mock.calls[0]
+      const body = new URLSearchParams(options?.body as string)
+      expect(body.get('rubric_association[association_id]')).toBe('55')
+      expect(body.get('rubric_association[association_type]')).toBe('Assignment')
+      expect(body.get('rubric_association[use_for_grading]')).toBe('true')
+      expect(body.get('rubric_association[purpose]')).toBe('grading')
+    })
+
+    it('omits rubric_association keys when no association is provided', async () => {
+      vi.spyOn(client, 'request').mockResolvedValueOnce(mockCreatedRubric)
+
+      await rubrics.create(100, {
+        title: 'Standalone Rubric',
+        criteria: [
+          {
+            description: 'Content',
+            points: 5,
+            ratings: [
+              { description: 'Good', points: 5 },
+              { description: 'Poor', points: 0 },
+            ],
+          },
+        ],
+      })
+
+      const [, options] = vi.mocked(client.request).mock.calls[0]
+      const body = new URLSearchParams(options?.body as string)
+      expect(body.get('rubric_association[association_id]')).toBeNull()
+    })
+  })
 })

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(106)
+    expect(manifest.tools).toHaveLength(107)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -32,6 +32,7 @@ function buildFullMockCanvas(): CanvasClient {
       get: async () => ({}),
       getAssessment: async () => ({}),
       submitAssessment: async () => ({}),
+      create: async () => ({}),
     },
     quizzes: {
       list: async () => [],
@@ -155,7 +156,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 105 tools across all domains', () => {
+  it('returns all 106 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 
@@ -179,11 +180,12 @@ describe('getAllTools', () => {
     expect(names).toContain('get_submission')
     expect(names).toContain('grade_submission')
     expect(names).toContain('comment_on_submission')
-    // Rubrics (4)
+    // Rubrics (5)
     expect(names).toContain('list_rubrics')
     expect(names).toContain('get_rubric')
     expect(names).toContain('get_rubric_assessment')
     expect(names).toContain('submit_rubric_assessment')
+    expect(names).toContain('create_rubric')
     // Quizzes (6)
     expect(names).toContain('list_quizzes')
     expect(names).toContain('get_quiz')
@@ -288,7 +290,7 @@ describe('getAllTools', () => {
     expect(names).toContain('get_upcoming_events')
     expect(names).toContain('get_missing_submissions')
 
-    expect(tools).toHaveLength(106)
+    expect(tools).toHaveLength(107)
   })
 
   it('all tools have openWorldHint: true', () => {
@@ -306,6 +308,7 @@ describe('getAllTools', () => {
       'grade_submission',
       'comment_on_submission',
       'submit_rubric_assessment',
+      'create_rubric',
       'score_quiz_question',
       'post_discussion_entry',
       'create_discussion',
@@ -344,6 +347,7 @@ describe('getAllTools', () => {
       'grade_submission',
       'comment_on_submission',
       'submit_rubric_assessment',
+      'create_rubric',
       'score_quiz_question',
       'post_discussion_entry',
       'create_discussion',

--- a/tests/tools/rubrics.test.ts
+++ b/tests/tools/rubrics.test.ts
@@ -38,13 +38,14 @@ describe('rubricTools', () => {
         get: vi.fn().mockResolvedValue(mockRubric),
         getAssessment: vi.fn().mockResolvedValue(mockSubmission),
         submitAssessment: vi.fn().mockResolvedValue(mockAssessment),
+        create: vi.fn().mockResolvedValue(mockRubric),
       },
     } as unknown as CanvasClient
   }
 
-  it('returns an array with 4 tool definitions', () => {
+  it('returns an array with 5 tool definitions', () => {
     const tools = rubricTools(buildMockCanvas())
-    expect(tools).toHaveLength(4)
+    expect(tools).toHaveLength(5)
   })
 
   it('exports tools with correct names', () => {
@@ -54,6 +55,7 @@ describe('rubricTools', () => {
       'get_rubric',
       'get_rubric_assessment',
       'submit_rubric_assessment',
+      'create_rubric',
     ])
   })
 
@@ -119,6 +121,57 @@ describe('rubricTools', () => {
       const data = [{ criterion_id: 'c1', points: 25, comments: 'Good' }]
       await tool.handler({ course_id: 1, association_id: 10, data })
       expect(canvas.rubrics.submitAssessment).toHaveBeenCalledWith(1, 10, data)
+    })
+  })
+
+  describe('create_rubric', () => {
+    const validCriteria = [
+      {
+        description: 'Content Quality',
+        points: 10,
+        ratings: [
+          { description: 'Excellent', points: 10 },
+          { description: 'Poor', points: 0 },
+        ],
+      },
+    ]
+
+    it('has destructive and openWorld annotations', () => {
+      const tool = rubricTools(buildMockCanvas()).find((t) => t.name === 'create_rubric')!
+      expect(tool.annotations).toEqual({ destructiveHint: true, openWorldHint: true })
+    })
+
+    it('delegates to canvas.rubrics.create without association', async () => {
+      const canvas = buildMockCanvas()
+      const tool = rubricTools(canvas).find((t) => t.name === 'create_rubric')!
+      const result = await tool.handler({
+        course_id: 1,
+        title: 'Essay Rubric',
+        criteria: validCriteria,
+      })
+      expect(canvas.rubrics.create).toHaveBeenCalledWith(
+        1,
+        { title: 'Essay Rubric', criteria: validCriteria },
+        undefined,
+      )
+      expect(result).toEqual(mockRubric)
+    })
+
+    it('delegates to canvas.rubrics.create with association', async () => {
+      const canvas = buildMockCanvas()
+      const tool = rubricTools(canvas).find((t) => t.name === 'create_rubric')!
+      const association = { assignment_id: 55, use_for_grading: true, purpose: 'grading' }
+      await tool.handler({
+        course_id: 1,
+        title: 'Essay Rubric',
+        criteria: validCriteria,
+        association,
+      })
+      expect(canvas.rubrics.create).toHaveBeenCalledWith(
+        1,
+        { title: 'Essay Rubric', criteria: validCriteria },
+        association,
+      )
     })
   })
 })


### PR DESCRIPTION
## Summary

- Adds `canvas.rubrics.create(courseId, rubric, association?)` to `src/canvas/rubrics.ts` — builds bracket-notation `URLSearchParams` (e.g. `rubric[criteria][0][ratings][0][description]`) and POSTs with `Content-Type: application/x-www-form-urlencoded`, bypassing the Canvas CloudFront JSON rejection
- Sorts ratings highest→lowest before encoding per the issue spec
- Optionally appends `rubric_association[...]` keys for immediate assignment linkage
- Adds `create_rubric` MCP tool to `src/tools/rubrics.ts` with Zod schema: `criteria` requires ≥1 item, each criterion's `ratings` requires ≥2 items — client-side validation saves a Canvas 500 round-trip
- Annotations: `destructiveHint: true`, `openWorldHint: true` (not idempotent — each call creates a new rubric)
- Regenerated `docs/generated/tool-manifest.json` (tool count: 106 → 107)

Closes [BRU-910](/BRU/issues/BRU-910).

## Test plan

- [ ] `pnpm typecheck` — passes (no type errors)
- [ ] `pnpm lint` — passes (ESLint + Prettier clean)
- [ ] `pnpm test` — 609/609 tests pass, including new tests in `tests/canvas/rubrics.test.ts` and `tests/tools/rubrics.test.ts`
- [ ] `pnpm build` — ESM + CJS bundles build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)