### PR TITLE
chore(http): drop dead Mcp-Session-Id from CORS headers (SEP-2567)

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -20,9 +20,9 @@ export function createHttpHandler(defaultConfig: {
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS')
     res.setHeader(
       'Access-Control-Allow-Headers',
-      'Content-Type, X-Canvas-Token, Mcp-Session-Id, Mcp-Protocol-Version',
+      'Content-Type, X-Canvas-Token, Mcp-Protocol-Version',
     )
-    res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id, Mcp-Protocol-Version')
+    res.setHeader('Access-Control-Expose-Headers', 'Mcp-Protocol-Version')
 
     if (req.method === 'OPTIONS') {
       res.writeHead(204)

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -109,6 +109,14 @@ describe('createHttpHandler', () => {
       await handler(req, res)
       expect(res._status).toBe(204)
     })
+
+    it('does not advertise Mcp-Session-Id in CORS preflight (SEP-2567)', async () => {
+      const req = createMockReq({ method: 'OPTIONS', url: '/mcp' })
+      const res = createMockRes()
+      await handler(req, res)
+      expect(res._headers['access-control-allow-headers']).not.toContain('Mcp-Session-Id')
+      expect(res._headers['access-control-expose-headers']).not.toContain('Mcp-Session-Id')
+    })
   })
 
   describe('/health', () => {


### PR DESCRIPTION
## Summary

- Removes `Mcp-Session-Id` from `Access-Control-Allow-Headers` and `Access-Control-Expose-Headers` in `src/http.ts`
- Aligns with [MCP SEP-2567](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567) (promoted to Final 2026-05-07), which formally removes protocol-level sessions and the `Mcp-Session-Id` header
- We already pass `sessionIdGenerator: undefined` so we never mint or read session IDs — this is purely dead config cleanup
- Adds a CORS preflight test asserting `Mcp-Session-Id` is absent from both headers

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm test` — 642/642 pass (new test: "does not advertise Mcp-Session-Id in CORS preflight (SEP-2567)")
- [x] `pnpm lint` — green
- [x] `pnpm build` — green

Closes BRU-979. Parent: BRU-978.

🤖 Generated with [Claude Code](https://claude.com/claude-code)