### PR TITLE
fix(tests): update registry test description to 107 tools

### DIFF
--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -156,7 +156,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 106 tools across all domains', () => {
+  it('returns all 107 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 


### PR DESCRIPTION
## Summary

- Fixes off-by-one in the `it()` description of the registry test: `returns all 106 tools across all domains` → `returns all 107 tools across all domains`
- The `toHaveLength(107)` assertion was already correct (updated when `create_rubric` was added in #106); only the string description was stale

## Test plan

- [x] All 609 tests pass (`pnpm test`)
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)