### PR TITLE
docs(specs): rename --version flag to --pin in CLI wizard spec [BRU-785]

### DIFF
--- a/docs/superpowers/specs/2026-05-07-cli-setup-wizard.md
+++ b/docs/superpowers/specs/2026-05-07-cli-setup-wizard.md
@@ -41,7 +41,7 @@ This document is design-only. It does not change current implementation.
 
 ```
 npx canvas-lms-mcp init [--client <id>...] [--token <t>] [--base-url <u>]
-                        [--server-name <name>] [--version <semver>]
+                        [--server-name <name>] [--pin <semver>]
                         [--non-interactive] [--dry-run] [--no-backup]
                         [--yes]
 ```
@@ -193,9 +193,16 @@ documentation/wizard mismatch.
 ### Version pinning
 
 By default the wizard writes `args: ["-y", "canvas-lms-mcp"]` — unpinned, the
-same as our README. With `--version <semver>` it writes
+same as our README. With `--pin <semver>` it writes
 `canvas-lms-mcp@<semver>`. Rationale: most users want auto-upgrade; users with
 production setups want pinning, and they explicitly opt in.
+
+The flag is `--pin`, not `--version`, because `--version` is the conventional
+way to ask any CLI to print its own version (e.g.,
+`npx canvas-lms-mcp --version` should print `1.12.0`, not configure pinning).
+Reusing `--version` here would silently shadow that convention. We reserve
+`--version` / `-v` for the version-print subcommand whenever Task 1 wires
+`init`'s argv parser.
 
 ## Inputs
 
@@ -205,7 +212,7 @@ production setups want pinning, and they explicitly opt in.
 | Canvas API token | `--token` flag → `CANVAS_API_TOKEN` env → prompt (masked input) | yes | non-empty; live-pinged against `/api/v1/users/self` (see Validation) |
 | Selected clients | `--client <id>` (repeatable) → multiselect prompt | yes | at least one; each must be in `clients.ts` |
 | Server entry name | `--server-name` flag → defaults to `canvas-lms` | no | matches `/^[a-z][a-z0-9-]{0,40}$/` |
-| Pinned version | `--version` flag → unpinned | no | parses as semver |
+| Pinned version | `--pin` flag → unpinned | no | parses as semver |
 
 The token prompt uses `prompts`'s `password` type so the value is not echoed
 or saved to shell history. We never persist the token anywhere except into the


### PR DESCRIPTION
## Summary

Addresses CTO nit on merged PR #109: `--version <semver>` for canvas-lms-mcp version pinning conflicts with the conventional `--version` for printing the CLI's own version. Renamed to `--pin <semver>` and added a one-paragraph note explaining the reservation so Task 1 (Core infrastructure, not yet filed) inherits the corrected design.

## Why land this on top of the merged spec

The original spec is already merged to `main` (#109). The implementer of Task 1 will read the spec, not the PR review thread, so the rename belongs in the spec itself. Cheap to fix now; expensive (and confusing) if Task 1 ships with `--version` and gets reviewed later.

## Test plan

- [ ] CTO confirms the rename matches their nit (no other flag conflicts intended).
- [ ] No code changes — `pnpm test` / `pnpm typecheck` not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)