### PR TITLE
feat(canvas): New Quizzes client module + types + facade wiring [BRU-1045]

### DIFF
--- a/src/canvas/index.ts
+++ b/src/canvas/index.ts
@@ -20,6 +20,7 @@ import { AnalyticsModule } from './analytics'
 import { DashboardModule } from './dashboard'
 import { OutcomesModule } from './outcomes'
 import { GradebookHistoryModule } from './gradebook-history'
+import { NewQuizzesModule } from './new-quizzes'
 
 export class CanvasClient {
   private client: CanvasHttpClient
@@ -43,6 +44,7 @@ export class CanvasClient {
   dashboard: DashboardModule
   outcomes: OutcomesModule
   gradebookHistory: GradebookHistoryModule
+  newQuizzes: NewQuizzesModule
 
   constructor(config: CanvasClientConfig) {
     this.client = new CanvasHttpClient(config)
@@ -66,6 +68,7 @@ export class CanvasClient {
     this.dashboard = new DashboardModule(this.client)
     this.outcomes = new OutcomesModule(this.client)
     this.gradebookHistory = new GradebookHistoryModule(this.client)
+    this.newQuizzes = new NewQuizzesModule(this.client)
   }
 }
 

--- a/src/canvas/new-quizzes.ts
+++ b/src/canvas/new-quizzes.ts
@@ -1,0 +1,285 @@
+import type { CanvasHttpClient } from './client'
+import type { CanvasNewQuiz, CanvasNewQuizItem } from './types'
+
+export interface NewQuizPayload {
+  title?: string
+  instructions?: string | null
+  points_possible?: number
+  due_at?: string | null
+  unlock_at?: string | null
+  lock_at?: string | null
+  published?: boolean
+}
+
+type ChoiceItem = {
+  interaction_type_slug: 'choice'
+  title?: string
+  item_body: string
+  choices: Array<{ id: string; item_body: string }>
+  correct_choice_id: string
+}
+
+type TrueFalseItem = {
+  interaction_type_slug: 'true-false'
+  item_body: string
+  correct_answer: boolean
+}
+
+type EssayItem = {
+  interaction_type_slug: 'essay'
+  item_body: string
+  rich_text?: boolean
+  word_count_min?: number
+  word_count_max?: number
+}
+
+type MatchingItem = {
+  interaction_type_slug: 'matching'
+  item_body: string
+  matches: Array<{ question: string; answer: string }>
+  distractors?: string[]
+}
+
+type NumericAnswer =
+  | { kind: 'exact'; value: number; margin?: number }
+  | { kind: 'range'; min: number; max: number }
+  | { kind: 'precision'; value: number; precision: number }
+
+type NumericItem = {
+  interaction_type_slug: 'numeric'
+  item_body: string
+  answers: NumericAnswer[]
+}
+
+export type NewQuizItemInput = ChoiceItem | TrueFalseItem | EssayItem | MatchingItem | NumericItem
+
+export interface NewQuizItemCreatePayload {
+  position?: number
+  points_possible: number
+  item: NewQuizItemInput
+}
+
+export interface NewQuizItemUpdatePayload {
+  position?: number
+  points_possible?: number
+  item?: NewQuizItemInput
+}
+
+export class NewQuizzesModule {
+  constructor(private client: CanvasHttpClient) {}
+
+  async create(courseId: number, payload: NewQuizPayload): Promise<CanvasNewQuiz> {
+    return this.client.request<CanvasNewQuiz>(`/api/quiz/v1/courses/${courseId}/quizzes`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    })
+  }
+
+  async update(
+    courseId: number,
+    assignmentId: number,
+    patch: NewQuizPayload,
+  ): Promise<CanvasNewQuiz> {
+    return this.client.request<CanvasNewQuiz>(
+      `/api/quiz/v1/courses/${courseId}/quizzes/${assignmentId}`,
+      { method: 'PATCH', body: JSON.stringify(patch) },
+    )
+  }
+
+  async delete(courseId: number, assignmentId: number): Promise<void> {
+    await this.client.request<void>(`/api/quiz/v1/courses/${courseId}/quizzes/${assignmentId}`, {
+      method: 'DELETE',
+    })
+  }
+
+  async listItems(courseId: number, assignmentId: number): Promise<CanvasNewQuizItem[]> {
+    return this.client.paginate<CanvasNewQuizItem>(
+      `/api/quiz/v1/courses/${courseId}/quizzes/${assignmentId}/items`,
+    )
+  }
+
+  async getItem(
+    courseId: number,
+    assignmentId: number,
+    itemId: string,
+  ): Promise<CanvasNewQuizItem> {
+    return this.client.request<CanvasNewQuizItem>(
+      `/api/quiz/v1/courses/${courseId}/quizzes/${assignmentId}/items/${itemId}`,
+    )
+  }
+
+  async createItem(
+    courseId: number,
+    assignmentId: number,
+    input: NewQuizItemCreatePayload,
+  ): Promise<CanvasNewQuizItem> {
+    const wireBody: Record<string, unknown> = {
+      entry_type: 'Item',
+      points_possible: input.points_possible,
+      entry: this.toWireItem(input.item),
+    }
+    if (input.position !== undefined) wireBody.position = input.position
+    return this.client.request<CanvasNewQuizItem>(
+      `/api/quiz/v1/courses/${courseId}/quizzes/${assignmentId}/items`,
+      { method: 'POST', body: JSON.stringify(wireBody) },
+    )
+  }
+
+  async updateItem(
+    courseId: number,
+    assignmentId: number,
+    itemId: string,
+    patch: NewQuizItemUpdatePayload,
+  ): Promise<CanvasNewQuizItem> {
+    const wireBody: Record<string, unknown> = {}
+    if (patch.position !== undefined) wireBody.position = patch.position
+    if (patch.points_possible !== undefined) wireBody.points_possible = patch.points_possible
+    if (patch.item !== undefined) wireBody.entry = this.toWireItem(patch.item)
+    return this.client.request<CanvasNewQuizItem>(
+      `/api/quiz/v1/courses/${courseId}/quizzes/${assignmentId}/items/${itemId}`,
+      { method: 'PATCH', body: JSON.stringify(wireBody) },
+    )
+  }
+
+  async deleteItem(courseId: number, assignmentId: number, itemId: string): Promise<void> {
+    await this.client.request<void>(
+      `/api/quiz/v1/courses/${courseId}/quizzes/${assignmentId}/items/${itemId}`,
+      { method: 'DELETE' },
+    )
+  }
+
+  private toWireItem(item: NewQuizItemInput): Record<string, unknown> {
+    switch (item.interaction_type_slug) {
+      case 'choice':
+        return this.choiceToWire(item)
+      case 'true-false':
+        return this.trueFalseToWire(item)
+      case 'essay':
+        return this.essayToWire(item)
+      case 'matching':
+        return this.matchingToWire(item)
+      case 'numeric':
+        return this.numericToWire(item)
+    }
+  }
+
+  private choiceToWire(item: ChoiceItem): Record<string, unknown> {
+    return {
+      interaction_type_slug: 'choice',
+      item_body: item.item_body,
+      interaction_data: {
+        choices: item.choices.map((c, i) => ({
+          id: c.id,
+          position: i + 1,
+          item_body: c.item_body,
+        })),
+      },
+      properties: {
+        shuffle_rules: { choices: { shuffled: true } },
+      },
+      scoring_data: {
+        value: item.correct_choice_id,
+      },
+      // Equivalence hard-coded per CTO direction; not exposed to callers
+      scoring_algorithm: 'Equivalence',
+    }
+  }
+
+  private trueFalseToWire(item: TrueFalseItem): Record<string, unknown> {
+    return {
+      interaction_type_slug: 'true-false',
+      item_body: item.item_body,
+      interaction_data: {
+        choices: [
+          { id: 'true', position: 1, item_body: 'True' },
+          { id: 'false', position: 2, item_body: 'False' },
+        ],
+      },
+      properties: {},
+      scoring_data: {
+        value: item.correct_answer ? 'true' : 'false',
+      },
+      scoring_algorithm: 'Equivalence',
+    }
+  }
+
+  private essayToWire(item: EssayItem): Record<string, unknown> {
+    const properties: Record<string, unknown> = {}
+    if (item.word_count_min !== undefined || item.word_count_max !== undefined) {
+      const wc: Record<string, unknown> = {}
+      if (item.word_count_min !== undefined) wc.min = item.word_count_min
+      if (item.word_count_max !== undefined) wc.max = item.word_count_max
+      properties.word_count = wc
+    }
+    return {
+      interaction_type_slug: 'essay',
+      item_body: item.item_body,
+      interaction_data: {
+        rce_enabled: item.rich_text !== false,
+      },
+      properties,
+      scoring_data: {},
+      scoring_algorithm: 'None',
+    }
+  }
+
+  private matchingToWire(item: MatchingItem): Record<string, unknown> {
+    const matches = item.matches.map((m, i) => ({
+      id: `match_${i}`,
+      item_body: m.question,
+    }))
+    const correctResponses = item.matches.map((m, i) => ({
+      id: `resp_${i}`,
+      item_body: m.answer,
+    }))
+    const distractorResponses = (item.distractors ?? []).map((d, i) => ({
+      id: `dist_${i}`,
+      item_body: d,
+    }))
+    const scoringValue = item.matches.map((_, i) => ({
+      id: `match_${i}`,
+      match_id: `resp_${i}`,
+    }))
+    return {
+      interaction_type_slug: 'matching',
+      item_body: item.item_body,
+      interaction_data: {
+        matches,
+        responses: [...correctResponses, ...distractorResponses],
+      },
+      properties: {},
+      scoring_data: {
+        value: scoringValue,
+      },
+      scoring_algorithm: 'Equivalence',
+    }
+  }
+
+  private numericToWire(item: NumericItem): Record<string, unknown> {
+    const answers = item.answers
+    const first = answers[0]
+    if (first === undefined) {
+      throw new Error('numeric item must have at least one answer')
+    }
+    let scoringData: Record<string, unknown>
+    let scoringAlgorithm: string
+    if (first.kind === 'exact') {
+      scoringData = { exact_answer: first.value, margin: first.margin ?? 0 }
+      scoringAlgorithm = 'Exact'
+    } else if (first.kind === 'range') {
+      scoringData = { lower_bound: first.min, upper_bound: first.max }
+      scoringAlgorithm = 'Range'
+    } else {
+      scoringData = { exact_answer: first.value, precision: first.precision }
+      scoringAlgorithm = 'Precision'
+    }
+    return {
+      interaction_type_slug: 'numeric',
+      item_body: item.item_body,
+      interaction_data: {},
+      properties: {},
+      scoring_data: scoringData,
+      scoring_algorithm: scoringAlgorithm,
+    }
+  }
+}

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -892,6 +892,36 @@ export interface CanvasMissingSubmission {
   html_url: string
 }
 
+// --- New Quizzes ---
+
+export interface CanvasNewQuiz {
+  id: number
+  title: string
+  instructions: string | null
+  points_possible: number
+  due_at: string | null
+  unlock_at: string | null
+  lock_at: string | null
+  published: boolean
+  assignment_id: number
+}
+
+export interface CanvasNewQuizItem {
+  id: string
+  position: number
+  points_possible: number
+  entry_type: 'Item' | 'Stimulus'
+  entry: {
+    interaction_type_slug: string
+    item_body: string
+    interaction_data: Record<string, unknown>
+    properties: Record<string, unknown>
+    scoring_data?: Record<string, unknown>
+    scoring_algorithm?: string
+    feedback?: Record<string, unknown>
+  }
+}
+
 // --- Peer Reviews ---
 
 export interface CanvasPeerReview {

--- a/tests/canvas/new-quizzes.test.ts
+++ b/tests/canvas/new-quizzes.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NewQuizzesModule } from '../../src/canvas/new-quizzes'
+import { CanvasHttpClient } from '../../src/canvas/client'
+
+const COURSE_ID = 100
+const ASSIGNMENT_ID = 42
+const ITEM_ID = 'item-uuid-001'
+
+function makeClient(): CanvasHttpClient {
+  return new CanvasHttpClient({ token: 'test-token', baseUrl: 'https://canvas.example.com' })
+}
+
+function makeQuiz() {
+  return {
+    id: 1,
+    title: 'My New Quiz',
+    instructions: null,
+    points_possible: 10,
+    due_at: null,
+    unlock_at: null,
+    lock_at: null,
+    published: false,
+    assignment_id: ASSIGNMENT_ID,
+  }
+}
+
+function makeItem(overrides: object = {}) {
+  return {
+    id: ITEM_ID,
+    position: 1,
+    points_possible: 5,
+    entry_type: 'Item',
+    entry: {
+      interaction_type_slug: 'choice',
+      item_body: '<p>Q</p>',
+      interaction_data: {},
+      properties: {},
+    },
+    ...overrides,
+  }
+}
+
+describe('NewQuizzesModule', () => {
+  let client: CanvasHttpClient
+  let mod: NewQuizzesModule
+
+  beforeEach(() => {
+    client = makeClient()
+    mod = new NewQuizzesModule(client)
+  })
+
+  // --- Quiz CRUD ---
+
+  it('creates a quiz', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce(makeQuiz())
+    const result = await mod.create(COURSE_ID, { title: 'My New Quiz' })
+    expect(result).toMatchObject({ id: 1, title: 'My New Quiz' })
+    expect(client.request).toHaveBeenCalledWith(
+      `/api/quiz/v1/courses/${COURSE_ID}/quizzes`,
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('updates a quiz', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce({ ...makeQuiz(), published: true })
+    const result = await mod.update(COURSE_ID, ASSIGNMENT_ID, { published: true })
+    expect(result.published).toBe(true)
+    expect(client.request).toHaveBeenCalledWith(
+      `/api/quiz/v1/courses/${COURSE_ID}/quizzes/${ASSIGNMENT_ID}`,
+      expect.objectContaining({ method: 'PATCH' }),
+    )
+  })
+
+  it('deletes a quiz without throwing on 204', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce(undefined)
+    await expect(mod.delete(COURSE_ID, ASSIGNMENT_ID)).resolves.toBeUndefined()
+    expect(client.request).toHaveBeenCalledWith(
+      `/api/quiz/v1/courses/${COURSE_ID}/quizzes/${ASSIGNMENT_ID}`,
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+  })
+
+  // --- Item reads ---
+
+  it('lists quiz items using bare-array pagination', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([makeItem()])
+    const result = await mod.listItems(COURSE_ID, ASSIGNMENT_ID)
+    expect(result).toHaveLength(1)
+    expect(client.paginate).toHaveBeenCalledWith(
+      `/api/quiz/v1/courses/${COURSE_ID}/quizzes/${ASSIGNMENT_ID}/items`,
+    )
+  })
+
+  it('gets a single quiz item', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce(makeItem())
+    const result = await mod.getItem(COURSE_ID, ASSIGNMENT_ID, ITEM_ID)
+    expect(result.id).toBe(ITEM_ID)
+    expect(client.request).toHaveBeenCalledWith(
+      `/api/quiz/v1/courses/${COURSE_ID}/quizzes/${ASSIGNMENT_ID}/items/${ITEM_ID}`,
+    )
+  })
+
+  // --- Item deletes ---
+
+  it('deletes a quiz item without throwing on 204', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce(undefined)
+    await expect(mod.deleteItem(COURSE_ID, ASSIGNMENT_ID, ITEM_ID)).resolves.toBeUndefined()
+    expect(client.request).toHaveBeenCalledWith(
+      `/api/quiz/v1/courses/${COURSE_ID}/quizzes/${ASSIGNMENT_ID}/items/${ITEM_ID}`,
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+  })
+
+  // --- createItem wire-format translations ---
+
+  it('createItem: choice — produces correct wire body', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce(makeItem())
+    await mod.createItem(COURSE_ID, ASSIGNMENT_ID, {
+      points_possible: 5,
+      item: {
+        interaction_type_slug: 'choice',
+        item_body: '<p>What is 2+2?</p>',
+        choices: [
+          { id: 'a', item_body: '<p>3</p>' },
+          { id: 'b', item_body: '<p>4</p>' },
+        ],
+        correct_choice_id: 'b',
+      },
+    })
+    expect(client.request).toHaveBeenCalledWith(
+      `/api/quiz/v1/courses/${COURSE_ID}/quizzes/${ASSIGNMENT_ID}/items`,
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"scoring_algorithm":"Equivalence"'),
+      }),
+    )
+    const callArgs = vi.mocked(client.request).mock.calls[0]
+    const body = JSON.parse(callArgs[1]!.body as string)
+    expect(body).toMatchObject({
+      entry_type: 'Item',
+      points_possible: 5,
+      entry: {
+        interaction_type_slug: 'choice',
+        item_body: '<p>What is 2+2?</p>',
+        interaction_data: {
+          choices: [
+            { id: 'a', position: 1, item_body: '<p>3</p>' },
+            { id: 'b', position: 2, item_body: '<p>4</p>' },
+          ],
+        },
+        scoring_data: { value: 'b' },
+        scoring_algorithm: 'Equivalence',
+      },
+    })
+  })
+
+  it('createItem: true-false — produces correct wire body', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce(makeItem())
+    await mod.createItem(COURSE_ID, ASSIGNMENT_ID, {
+      points_possible: 1,
+      item: {
+        interaction_type_slug: 'true-false',
+        item_body: '<p>The sky is blue.</p>',
+        correct_answer: true,
+      },
+    })
+    const body = JSON.parse(vi.mocked(client.request).mock.calls[0][1]!.body as string)
+    expect(body).toMatchObject({
+      entry_type: 'Item',
+      points_possible: 1,
+      entry: {
+        interaction_type_slug: 'true-false',
+        item_body: '<p>The sky is blue.</p>',
+        interaction_data: {
+          choices: [
+            { id: 'true', position: 1, item_body: 'True' },
+            { id: 'false', position: 2, item_body: 'False' },
+          ],
+        },
+        scoring_data: { value: 'true' },
+        scoring_algorithm: 'Equivalence',
+      },
+    })
+  })
+
+  it('createItem: essay — produces correct wire body', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce(makeItem())
+    await mod.createItem(COURSE_ID, ASSIGNMENT_ID, {
+      points_possible: 10,
+      item: {
+        interaction_type_slug: 'essay',
+        item_body: '<p>Describe the water cycle.</p>',
+        rich_text: true,
+        word_count_min: 50,
+        word_count_max: 300,
+      },
+    })
+    const body = JSON.parse(vi.mocked(client.request).mock.calls[0][1]!.body as string)
+    expect(body).toMatchObject({
+      entry_type: 'Item',
+      points_possible: 10,
+      entry: {
+        interaction_type_slug: 'essay',
+        item_body: '<p>Describe the water cycle.</p>',
+        interaction_data: { rce_enabled: true },
+        properties: { word_count: { min: 50, max: 300 } },
+        scoring_data: {},
+        scoring_algorithm: 'None',
+      },
+    })
+  })
+
+  it('createItem: matching — produces correct wire body with scoring pairs', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce(makeItem())
+    await mod.createItem(COURSE_ID, ASSIGNMENT_ID, {
+      points_possible: 4,
+      item: {
+        interaction_type_slug: 'matching',
+        item_body: '<p>Match the capitals.</p>',
+        matches: [
+          { question: 'France', answer: 'Paris' },
+          { question: 'Germany', answer: 'Berlin' },
+        ],
+        distractors: ['London'],
+      },
+    })
+    const body = JSON.parse(vi.mocked(client.request).mock.calls[0][1]!.body as string)
+    expect(body).toMatchObject({
+      entry_type: 'Item',
+      points_possible: 4,
+      entry: {
+        interaction_type_slug: 'matching',
+        item_body: '<p>Match the capitals.</p>',
+        interaction_data: {
+          matches: [
+            { id: 'match_0', item_body: 'France' },
+            { id: 'match_1', item_body: 'Germany' },
+          ],
+          responses: [
+            { id: 'resp_0', item_body: 'Paris' },
+            { id: 'resp_1', item_body: 'Berlin' },
+            { id: 'dist_0', item_body: 'London' },
+          ],
+        },
+        scoring_data: {
+          value: [
+            { id: 'match_0', match_id: 'resp_0' },
+            { id: 'match_1', match_id: 'resp_1' },
+          ],
+        },
+        scoring_algorithm: 'Equivalence',
+      },
+    })
+  })
+
+  it('createItem: numeric exact — produces Exact scoring algorithm', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce(makeItem())
+    await mod.createItem(COURSE_ID, ASSIGNMENT_ID, {
+      points_possible: 2,
+      item: {
+        interaction_type_slug: 'numeric',
+        item_body: '<p>What is 2+2?</p>',
+        answers: [{ kind: 'exact', value: 4, margin: 0 }],
+      },
+    })
+    const body = JSON.parse(vi.mocked(client.request).mock.calls[0][1]!.body as string)
+    expect(body).toMatchObject({
+      entry: {
+        interaction_type_slug: 'numeric',
+        scoring_data: { exact_answer: 4, margin: 0 },
+        scoring_algorithm: 'Exact',
+      },
+    })
+  })
+
+  it('createItem: numeric range — produces Range scoring algorithm', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce(makeItem())
+    await mod.createItem(COURSE_ID, ASSIGNMENT_ID, {
+      points_possible: 2,
+      item: {
+        interaction_type_slug: 'numeric',
+        item_body: '<p>Approximate value of pi?</p>',
+        answers: [{ kind: 'range', min: 3.1, max: 3.2 }],
+      },
+    })
+    const body = JSON.parse(vi.mocked(client.request).mock.calls[0][1]!.body as string)
+    expect(body).toMatchObject({
+      entry: {
+        interaction_type_slug: 'numeric',
+        scoring_data: { lower_bound: 3.1, upper_bound: 3.2 },
+        scoring_algorithm: 'Range',
+      },
+    })
+  })
+
+  it('createItem: numeric precision — produces Precision scoring algorithm', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce(makeItem())
+    await mod.createItem(COURSE_ID, ASSIGNMENT_ID, {
+      points_possible: 2,
+      item: {
+        interaction_type_slug: 'numeric',
+        item_body: '<p>Value of pi to 2 decimal places?</p>',
+        answers: [{ kind: 'precision', value: 3.14, precision: 2 }],
+      },
+    })
+    const body = JSON.parse(vi.mocked(client.request).mock.calls[0][1]!.body as string)
+    expect(body).toMatchObject({
+      entry: {
+        interaction_type_slug: 'numeric',
+        scoring_data: { exact_answer: 3.14, precision: 2 },
+        scoring_algorithm: 'Precision',
+      },
+    })
+  })
+
+  // --- updateItem ---
+
+  it('updateItem: sends entry when item provided', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce(makeItem())
+    await mod.updateItem(COURSE_ID, ASSIGNMENT_ID, ITEM_ID, {
+      points_possible: 3,
+      item: {
+        interaction_type_slug: 'true-false',
+        item_body: '<p>Updated.</p>',
+        correct_answer: false,
+      },
+    })
+    expect(client.request).toHaveBeenCalledWith(
+      `/api/quiz/v1/courses/${COURSE_ID}/quizzes/${ASSIGNMENT_ID}/items/${ITEM_ID}`,
+      expect.objectContaining({ method: 'PATCH' }),
+    )
+    const body = JSON.parse(vi.mocked(client.request).mock.calls[0][1]!.body as string)
+    expect(body).toMatchObject({
+      points_possible: 3,
+      entry: { scoring_data: { value: 'false' } },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `CanvasNewQuiz` and `CanvasNewQuizItem` types in `src/canvas/types.ts`
- Implements `NewQuizzesModule` in `src/canvas/new-quizzes.ts` with 8 methods targeting `/api/quiz/v1/` endpoints
- Private `toWireItem()` translates friendly discriminated-union input to Canvas wire format for 5 V1 item types: `choice` (MCQ, Equivalence hard-coded per CTO direction), `true-false`, `essay`, `matching`, `numeric` (exact/range/precision variants)
- Wires `newQuizzes: NewQuizzesModule` into `CanvasClient` facade
- Tests: 13 new tests in `tests/canvas/new-quizzes.test.ts` covering all 8 methods + all 5 item-type wire translations; 656 total passing

**No tool definitions** — those are Subtask B (BRU-1046), which depends on this PR's facade wiring.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 656/656 passing (60 test files)
- [x] `pnpm build` — ESM + CJS both succeed
- [x] All 8 methods assert correct `/api/quiz/v1/` endpoint + HTTP verb
- [x] All 5 item-type translations asserted via `toMatchObject` in tests

Closes [BRU-1045](https://app.paperclip.ai)
Parent: bruchris/canvas-lms-mcp#124

🤖 Generated with [Claude Code](https://claude.com/claude-code)