### PR TITLE
docs: reconcile tool inventory (88/104 → 107)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 
 MCP server for [Canvas LMS](https://www.instructure.com/canvas). Read courses, assignments, submissions, rubrics, quizzes; grade, comment, manage course content, and handle Canvas admin workflows from any AI agent.
 
-104 tools across Canvas courses, assignments, submissions, gradebook history, rubrics, quizzes, files, users, groups, enrollments, discussions, modules, pages, calendar, conversations, peer reviews, accounts, analytics, outcomes, student workflows, dashboard, and health checks. Three deployment modes: stdio, HTTP, and library import.
+107 tools across Canvas courses, assignments, submissions, gradebook history, rubrics, quizzes, files, users, groups, enrollments, discussions, modules, pages, calendar, conversations, peer reviews, accounts, analytics, outcomes, student workflows, dashboard, and health checks. Three deployment modes: stdio, HTTP, and library import.
 
 ## Comparison
 
 | | canvas-lms-mcp | [vishalsachdev/canvas-mcp](https://github.com/vishalsachdev/canvas-mcp) | [DMontgomery40/mcp-canvas-lms](https://github.com/DMontgomery40/mcp-canvas-lms) |
 |---|---|---|---|
 | Language | TypeScript | Python | TypeScript |
-| Tools | 104 | 80+ | 54 |
+| Tools | 107 | 80+ | 54 |
 | License | [![License: MIT](https://img.shields.io/github/license/bruchris/canvas-lms-mcp)](https://github.com/bruchris/canvas-lms-mcp/blob/main/LICENSE) | [![License](https://img.shields.io/github/license/vishalsachdev/canvas-mcp)](https://github.com/vishalsachdev/canvas-mcp/blob/main/LICENSE) | [![License](https://img.shields.io/github/license/DMontgomery40/mcp-canvas-lms)](https://github.com/DMontgomery40/mcp-canvas-lms/blob/main/LICENSE) |
 | Last commit | [![Last commit](https://img.shields.io/github/last-commit/bruchris/canvas-lms-mcp)](https://github.com/bruchris/canvas-lms-mcp) | [![Last commit](https://img.shields.io/github/last-commit/vishalsachdev/canvas-mcp)](https://github.com/vishalsachdev/canvas-mcp) | [![Last commit](https://img.shields.io/github/last-commit/DMontgomery40/mcp-canvas-lms)](https://github.com/DMontgomery40/mcp-canvas-lms) |
 
@@ -216,7 +216,7 @@ Once configured, try these prompts with your AI client:
 | Student | `get_my_courses`, `get_my_grades`, `get_my_submissions`, `get_my_upcoming_assignments` |
 | Dashboard | `get_dashboard_cards`, `get_todo_items`, `get_upcoming_events`, `get_missing_submissions` |
 
-76 tools are read-only and 28 tools perform Canvas write operations.
+78 tools are read-only and 29 tools perform Canvas write operations.
 
 All write tools require appropriate Canvas permissions. Canvas enforces its own permission model -- the MCP server does not bypass it.
 

--- a/docs/superpowers/specs/2026-04-12-canvas-lms-mcp-design.md
+++ b/docs/superpowers/specs/2026-04-12-canvas-lms-mcp-design.md
@@ -253,7 +253,7 @@ Built fresh referencing the Fjordbyte Canvas Integration's `src/types/canvas.ts`
 
 ## MCP Tool Inventory
 
-88 tools across Canvas courses, assignments, submissions, rubrics, quizzes, files, users, groups, enrollments, discussions, modules, pages, calendar, conversations, peer reviews, accounts, analytics, student workflows, dashboard, and health checks.
+107 tools across Canvas courses, assignments, submissions, gradebook history, rubrics, quizzes, files, users, groups, enrollments, discussions, modules, pages, calendar, conversations, peer reviews, accounts, analytics, outcomes, student workflows, dashboard, and health checks.
 
 ### Tool Pattern
 
@@ -332,7 +332,7 @@ All errors returned as structured MCP content, never thrown:
 | `grade_submission` | write | Post a grade to a submission |
 | `comment_on_submission` | write | Post a comment, optionally with a file attachment (uses Canvas's comment file upload workflow — not general file uploads) |
 
-#### Rubrics (4 tools)
+#### Rubrics (5 tools)
 
 | Tool | Type | Description |
 |------|------|-------------|
@@ -340,6 +340,7 @@ All errors returned as structured MCP content, never thrown:
 | `get_rubric` | read | Full rubric with criteria/ratings |
 | `get_rubric_assessment` | read | Existing assessment for a submission |
 | `submit_rubric_assessment` | write | Grade via rubric criteria |
+| `create_rubric` | write | Create a new rubric in a course with criteria and rating levels |
 
 #### Quizzes (6 tools)
 
@@ -352,13 +353,14 @@ All errors returned as structured MCP content, never thrown:
 | `get_quiz_submission_answers` | read | Student's answered questions |
 | `score_quiz_question` | write | Score an essay/open-ended question |
 
-#### Files (5 tools)
+#### Files (6 tools)
 
 | Tool | Type | Description |
 |------|------|-------------|
 | `list_files` | read | Files in a course |
 | `list_folders` | read | Folder structure |
 | `get_file` | read | File metadata + download URL |
+| `download_file` | read | Download file content by ID (text returned as-is; binary as base64) |
 | `upload_file` | write | Upload a file to a course folder |
 | `delete_file` | write | Delete a file |
 
@@ -379,11 +381,12 @@ All errors returned as structured MCP content, never thrown:
 | `list_groups` | read | Course groups |
 | `list_group_members` | read | Members of a group |
 
-#### Enrollments (3 tools)
+#### Enrollments (4 tools)
 
 | Tool | Type | Description |
 |------|------|-------------|
 | `list_enrollments` | read | User's enrollments across courses |
+| `list_course_enrollments` | read | Enrollments within a specific course with role and grade filters |
 | `enroll_user` | write | Enroll a user in a course |
 | `remove_enrollment` | write | Remove or conclude an enrollment |
 
@@ -408,7 +411,7 @@ All errors returned as structured MCP content, never thrown:
 | `update_page` | write | Update a wiki page |
 | `delete_page` | write | Delete a wiki page |
 
-#### Discussions (4 tools)
+#### Discussions (7 tools)
 
 | Tool | Type | Description |
 |------|------|-------------|
@@ -484,7 +487,33 @@ All errors returned as structured MCP content, never thrown:
 | `get_upcoming_events` | read | Current user's upcoming events |
 | `get_missing_submissions` | read | Current user's missing submissions |
 
-**Totals: 88 tools (60 read, 28 write)**
+#### Gradebook History (4 tools)
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `list_gradebook_history_days` | read | Dates in a course gradebook history that contain grading activity |
+| `get_gradebook_history_day` | read | Graders and assignment IDs that had activity on a specific date |
+| `list_gradebook_history_submissions` | read | Versioned submission history for one grader and assignment on a date |
+| `get_gradebook_history_feed` | read | Paginated gradebook history feed, optionally filtered by assignment or user |
+
+#### Outcomes (12 tools)
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `get_root_outcome_group` | read | Root outcome group for an account or course context |
+| `list_outcome_groups` | read | All outcome groups for an account or course context |
+| `list_outcome_group_links` | read | All outcome links in an account or course context |
+| `get_outcome_group` | read | Details for a specific outcome group |
+| `list_outcome_group_outcomes` | read | Outcomes linked into a specific outcome group |
+| `list_outcome_group_subgroups` | read | Subgroups of a specific outcome group |
+| `get_outcome` | read | Single outcome definition |
+| `get_outcome_alignments` | read | Alignments for an outcome in a course |
+| `get_outcome_results` | read | Raw outcome results for a course |
+| `get_outcome_rollups` | read | Outcome rollups (summary scores) for a course |
+| `get_outcome_contributing_scores` | read | Scores contributing to an outcome rollup for a user |
+| `get_outcome_mastery_distribution` | read | Distribution of mastery levels across students for an outcome |
+
+**Totals: 107 tools (78 read, 29 write)**
 
 ## MCP Resources
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "canvas-lms-mcp",
   "version": "1.14.1",
   "mcpName": "io.github.bruchris/canvas-lms-mcp",
-  "description": "TypeScript MCP 1.x server for Canvas LMS — 104 tools across Canvas courses, assignments, grades, gradebook history, quizzes, outcomes, discussions, admin workflows, and more.",
+  "description": "TypeScript MCP 1.x server for Canvas LMS — 107 tools across Canvas courses, assignments, grades, gradebook history, quizzes, outcomes, discussions, admin workflows, and more.",
   "type": "module",
   "types": "./dist/server.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary

- Updates tool count from stale 104 (README) / 88 (spec) to the actual **107** registered tools
- Recomputed read/write split from source annotations: **78 read-only, 29 write** (was 76/28)
- Adds missing spec sections for Gradebook History (4 tools) and Outcomes (12 tools)
- Fixes per-domain headers in spec: Rubrics 4→5, Files 5→6, Enrollments 3→4, Discussions 4→7

Closes BRU-987.

## Test plan

- [x] `pnpm test` — 642 tests, 59 files, all pass
- [x] `pnpm lint` — ESLint + Prettier clean
- [x] Tool counts verified by grepping `readOnlyHint: true` (78) and `destructiveHint: true` (29) across `src/tools/*.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)