### PR TITLE
fix(ci): remove workflow_dispatch clause from npm-publish if-gate

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,7 @@ jobs:
 
   npm-publish:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Removes `|| github.event_name == 'workflow_dispatch'` from the `npm-publish` job's `if` condition in `release-please.yml`
- The `npm-publish` job now only runs when `release-please` actually creates a release (`release_created == 'true'`)
- Backfill dispatches (and any other `workflow_dispatch` runs) will no longer trigger a publish, preventing "cannot publish over previously published version" errors

Fixes BRU-970. Failure evidence: https://github.com/bruchris/canvas-lms-mcp/actions/runs/25509423444

## Test plan

- [ ] Trigger a `workflow_dispatch` (e.g. backfill run) — confirm `npm-publish` job is skipped
- [ ] Confirm that a release-please-created release still triggers `npm-publish` (job runs when `release_created == 'true'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)