### PR TITLE
feat(init): CLI wizard core infrastructure (BRU-952)

### DIFF
--- a/bin/canvas-lms-mcp.js
+++ b/bin/canvas-lms-mcp.js
@@ -1,3 +1,11 @@
 #!/usr/bin/env node
 
-import '../dist/stdio.js'
+const sub = process.argv[2]
+
+if (sub === 'init') {
+  await import('../dist/init.js')
+} else if (sub === 'serve') {
+  await import('../dist/http.js')
+} else {
+  await import('../dist/stdio.js')
+}

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// init wizard entry — Task 1 stub. Subsequent tasks (BRU-?) wire the wizard
+// (prompts, Canvas /users/self validation) and config writers.
+
+import { helpText, parseInitArgs } from './init/argv'
+
+async function main() {
+  const args = process.argv.slice(2)
+  if (args[0] === 'init') args.shift()
+  const result = parseInitArgs(args)
+  if (!result.ok) {
+    console.error(`Error: ${result.message}`)
+    process.exit(2)
+  }
+  if (result.config.showHelp) {
+    console.log(helpText())
+    process.exit(0)
+  }
+  console.log('canvas-lms-mcp init: setup wizard coming soon.')
+  console.log(
+    'For now, configure your MCP client manually — see https://github.com/bruchris/canvas-lms-mcp#setup',
+  )
+  process.exit(0)
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error)
+  process.exit(1)
+})

--- a/src/init/argv.ts
+++ b/src/init/argv.ts
@@ -1,0 +1,164 @@
+import { CLIENT_IDS, type ClientId } from './clients'
+
+export interface InitConfig {
+  clients: ClientId[]
+  token?: string
+  baseUrl?: string
+  serverName: string
+  pin?: string
+  nonInteractive: boolean
+  dryRun: boolean
+  noBackup: boolean
+  showHelp: boolean
+}
+
+export interface InitError {
+  ok: false
+  message: string
+  flag?: string
+}
+
+export type ParseInitResult = { ok: true; config: InitConfig } | InitError
+
+const SERVER_NAME_RE = /^[a-z][a-z0-9-]{0,40}$/
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/
+
+export function parseInitArgs(args: string[]): ParseInitResult {
+  const config: InitConfig = {
+    clients: [],
+    token: process.env.CANVAS_API_TOKEN || undefined,
+    baseUrl: process.env.CANVAS_BASE_URL || undefined,
+    serverName: 'canvas-lms',
+    pin: undefined,
+    nonInteractive: false,
+    dryRun: false,
+    noBackup: false,
+    showHelp: false,
+  }
+
+  const requireValue = (flag: string, value: string | undefined): InitError | string => {
+    if (value === undefined || value.startsWith('--')) {
+      return { ok: false, message: `Missing value for ${flag}`, flag }
+    }
+    return value
+  }
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    switch (arg) {
+      case '-h':
+      case '--help':
+        config.showHelp = true
+        break
+      case '--client': {
+        const v = requireValue(arg, args[++i])
+        if (typeof v !== 'string') return v
+        if (!CLIENT_IDS.includes(v as ClientId)) {
+          return {
+            ok: false,
+            message: `Unknown client "${v}". Supported: ${CLIENT_IDS.join(', ')}`,
+            flag: '--client',
+          }
+        }
+        if (!config.clients.includes(v as ClientId)) {
+          config.clients.push(v as ClientId)
+        }
+        break
+      }
+      case '--token': {
+        const v = requireValue(arg, args[++i])
+        if (typeof v !== 'string') return v
+        config.token = v
+        break
+      }
+      case '--base-url': {
+        const v = requireValue(arg, args[++i])
+        if (typeof v !== 'string') return v
+        const urlError = validateBaseUrl(v)
+        if (urlError) return urlError
+        config.baseUrl = v
+        break
+      }
+      case '--server-name': {
+        const v = requireValue(arg, args[++i])
+        if (typeof v !== 'string') return v
+        if (!SERVER_NAME_RE.test(v)) {
+          return {
+            ok: false,
+            message: `--server-name must match /^[a-z][a-z0-9-]{0,40}$/, got "${v}"`,
+            flag: '--server-name',
+          }
+        }
+        config.serverName = v
+        break
+      }
+      case '--pin': {
+        const v = requireValue(arg, args[++i])
+        if (typeof v !== 'string') return v
+        if (!SEMVER_RE.test(v)) {
+          return {
+            ok: false,
+            message: `--pin must be a semver string (e.g., 1.12.0), got "${v}"`,
+            flag: '--pin',
+          }
+        }
+        config.pin = v
+        break
+      }
+      case '--non-interactive':
+      case '--yes':
+        config.nonInteractive = true
+        break
+      case '--dry-run':
+        config.dryRun = true
+        break
+      case '--no-backup':
+        config.noBackup = true
+        break
+      default:
+        return { ok: false, message: `Unknown argument: ${arg}`, flag: arg }
+    }
+  }
+
+  return { ok: true, config }
+}
+
+function validateBaseUrl(value: string): InitError | undefined {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    return {
+      ok: false,
+      message: `--base-url is not a valid URL: ${value}`,
+      flag: '--base-url',
+    }
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    return {
+      ok: false,
+      message: `--base-url must use http(s):// (got ${url.protocol})`,
+      flag: '--base-url',
+    }
+  }
+  return undefined
+}
+
+export function helpText(): string {
+  return `Usage: canvas-lms-mcp init [options]
+
+Configures the canvas-lms-mcp server in one or more MCP clients.
+
+Options:
+  --client <id>           MCP client to configure (repeatable). Supported:
+                          ${CLIENT_IDS.join(', ')}
+  --token <t>             Canvas API token (else CANVAS_API_TOKEN, else prompt)
+  --base-url <u>          Canvas base URL (else CANVAS_BASE_URL, else prompt)
+  --server-name <name>    MCP server entry name (default: canvas-lms)
+  --pin <semver>          Pin to canvas-lms-mcp@<semver> instead of latest
+  --non-interactive       Fail rather than prompt; alias --yes
+  --dry-run               Print planned changes; do not write
+  --no-backup             Do not write <file>.bak before each change
+  -h, --help              Show this help and exit
+`
+}

--- a/src/init/clients.ts
+++ b/src/init/clients.ts
@@ -1,0 +1,130 @@
+import { homedir } from 'node:os'
+import { posix as posixPath, win32 as winPath } from 'node:path'
+
+export type ClientId =
+  | 'claude-desktop'
+  | 'claude-code'
+  | 'cursor'
+  | 'vscode'
+  | 'windsurf'
+  | 'codex'
+  | 'continue'
+
+export type ConfigFormat = 'json' | 'toml'
+
+export interface ClientDescriptor {
+  id: ClientId
+  name: string
+  format: ConfigFormat
+  wrapperKey: string
+  resolvePath: (env: PathEnv) => string
+}
+
+export interface PathEnv {
+  platform: NodeJS.Platform
+  home: string
+  appData?: string
+}
+
+const winAppDataOrThrow = (env: PathEnv): string => {
+  if (!env.appData) {
+    throw new Error('Cannot resolve Windows config path: %APPDATA% is not set')
+  }
+  return env.appData
+}
+
+const joinFor = (platform: NodeJS.Platform) =>
+  platform === 'win32' ? winPath.join : posixPath.join
+
+export const CLIENTS: readonly ClientDescriptor[] = [
+  {
+    id: 'claude-desktop',
+    name: 'Claude Desktop',
+    format: 'json',
+    wrapperKey: 'mcpServers',
+    resolvePath: (env) => {
+      const join = joinFor(env.platform)
+      switch (env.platform) {
+        case 'win32':
+          return join(winAppDataOrThrow(env), 'Claude', 'claude_desktop_config.json')
+        case 'darwin':
+          return join(
+            env.home,
+            'Library',
+            'Application Support',
+            'Claude',
+            'claude_desktop_config.json',
+          )
+        default:
+          return join(env.home, '.config', 'Claude', 'claude_desktop_config.json')
+      }
+    },
+  },
+  {
+    id: 'claude-code',
+    name: 'Claude Code',
+    format: 'json',
+    wrapperKey: 'mcpServers',
+    resolvePath: (env) => joinFor(env.platform)(env.home, '.claude.json'),
+  },
+  {
+    id: 'cursor',
+    name: 'Cursor',
+    format: 'json',
+    wrapperKey: 'mcpServers',
+    resolvePath: (env) => joinFor(env.platform)(env.home, '.cursor', 'mcp.json'),
+  },
+  {
+    id: 'vscode',
+    name: 'VS Code (Copilot)',
+    format: 'json',
+    wrapperKey: 'servers',
+    resolvePath: (env) => {
+      const join = joinFor(env.platform)
+      switch (env.platform) {
+        case 'win32':
+          return join(winAppDataOrThrow(env), 'Code', 'User', 'mcp.json')
+        case 'darwin':
+          return join(env.home, 'Library', 'Application Support', 'Code', 'User', 'mcp.json')
+        default:
+          return join(env.home, '.config', 'Code', 'User', 'mcp.json')
+      }
+    },
+  },
+  {
+    id: 'windsurf',
+    name: 'Windsurf',
+    format: 'json',
+    wrapperKey: 'mcpServers',
+    resolvePath: (env) =>
+      joinFor(env.platform)(env.home, '.codeium', 'windsurf', 'mcp_config.json'),
+  },
+  {
+    id: 'codex',
+    name: 'Codex CLI',
+    format: 'toml',
+    wrapperKey: 'mcp_servers',
+    resolvePath: (env) => joinFor(env.platform)(env.home, '.codex', 'config.toml'),
+  },
+  {
+    id: 'continue',
+    name: 'Continue',
+    format: 'json',
+    wrapperKey: 'mcpServers',
+    resolvePath: (env) => joinFor(env.platform)(env.home, '.continue', 'config.json'),
+  },
+] as const
+
+export const CLIENT_IDS: readonly ClientId[] = CLIENTS.map((c) => c.id)
+
+export function getClient(id: string): ClientDescriptor | undefined {
+  return CLIENTS.find((c) => c.id === id)
+}
+
+export function currentPathEnv(): PathEnv {
+  return {
+    platform: process.platform,
+    home: homedir(),
+    appData: process.env.APPDATA,
+  }
+}

--- a/src/init/io.ts
+++ b/src/init/io.ts
@@ -1,0 +1,130 @@
+import {
+  copyFile as fsCopyFile,
+  mkdir as fsMkdir,
+  readFile as fsReadFile,
+  rename as fsRename,
+  writeFile as fsWriteFile,
+} from 'node:fs/promises'
+import { dirname, posix as posixPath, win32 as winPath } from 'node:path'
+
+export interface FileSystem {
+  exists(path: string): Promise<boolean>
+  readFile(path: string): Promise<string>
+  writeFile(path: string, data: string): Promise<void>
+  copyFile(src: string, dest: string): Promise<void>
+  rename(src: string, dest: string): Promise<void>
+  mkdir(path: string, opts?: { recursive?: boolean }): Promise<void>
+}
+
+export const nodeFileSystem: FileSystem = {
+  async exists(path) {
+    try {
+      await fsReadFile(path)
+      return true
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
+      // Permission errors etc. mean the file is there but we can't read it —
+      // surface as "exists" so callers don't try to overwrite it blindly.
+      return true
+    }
+  },
+  readFile: (path) => fsReadFile(path, 'utf8'),
+  writeFile: (path, data) => fsWriteFile(path, data, 'utf8'),
+  copyFile: (src, dest) => fsCopyFile(src, dest),
+  rename: (src, dest) => fsRename(src, dest),
+  mkdir: async (path, opts) => {
+    await fsMkdir(path, { recursive: opts?.recursive ?? true })
+  },
+}
+
+export interface MemoryFileSystem extends FileSystem {
+  files: Map<string, string>
+  has(path: string): boolean
+  reset(): void
+}
+
+const memoryDirname = (path: string): string =>
+  path.includes('\\') ? winPath.dirname(path) : posixPath.dirname(path)
+
+export function createMemoryFileSystem(initial?: Record<string, string>): MemoryFileSystem {
+  const files = new Map<string, string>(initial ? Object.entries(initial) : [])
+  const dirs = new Set<string>()
+
+  const ensureParent = (path: string) => {
+    const parent = memoryDirname(path)
+    if (!dirs.has(parent)) {
+      throw Object.assign(new Error(`ENOENT: no such directory '${parent}'`), {
+        code: 'ENOENT',
+      })
+    }
+  }
+
+  return {
+    files,
+    has: (path) => files.has(path),
+    reset: () => {
+      files.clear()
+      dirs.clear()
+    },
+    async exists(path) {
+      return files.has(path)
+    },
+    async readFile(path) {
+      const content = files.get(path)
+      if (content === undefined) {
+        throw Object.assign(new Error(`ENOENT: no such file '${path}'`), { code: 'ENOENT' })
+      }
+      return content
+    },
+    async writeFile(path, data) {
+      ensureParent(path)
+      files.set(path, data)
+    },
+    async copyFile(src, dest) {
+      const content = files.get(src)
+      if (content === undefined) {
+        throw Object.assign(new Error(`ENOENT: no such file '${src}'`), { code: 'ENOENT' })
+      }
+      ensureParent(dest)
+      files.set(dest, content)
+    },
+    async rename(src, dest) {
+      const content = files.get(src)
+      if (content === undefined) {
+        throw Object.assign(new Error(`ENOENT: no such file '${src}'`), { code: 'ENOENT' })
+      }
+      ensureParent(dest)
+      files.set(dest, content)
+      files.delete(src)
+    },
+    async mkdir(path, opts) {
+      if (opts?.recursive !== false) {
+        // Walk parents — supports both / and \ separators.
+        const parts = path.split(/[\\/]/).filter(Boolean)
+        let acc = path.startsWith('/') ? '' : ''
+        const sep = path.includes('\\') ? '\\' : '/'
+        if (path.startsWith('/')) acc = ''
+        for (const part of parts) {
+          acc =
+            acc.length === 0 && path.startsWith('/')
+              ? `/${part}`
+              : acc
+                ? `${acc}${sep}${part}`
+                : part
+          dirs.add(acc)
+        }
+      } else {
+        const parent = memoryDirname(path)
+        if (!dirs.has(parent) && parent !== path) {
+          throw Object.assign(new Error(`ENOENT: parent '${parent}' does not exist`), {
+            code: 'ENOENT',
+          })
+        }
+        dirs.add(path)
+      }
+    },
+  }
+}
+
+// Re-export for callers that prefer to seed parent directories before writing.
+export { dirname }

--- a/tests/init/argv.test.ts
+++ b/tests/init/argv.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { parseInitArgs } from '../../src/init/argv'
+
+describe('parseInitArgs', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    delete process.env.CANVAS_API_TOKEN
+    delete process.env.CANVAS_BASE_URL
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('returns sensible defaults with no args', () => {
+    const result = parseInitArgs([])
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.config).toEqual({
+      clients: [],
+      token: undefined,
+      baseUrl: undefined,
+      serverName: 'canvas-lms',
+      pin: undefined,
+      nonInteractive: false,
+      dryRun: false,
+      noBackup: false,
+      showHelp: false,
+    })
+  })
+
+  it('reads token and base-url from env when flags absent', () => {
+    process.env.CANVAS_API_TOKEN = 'env-token'
+    process.env.CANVAS_BASE_URL = 'https://canvas.example.com/api/v1'
+    const result = parseInitArgs([])
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.config.token).toBe('env-token')
+    expect(result.config.baseUrl).toBe('https://canvas.example.com/api/v1')
+  })
+
+  it('flags override env vars', () => {
+    process.env.CANVAS_API_TOKEN = 'env-token'
+    const result = parseInitArgs(['--token', 'flag-token'])
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.config.token).toBe('flag-token')
+  })
+
+  it('accepts repeatable --client flags and dedupes', () => {
+    const result = parseInitArgs([
+      '--client',
+      'cursor',
+      '--client',
+      'claude-desktop',
+      '--client',
+      'cursor',
+    ])
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.config.clients).toEqual(['cursor', 'claude-desktop'])
+  })
+
+  it('rejects unknown clients with a helpful list', () => {
+    const result = parseInitArgs(['--client', 'emacs'])
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.message).toMatch(/Unknown client "emacs"/)
+    expect(result.message).toMatch(/cursor/)
+    expect(result.flag).toBe('--client')
+  })
+
+  it('--non-interactive and --yes are equivalent', () => {
+    const a = parseInitArgs(['--non-interactive'])
+    const b = parseInitArgs(['--yes'])
+    if (!a.ok || !b.ok) throw new Error('expected ok')
+    expect(a.config.nonInteractive).toBe(true)
+    expect(b.config.nonInteractive).toBe(true)
+  })
+
+  it('parses --dry-run and --no-backup', () => {
+    const r = parseInitArgs(['--dry-run', '--no-backup'])
+    if (!r.ok) throw new Error('expected ok')
+    expect(r.config.dryRun).toBe(true)
+    expect(r.config.noBackup).toBe(true)
+  })
+
+  it('validates --pin as semver', () => {
+    const ok = parseInitArgs(['--pin', '1.12.0'])
+    expect(ok.ok).toBe(true)
+    const bad = parseInitArgs(['--pin', 'latest'])
+    expect(bad.ok).toBe(false)
+    if (bad.ok) return
+    expect(bad.flag).toBe('--pin')
+  })
+
+  it('accepts pre-release semver in --pin', () => {
+    const r = parseInitArgs(['--pin', '2.0.0-alpha.1'])
+    if (!r.ok) throw new Error('expected ok')
+    expect(r.config.pin).toBe('2.0.0-alpha.1')
+  })
+
+  it('does NOT recognise --version (reserved for "print version")', () => {
+    const r = parseInitArgs(['--version', '1.0.0'])
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.message).toMatch(/Unknown argument: --version/)
+  })
+
+  it('validates --base-url is an http(s) URL', () => {
+    const ok = parseInitArgs(['--base-url', 'https://canvas.example.com/api/v1'])
+    expect(ok.ok).toBe(true)
+    const noScheme = parseInitArgs(['--base-url', 'canvas.example.com'])
+    expect(noScheme.ok).toBe(false)
+    const ftp = parseInitArgs(['--base-url', 'ftp://canvas.example.com'])
+    expect(ftp.ok).toBe(false)
+  })
+
+  it('validates --server-name shape', () => {
+    const ok = parseInitArgs(['--server-name', 'canvas-lms-2'])
+    expect(ok.ok).toBe(true)
+    const bad = parseInitArgs(['--server-name', 'Canvas LMS'])
+    expect(bad.ok).toBe(false)
+    if (bad.ok) return
+    expect(bad.flag).toBe('--server-name')
+  })
+
+  it('rejects flags missing a value', () => {
+    const r = parseInitArgs(['--token'])
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.message).toMatch(/Missing value for --token/)
+  })
+
+  it('rejects unknown arguments', () => {
+    const r = parseInitArgs(['--frobnicate'])
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.message).toMatch(/Unknown argument: --frobnicate/)
+  })
+
+  it('--help / -h surfaces showHelp', () => {
+    const a = parseInitArgs(['--help'])
+    const b = parseInitArgs(['-h'])
+    if (!a.ok || !b.ok) throw new Error('expected ok')
+    expect(a.config.showHelp).toBe(true)
+    expect(b.config.showHelp).toBe(true)
+  })
+})

--- a/tests/init/clients.test.ts
+++ b/tests/init/clients.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import { CLIENTS, CLIENT_IDS, getClient, type PathEnv } from '../../src/init/clients'
+
+const linuxEnv: PathEnv = { platform: 'linux', home: '/home/alice' }
+const macEnv: PathEnv = { platform: 'darwin', home: '/Users/alice' }
+const winEnv: PathEnv = {
+  platform: 'win32',
+  home: 'C:\\Users\\Alice',
+  appData: 'C:\\Users\\Alice\\AppData\\Roaming',
+}
+
+describe('clients registry', () => {
+  it('exposes the seven v1 clients in stable order', () => {
+    expect(CLIENT_IDS).toEqual([
+      'claude-desktop',
+      'claude-code',
+      'cursor',
+      'vscode',
+      'windsurf',
+      'codex',
+      'continue',
+    ])
+  })
+
+  it('returns undefined for unknown ids', () => {
+    expect(getClient('emacs')).toBeUndefined()
+  })
+
+  it('returns the descriptor for a known id', () => {
+    const cursor = getClient('cursor')
+    expect(cursor?.name).toBe('Cursor')
+    expect(cursor?.format).toBe('json')
+    expect(cursor?.wrapperKey).toBe('mcpServers')
+  })
+
+  it('VS Code uses the "servers" wrapper key (not "mcpServers")', () => {
+    expect(getClient('vscode')?.wrapperKey).toBe('servers')
+  })
+
+  it('Codex CLI is the only TOML target', () => {
+    const tomlClients = CLIENTS.filter((c) => c.format === 'toml')
+    expect(tomlClients.map((c) => c.id)).toEqual(['codex'])
+  })
+})
+
+describe('clients path resolution — Linux', () => {
+  const paths = Object.fromEntries(CLIENTS.map((c) => [c.id, c.resolvePath(linuxEnv)]))
+
+  it('matches the snapshot for every client', () => {
+    expect(paths).toMatchInlineSnapshot(`
+      {
+        "claude-code": "/home/alice/.claude.json",
+        "claude-desktop": "/home/alice/.config/Claude/claude_desktop_config.json",
+        "codex": "/home/alice/.codex/config.toml",
+        "continue": "/home/alice/.continue/config.json",
+        "cursor": "/home/alice/.cursor/mcp.json",
+        "vscode": "/home/alice/.config/Code/User/mcp.json",
+        "windsurf": "/home/alice/.codeium/windsurf/mcp_config.json",
+      }
+    `)
+  })
+})
+
+describe('clients path resolution — macOS', () => {
+  const paths = Object.fromEntries(CLIENTS.map((c) => [c.id, c.resolvePath(macEnv)]))
+
+  it('matches the snapshot for every client', () => {
+    expect(paths).toMatchInlineSnapshot(`
+      {
+        "claude-code": "/Users/alice/.claude.json",
+        "claude-desktop": "/Users/alice/Library/Application Support/Claude/claude_desktop_config.json",
+        "codex": "/Users/alice/.codex/config.toml",
+        "continue": "/Users/alice/.continue/config.json",
+        "cursor": "/Users/alice/.cursor/mcp.json",
+        "vscode": "/Users/alice/Library/Application Support/Code/User/mcp.json",
+        "windsurf": "/Users/alice/.codeium/windsurf/mcp_config.json",
+      }
+    `)
+  })
+})
+
+describe('clients path resolution — Windows', () => {
+  const paths = Object.fromEntries(CLIENTS.map((c) => [c.id, c.resolvePath(winEnv)]))
+
+  it('matches the snapshot for every client', () => {
+    expect(paths).toMatchInlineSnapshot(`
+      {
+        "claude-code": "C:\\Users\\Alice\\.claude.json",
+        "claude-desktop": "C:\\Users\\Alice\\AppData\\Roaming\\Claude\\claude_desktop_config.json",
+        "codex": "C:\\Users\\Alice\\.codex\\config.toml",
+        "continue": "C:\\Users\\Alice\\.continue\\config.json",
+        "cursor": "C:\\Users\\Alice\\.cursor\\mcp.json",
+        "vscode": "C:\\Users\\Alice\\AppData\\Roaming\\Code\\User\\mcp.json",
+        "windsurf": "C:\\Users\\Alice\\.codeium\\windsurf\\mcp_config.json",
+      }
+    `)
+  })
+
+  it('throws if APPDATA is unset for clients that need it', () => {
+    const winNoAppData: PathEnv = { ...winEnv, appData: undefined }
+    expect(() => getClient('claude-desktop')!.resolvePath(winNoAppData)).toThrow(/APPDATA/)
+    expect(() => getClient('vscode')!.resolvePath(winNoAppData)).toThrow(/APPDATA/)
+  })
+
+  it('does not require APPDATA for home-anchored clients', () => {
+    const winNoAppData: PathEnv = { ...winEnv, appData: undefined }
+    expect(() => getClient('cursor')!.resolvePath(winNoAppData)).not.toThrow()
+    expect(() => getClient('claude-code')!.resolvePath(winNoAppData)).not.toThrow()
+  })
+})

--- a/tests/init/io.test.ts
+++ b/tests/init/io.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { createMemoryFileSystem } from '../../src/init/io'
+
+describe('memoryFileSystem', () => {
+  it('reports a file as not existing before it is written', async () => {
+    const fs = createMemoryFileSystem()
+    await fs.mkdir('/tmp', { recursive: true })
+    expect(await fs.exists('/tmp/cfg.json')).toBe(false)
+  })
+
+  it('writes and reads back a file once the parent dir exists', async () => {
+    const fs = createMemoryFileSystem()
+    await fs.mkdir('/tmp/x', { recursive: true })
+    await fs.writeFile('/tmp/x/cfg.json', '{"a":1}')
+    expect(await fs.readFile('/tmp/x/cfg.json')).toBe('{"a":1}')
+    expect(await fs.exists('/tmp/x/cfg.json')).toBe(true)
+  })
+
+  it('refuses to write into a non-existent directory', async () => {
+    const fs = createMemoryFileSystem()
+    await expect(fs.writeFile('/no/such/dir/cfg.json', '{}')).rejects.toThrow(/ENOENT/)
+  })
+
+  it('seeds initial files via the constructor', async () => {
+    const fs = createMemoryFileSystem({ '/seed.json': '{"seed":true}' })
+    expect(await fs.readFile('/seed.json')).toBe('{"seed":true}')
+  })
+
+  it('rename is atomic-ish: source disappears, dest holds the content', async () => {
+    const fs = createMemoryFileSystem()
+    await fs.mkdir('/a', { recursive: true })
+    await fs.writeFile('/a/cfg.json.tmp', '{"v":2}')
+    await fs.rename('/a/cfg.json.tmp', '/a/cfg.json')
+    expect(await fs.readFile('/a/cfg.json')).toBe('{"v":2}')
+    expect(await fs.exists('/a/cfg.json.tmp')).toBe(false)
+  })
+
+  it('supports Windows-style paths under mkdir/writeFile', async () => {
+    const fs = createMemoryFileSystem()
+    await fs.mkdir('C:\\Users\\A\\.cursor', { recursive: true })
+    await fs.writeFile('C:\\Users\\A\\.cursor\\mcp.json', '{}')
+    expect(await fs.readFile('C:\\Users\\A\\.cursor\\mcp.json')).toBe('{}')
+  })
+
+  it('copyFile duplicates content; the source still exists', async () => {
+    const fs = createMemoryFileSystem()
+    await fs.mkdir('/d', { recursive: true })
+    await fs.writeFile('/d/orig.json', '{"o":1}')
+    await fs.copyFile('/d/orig.json', '/d/orig.json.bak')
+    expect(await fs.readFile('/d/orig.json.bak')).toBe('{"o":1}')
+    expect(await fs.exists('/d/orig.json')).toBe(true)
+  })
+})

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     server: 'src/server.ts',
     stdio: 'src/stdio.ts',
     http: 'src/http.ts',
+    init: 'src/init.ts',
     cli: 'src/cli.ts',
     'canvas/index': 'src/canvas/index.ts',
   },


### PR DESCRIPTION
## Summary

Task 1 of the `npx canvas-lms-mcp init` wizard, per the merged spec at `docs/superpowers/specs/2026-05-07-cli-setup-wizard.md`. Lands the bones; subsequent tasks layer config writers, prompts, and Canvas `/users/self` validation on top.

- **`bin/canvas-lms-mcp.js`** dispatcher routes `argv[2]` → `init` / `serve` / default-stdio. Side-effect: fixes a latent bug where `serve` previously routed through `dist/stdio.js` and never actually started HTTP mode.
- **`src/init.ts`** stub: prints "wizard coming soon" and exits 0. Honours `--help` and validates flags through `parseInitArgs` so flag errors surface today.
- **`src/init/argv.ts`** — `parseInitArgs()` returns `{ ok, config } | { ok: false, message }`. No `process.exit` in production code (testability). Validates `--pin` as semver, `--base-url` as http(s), `--server-name` shape; dedupes `--client`. `--version` is intentionally NOT recognized (reserved for "print version", per the spec nit landed in #109).
- **`src/init/clients.ts`** — static registry for the seven v1 clients (Claude Desktop, Claude Code, Cursor, VS Code, Windsurf, Codex CLI, Continue) with per-OS path resolution. Uses `path.posix` / `path.win32` explicitly so cross-platform snapshot tests are stable regardless of the runner OS.
- **`src/init/io.ts`** — `FileSystem` interface, `nodeFileSystem`, and an injectable `memoryFileSystem` so Tasks 2-3 can test config writers without ever touching the developer's real `~/.cursor/mcp.json`.

### Open question resolved

Spec Open Question #1 (path of Claude Code config): verified `~/.claude.json` exists today on the implementer's Windows install (44 KB). Path is correct; no spec change needed.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 641 / 641 passing (32 new tests across `tests/init/`)
- [x] `pnpm build` — produces `dist/init.cjs`/`dist/init.js`
- [x] `pnpm lint` — clean (Prettier + ESLint)
- [x] `node bin/canvas-lms-mcp.js init` → "wizard coming soon", exit 0
- [x] `node bin/canvas-lms-mcp.js init --help` → prints usage, exit 0
- [x] `node bin/canvas-lms-mcp.js init --pin notsemver` → flag error, exit 2
- [x] `node bin/canvas-lms-mcp.js serve` → loads HTTP path (fails on missing token, as expected)
- [x] `node bin/canvas-lms-mcp.js` → loads stdio path (fails on missing token, as expected)

Closes BRU-952.