### PR TITLE
feat(tools): New Quizzes MCP tools + formatError LTI discriminator [BRU-1046]

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 107,
+  "toolCount": 115,
   "tools": [
     {
       "name": "health_check",
@@ -342,6 +342,106 @@
       "name": "score_quiz_question",
       "domain": "quizzes",
       "description": "Score a specific question in a quiz submission. Specify attempt to score a particular attempt (omit for latest). Requires grading permissions.",
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "create_new_quiz",
+      "domain": "new_quizzes",
+      "description": "Create a New Quiz (LTI) in a Canvas course. New Quizzes is the modern quiz engine; for Classic quizzes use create_quiz.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "update_new_quiz",
+      "domain": "new_quizzes",
+      "description": "Update an existing New Quiz (LTI) in a Canvas course.",
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "delete_new_quiz",
+      "domain": "new_quizzes",
+      "description": "Delete a New Quiz (LTI) from a Canvas course. This action is permanent. Use assignment_id (not quiz_id).",
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_new_quiz_items",
+      "domain": "new_quizzes",
+      "description": "List all items (questions) in a New Quiz (LTI).",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_new_quiz_item",
+      "domain": "new_quizzes",
+      "description": "Get a single item (question) from a New Quiz (LTI) by item ID.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "create_new_quiz_item",
+      "domain": "new_quizzes",
+      "description": "Create an item (question) in a New Quiz (LTI). Supports 5 types: choice (MCQ), true-false, essay, matching, numeric. Canvas may rate-limit rapid sequential creates. Call serially (not in parallel). For >50 items, chunk and pause between batches.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "update_new_quiz_item",
+      "domain": "new_quizzes",
+      "description": "Update an existing item (question) in a New Quiz (LTI). All fields are optional; supply only what changes. Canvas may rate-limit rapid sequential updates. Call serially (not in parallel). For >50 items, chunk and pause between batches.",
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "delete_new_quiz_item",
+      "domain": "new_quizzes",
+      "description": "Delete an item (question) from a New Quiz (LTI). This action is permanent.",
       "annotations": {
         "destructiveHint": true,
         "idempotentHint": true,

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -17,6 +17,7 @@ import { outcomeTools } from './outcomes'
 import { pageTools } from './pages'
 import { peerReviewTools } from './peer-reviews'
 import { quizTools } from './quizzes'
+import { newQuizTools } from './new-quizzes'
 import { rubricTools } from './rubrics'
 import { studentTools } from './student'
 import { submissionTools } from './submissions'
@@ -59,6 +60,11 @@ export const toolDomainCatalog: readonly ToolDomainRegistration[] = [
     domain: 'quizzes',
     defaultPrimaryAudience: 'educator',
     getTools: quizTools,
+  },
+  {
+    domain: 'new_quizzes',
+    defaultPrimaryAudience: 'educator',
+    getTools: newQuizTools,
   },
   {
     domain: 'files',

--- a/src/tools/errors.ts
+++ b/src/tools/errors.ts
@@ -4,6 +4,23 @@ export function formatError(error: unknown): string {
   if (error instanceof CanvasApiError) {
     const status = error.status
     const message = error.message
+
+    // LTI not enabled: Canvas returns "Tool not configured" for /api/quiz/v1/ when New Quizzes
+    // LTI isn't enabled on the instance. A real 404 on a valid endpoint won't include this phrase.
+    const ltiMarkers = ['Tool not configured', 'tool is not configured']
+    const looksLikeLtiNotEnabled =
+      error.endpoint.startsWith('/api/quiz/v1/') &&
+      (status === 404 || status === 401) &&
+      ltiMarkers.some((m) => message.toLowerCase().includes(m.toLowerCase()))
+    if (looksLikeLtiNotEnabled) {
+      return 'New Quizzes is not enabled on this Canvas instance. Ask a Canvas admin to enable the "New Quizzes" LTI tool, or use the Classic quiz tools (list_quizzes / get_quiz) instead.'
+    }
+
+    // Rate-limit on New Quizzes: 403 + body containing "Rate Limit Exceeded"
+    if (status === 403 && message.toLowerCase().includes('rate limit exceeded')) {
+      return 'Canvas rate-limit hit. Wait a few seconds and retry, or chunk your bulk operation.'
+    }
+
     switch (status) {
       case 401:
         return 'Canvas token is invalid or expired'

--- a/src/tools/new-quizzes.ts
+++ b/src/tools/new-quizzes.ts
@@ -1,0 +1,265 @@
+import { z } from 'zod'
+import type { CanvasClient } from '../canvas'
+import type { ToolDefinition } from './types'
+
+const choiceItemSchema = z.object({
+  interaction_type_slug: z.literal('choice'),
+  title: z.string().optional(),
+  item_body: z.string().describe('HTML question stem'),
+  choices: z
+    .array(
+      z.object({
+        id: z.string().describe('Stable choice identifier (caller-generated, e.g. "a")'),
+        item_body: z.string().describe('HTML choice text'),
+      }),
+    )
+    .min(2),
+  correct_choice_id: z.string().describe('id of the correct choice'),
+})
+
+const trueFalseItemSchema = z.object({
+  interaction_type_slug: z.literal('true-false'),
+  item_body: z.string(),
+  correct_answer: z.boolean(),
+})
+
+const essayItemSchema = z.object({
+  interaction_type_slug: z.literal('essay'),
+  item_body: z.string(),
+  rich_text: z.boolean().default(true).describe('Allow rich text editor'),
+  word_count_min: z.number().int().optional(),
+  word_count_max: z.number().int().optional(),
+})
+
+const matchingItemSchema = z.object({
+  interaction_type_slug: z.literal('matching'),
+  item_body: z.string(),
+  matches: z
+    .array(
+      z.object({
+        question: z.string(),
+        answer: z.string(),
+      }),
+    )
+    .min(2),
+  distractors: z.array(z.string()).optional().describe('Wrong-answer distractor pool'),
+})
+
+const numericItemSchema = z.object({
+  interaction_type_slug: z.literal('numeric'),
+  item_body: z.string(),
+  answers: z
+    .array(
+      z.discriminatedUnion('kind', [
+        z.object({ kind: z.literal('exact'), value: z.number(), margin: z.number().default(0) }),
+        z.object({ kind: z.literal('range'), min: z.number(), max: z.number() }),
+        z.object({
+          kind: z.literal('precision'),
+          value: z.number(),
+          precision: z.number().int(),
+        }),
+      ]),
+    )
+    .min(1),
+})
+
+const itemDiscriminatedUnion = z.discriminatedUnion('interaction_type_slug', [
+  choiceItemSchema,
+  trueFalseItemSchema,
+  essayItemSchema,
+  matchingItemSchema,
+  numericItemSchema,
+])
+
+export function newQuizTools(canvas: CanvasClient): ToolDefinition[] {
+  return [
+    {
+      name: 'create_new_quiz',
+      description:
+        'Create a New Quiz (LTI) in a Canvas course. New Quizzes is the modern quiz engine; for Classic quizzes use create_quiz.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        title: z.string().describe('Title of the quiz'),
+        instructions: z
+          .string()
+          .nullable()
+          .optional()
+          .describe('HTML instructions shown before the quiz starts'),
+        points_possible: z
+          .number()
+          .optional()
+          .describe('Total points; defaults to sum of item points'),
+        due_at: z.string().optional().describe('ISO-8601 due date'),
+        unlock_at: z.string().optional().describe('ISO-8601 unlock time'),
+        lock_at: z.string().optional().describe('ISO-8601 lock time'),
+        published: z.boolean().optional().describe('Whether the quiz is visible to students'),
+      },
+      annotations: { destructiveHint: true, openWorldHint: true },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+        return canvas.newQuizzes.create(courseId, {
+          title: params.title as string,
+          instructions: params.instructions as string | null | undefined,
+          points_possible: params.points_possible as number | undefined,
+          due_at: params.due_at as string | null | undefined,
+          unlock_at: params.unlock_at as string | null | undefined,
+          lock_at: params.lock_at as string | null | undefined,
+          published: params.published as boolean | undefined,
+        })
+      },
+    },
+    {
+      name: 'update_new_quiz',
+      description: 'Update an existing New Quiz (LTI) in a Canvas course.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        assignment_id: z.number().describe('The assignment ID of the New Quiz'),
+        title: z.string().optional().describe('Title of the quiz'),
+        instructions: z
+          .string()
+          .nullable()
+          .optional()
+          .describe('HTML instructions shown before the quiz starts'),
+        points_possible: z.number().optional().describe('Total points'),
+        due_at: z.string().nullable().optional().describe('ISO-8601 due date (null to clear)'),
+        unlock_at: z
+          .string()
+          .nullable()
+          .optional()
+          .describe('ISO-8601 unlock time (null to clear)'),
+        lock_at: z.string().nullable().optional().describe('ISO-8601 lock time (null to clear)'),
+        published: z.boolean().optional().describe('Whether the quiz is visible to students'),
+      },
+      annotations: { destructiveHint: true, idempotentHint: true, openWorldHint: true },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+        const assignmentId = params.assignment_id as number
+        return canvas.newQuizzes.update(courseId, assignmentId, {
+          title: params.title as string | undefined,
+          instructions: params.instructions as string | null | undefined,
+          points_possible: params.points_possible as number | undefined,
+          due_at: params.due_at as string | null | undefined,
+          unlock_at: params.unlock_at as string | null | undefined,
+          lock_at: params.lock_at as string | null | undefined,
+          published: params.published as boolean | undefined,
+        })
+      },
+    },
+    {
+      name: 'delete_new_quiz',
+      description:
+        'Delete a New Quiz (LTI) from a Canvas course. This action is permanent. Use assignment_id (not quiz_id).',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        assignment_id: z.number().describe('The assignment ID of the New Quiz'),
+      },
+      annotations: { destructiveHint: true, idempotentHint: true, openWorldHint: true },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+        const assignmentId = params.assignment_id as number
+        await canvas.newQuizzes.delete(courseId, assignmentId)
+        return { success: true }
+      },
+    },
+    {
+      name: 'list_new_quiz_items',
+      description: 'List all items (questions) in a New Quiz (LTI).',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        assignment_id: z.number().describe('The assignment ID of the New Quiz'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+        const assignmentId = params.assignment_id as number
+        return canvas.newQuizzes.listItems(courseId, assignmentId)
+      },
+    },
+    {
+      name: 'get_new_quiz_item',
+      description: 'Get a single item (question) from a New Quiz (LTI) by item ID.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        assignment_id: z.number().describe('The assignment ID of the New Quiz'),
+        item_id: z.string().describe('The New Quiz item ID (string, not numeric)'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+        const assignmentId = params.assignment_id as number
+        const itemId = params.item_id as string
+        return canvas.newQuizzes.getItem(courseId, assignmentId, itemId)
+      },
+    },
+    {
+      name: 'create_new_quiz_item',
+      description:
+        'Create an item (question) in a New Quiz (LTI). Supports 5 types: choice (MCQ), true-false, essay, matching, numeric. Canvas may rate-limit rapid sequential creates. Call serially (not in parallel). For >50 items, chunk and pause between batches.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        assignment_id: z.number().describe('The assignment ID of the New Quiz'),
+        points_possible: z.number().describe('Points awarded for a fully correct answer'),
+        position: z
+          .number()
+          .int()
+          .optional()
+          .describe('1-based position in the quiz; appended if omitted'),
+        item: itemDiscriminatedUnion,
+      },
+      annotations: { destructiveHint: true, openWorldHint: true },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+        const assignmentId = params.assignment_id as number
+        return canvas.newQuizzes.createItem(courseId, assignmentId, {
+          points_possible: params.points_possible as number,
+          position: params.position as number | undefined,
+          item: params.item as Parameters<typeof canvas.newQuizzes.createItem>[2]['item'],
+        })
+      },
+    },
+    {
+      name: 'update_new_quiz_item',
+      description:
+        'Update an existing item (question) in a New Quiz (LTI). All fields are optional; supply only what changes. Canvas may rate-limit rapid sequential updates. Call serially (not in parallel). For >50 items, chunk and pause between batches.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        assignment_id: z.number().describe('The assignment ID of the New Quiz'),
+        item_id: z.string().describe('The New Quiz item ID (string, not numeric)'),
+        points_possible: z.number().optional().describe('Updated point value'),
+        position: z.number().int().optional().describe('Updated 1-based position'),
+        item: itemDiscriminatedUnion.optional(),
+      },
+      annotations: { destructiveHint: true, idempotentHint: true, openWorldHint: true },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+        const assignmentId = params.assignment_id as number
+        const itemId = params.item_id as string
+        return canvas.newQuizzes.updateItem(courseId, assignmentId, itemId, {
+          points_possible: params.points_possible as number | undefined,
+          position: params.position as number | undefined,
+          item:
+            params.item !== undefined
+              ? (params.item as Parameters<typeof canvas.newQuizzes.updateItem>[3]['item'])
+              : undefined,
+        })
+      },
+    },
+    {
+      name: 'delete_new_quiz_item',
+      description: 'Delete an item (question) from a New Quiz (LTI). This action is permanent.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        assignment_id: z.number().describe('The assignment ID of the New Quiz'),
+        item_id: z.string().describe('The New Quiz item ID (string, not numeric)'),
+      },
+      annotations: { destructiveHint: true, idempotentHint: true, openWorldHint: true },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+        const assignmentId = params.assignment_id as number
+        const itemId = params.item_id as string
+        await canvas.newQuizzes.deleteItem(courseId, assignmentId, itemId)
+        return { success: true }
+      },
+    },
+  ]
+}

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(107)
+    expect(manifest.tools).toHaveLength(115)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/tools/new-quizzes.test.ts
+++ b/tests/tools/new-quizzes.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { CanvasClient } from '../../src/canvas'
+import { CanvasApiError } from '../../src/canvas'
+import { formatError } from '../../src/tools'
+import { newQuizTools } from '../../src/tools/new-quizzes'
+import type { CanvasNewQuiz, CanvasNewQuizItem } from '../../src/canvas/types'
+
+const mockQuiz: CanvasNewQuiz = {
+  id: 42,
+  title: 'Chapter 1 Quiz',
+  instructions: null,
+  points_possible: 10,
+  due_at: null,
+  unlock_at: null,
+  lock_at: null,
+  published: false,
+  assignment_id: 42,
+}
+
+const mockItem: CanvasNewQuizItem = {
+  id: 'item-1',
+  position: 1,
+  points_possible: 5,
+  entry_type: 'Item',
+  entry: { interaction_type_slug: 'choice' },
+}
+
+function buildMockCanvas(): CanvasClient {
+  return {
+    newQuizzes: {
+      create: vi.fn().mockResolvedValue(mockQuiz),
+      update: vi.fn().mockResolvedValue(mockQuiz),
+      delete: vi.fn().mockResolvedValue(undefined),
+      listItems: vi.fn().mockResolvedValue([mockItem]),
+      getItem: vi.fn().mockResolvedValue(mockItem),
+      createItem: vi.fn().mockResolvedValue(mockItem),
+      updateItem: vi.fn().mockResolvedValue(mockItem),
+      deleteItem: vi.fn().mockResolvedValue(undefined),
+    },
+  } as unknown as CanvasClient
+}
+
+describe('newQuizTools', () => {
+  it('returns 8 tool definitions', () => {
+    expect(newQuizTools(buildMockCanvas())).toHaveLength(8)
+  })
+
+  it('exports tools with correct names', () => {
+    const names = newQuizTools(buildMockCanvas()).map((t) => t.name)
+    expect(names).toEqual([
+      'create_new_quiz',
+      'update_new_quiz',
+      'delete_new_quiz',
+      'list_new_quiz_items',
+      'get_new_quiz_item',
+      'create_new_quiz_item',
+      'update_new_quiz_item',
+      'delete_new_quiz_item',
+    ])
+  })
+
+  // ── Annotation assertions ───────────────────────────────────────────────────
+
+  describe('annotations', () => {
+    it('list_new_quiz_items has readOnlyHint + openWorldHint', () => {
+      const tool = newQuizTools(buildMockCanvas()).find((t) => t.name === 'list_new_quiz_items')!
+      expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+    })
+
+    it('get_new_quiz_item has readOnlyHint + openWorldHint', () => {
+      const tool = newQuizTools(buildMockCanvas()).find((t) => t.name === 'get_new_quiz_item')!
+      expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+    })
+
+    it('create_new_quiz has destructiveHint + openWorldHint (no idempotentHint)', () => {
+      const tool = newQuizTools(buildMockCanvas()).find((t) => t.name === 'create_new_quiz')!
+      expect(tool.annotations).toEqual({ destructiveHint: true, openWorldHint: true })
+    })
+
+    it('create_new_quiz_item has destructiveHint + openWorldHint (no idempotentHint)', () => {
+      const tool = newQuizTools(buildMockCanvas()).find((t) => t.name === 'create_new_quiz_item')!
+      expect(tool.annotations).toEqual({ destructiveHint: true, openWorldHint: true })
+    })
+
+    it('update_new_quiz has destructiveHint + idempotentHint + openWorldHint', () => {
+      const tool = newQuizTools(buildMockCanvas()).find((t) => t.name === 'update_new_quiz')!
+      expect(tool.annotations).toEqual({
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      })
+    })
+
+    it('update_new_quiz_item has destructiveHint + idempotentHint + openWorldHint', () => {
+      const tool = newQuizTools(buildMockCanvas()).find((t) => t.name === 'update_new_quiz_item')!
+      expect(tool.annotations).toEqual({
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      })
+    })
+
+    it('delete_new_quiz has destructiveHint + idempotentHint + openWorldHint', () => {
+      const tool = newQuizTools(buildMockCanvas()).find((t) => t.name === 'delete_new_quiz')!
+      expect(tool.annotations).toEqual({
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      })
+    })
+
+    it('delete_new_quiz_item has destructiveHint + idempotentHint + openWorldHint', () => {
+      const tool = newQuizTools(buildMockCanvas()).find((t) => t.name === 'delete_new_quiz_item')!
+      expect(tool.annotations).toEqual({
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      })
+    })
+  })
+
+  // ── Handler delegation ──────────────────────────────────────────────────────
+
+  describe('create_new_quiz', () => {
+    it('delegates to canvas.newQuizzes.create', async () => {
+      const canvas = buildMockCanvas()
+      const tool = newQuizTools(canvas).find((t) => t.name === 'create_new_quiz')!
+      const result = await tool.handler({ course_id: 1, title: 'Quiz 1' })
+      expect(canvas.newQuizzes.create).toHaveBeenCalledWith(1, {
+        title: 'Quiz 1',
+        instructions: undefined,
+        points_possible: undefined,
+        due_at: undefined,
+        unlock_at: undefined,
+        lock_at: undefined,
+        published: undefined,
+      })
+      expect(result).toEqual(mockQuiz)
+    })
+  })
+
+  describe('update_new_quiz', () => {
+    it('delegates to canvas.newQuizzes.update', async () => {
+      const canvas = buildMockCanvas()
+      const tool = newQuizTools(canvas).find((t) => t.name === 'update_new_quiz')!
+      await tool.handler({ course_id: 1, assignment_id: 42, title: 'Updated' })
+      expect(canvas.newQuizzes.update).toHaveBeenCalledWith(1, 42, {
+        title: 'Updated',
+        instructions: undefined,
+        points_possible: undefined,
+        due_at: undefined,
+        unlock_at: undefined,
+        lock_at: undefined,
+        published: undefined,
+      })
+    })
+  })
+
+  describe('delete_new_quiz', () => {
+    it('delegates to canvas.newQuizzes.delete and returns success', async () => {
+      const canvas = buildMockCanvas()
+      const tool = newQuizTools(canvas).find((t) => t.name === 'delete_new_quiz')!
+      const result = await tool.handler({ course_id: 1, assignment_id: 42 })
+      expect(canvas.newQuizzes.delete).toHaveBeenCalledWith(1, 42)
+      expect(result).toEqual({ success: true })
+    })
+  })
+
+  describe('list_new_quiz_items', () => {
+    it('delegates to canvas.newQuizzes.listItems', async () => {
+      const canvas = buildMockCanvas()
+      const tool = newQuizTools(canvas).find((t) => t.name === 'list_new_quiz_items')!
+      const result = await tool.handler({ course_id: 1, assignment_id: 42 })
+      expect(canvas.newQuizzes.listItems).toHaveBeenCalledWith(1, 42)
+      expect(result).toEqual([mockItem])
+    })
+  })
+
+  describe('get_new_quiz_item', () => {
+    it('delegates to canvas.newQuizzes.getItem', async () => {
+      const canvas = buildMockCanvas()
+      const tool = newQuizTools(canvas).find((t) => t.name === 'get_new_quiz_item')!
+      const result = await tool.handler({ course_id: 1, assignment_id: 42, item_id: 'item-1' })
+      expect(canvas.newQuizzes.getItem).toHaveBeenCalledWith(1, 42, 'item-1')
+      expect(result).toEqual(mockItem)
+    })
+  })
+
+  describe('delete_new_quiz_item', () => {
+    it('delegates to canvas.newQuizzes.deleteItem and returns success', async () => {
+      const canvas = buildMockCanvas()
+      const tool = newQuizTools(canvas).find((t) => t.name === 'delete_new_quiz_item')!
+      const result = await tool.handler({ course_id: 1, assignment_id: 42, item_id: 'item-1' })
+      expect(canvas.newQuizzes.deleteItem).toHaveBeenCalledWith(1, 42, 'item-1')
+      expect(result).toEqual({ success: true })
+    })
+  })
+
+  // ── Per-type create_new_quiz_item input → canvas.newQuizzes.createItem ──────
+
+  describe('create_new_quiz_item — per-type input', () => {
+    it('passes choice item to createItem', async () => {
+      const canvas = buildMockCanvas()
+      const tool = newQuizTools(canvas).find((t) => t.name === 'create_new_quiz_item')!
+      const choiceItem = {
+        interaction_type_slug: 'choice',
+        item_body: '<p>What is 2+2?</p>',
+        choices: [
+          { id: 'a', item_body: '3' },
+          { id: 'b', item_body: '4' },
+        ],
+        correct_choice_id: 'b',
+      }
+      await tool.handler({ course_id: 1, assignment_id: 42, points_possible: 5, item: choiceItem })
+      expect(canvas.newQuizzes.createItem).toHaveBeenCalledWith(1, 42, {
+        points_possible: 5,
+        position: undefined,
+        item: choiceItem,
+      })
+    })
+
+    it('passes true-false item to createItem', async () => {
+      const canvas = buildMockCanvas()
+      const tool = newQuizTools(canvas).find((t) => t.name === 'create_new_quiz_item')!
+      const tfItem = {
+        interaction_type_slug: 'true-false',
+        item_body: '<p>The sky is blue.</p>',
+        correct_answer: true,
+      }
+      await tool.handler({ course_id: 1, assignment_id: 42, points_possible: 1, item: tfItem })
+      expect(canvas.newQuizzes.createItem).toHaveBeenCalledWith(1, 42, {
+        points_possible: 1,
+        position: undefined,
+        item: tfItem,
+      })
+    })
+
+    it('passes essay item to createItem', async () => {
+      const canvas = buildMockCanvas()
+      const tool = newQuizTools(canvas).find((t) => t.name === 'create_new_quiz_item')!
+      const essayItem = {
+        interaction_type_slug: 'essay',
+        item_body: '<p>Explain photosynthesis.</p>',
+        rich_text: true,
+      }
+      await tool.handler({ course_id: 1, assignment_id: 42, points_possible: 10, item: essayItem })
+      expect(canvas.newQuizzes.createItem).toHaveBeenCalledWith(1, 42, {
+        points_possible: 10,
+        position: undefined,
+        item: essayItem,
+      })
+    })
+
+    it('passes matching item to createItem', async () => {
+      const canvas = buildMockCanvas()
+      const tool = newQuizTools(canvas).find((t) => t.name === 'create_new_quiz_item')!
+      const matchItem = {
+        interaction_type_slug: 'matching',
+        item_body: '<p>Match the capitals.</p>',
+        matches: [
+          { question: 'France', answer: 'Paris' },
+          { question: 'Germany', answer: 'Berlin' },
+        ],
+      }
+      await tool.handler({
+        course_id: 1,
+        assignment_id: 42,
+        points_possible: 4,
+        item: matchItem,
+      })
+      expect(canvas.newQuizzes.createItem).toHaveBeenCalledWith(1, 42, {
+        points_possible: 4,
+        position: undefined,
+        item: matchItem,
+      })
+    })
+
+    it('passes numeric item to createItem', async () => {
+      const canvas = buildMockCanvas()
+      const tool = newQuizTools(canvas).find((t) => t.name === 'create_new_quiz_item')!
+      const numItem = {
+        interaction_type_slug: 'numeric',
+        item_body: '<p>What is π to 2 decimal places?</p>',
+        answers: [{ kind: 'exact', value: 3.14, margin: 0 }],
+      }
+      await tool.handler({ course_id: 1, assignment_id: 42, points_possible: 2, item: numItem })
+      expect(canvas.newQuizzes.createItem).toHaveBeenCalledWith(1, 42, {
+        points_possible: 2,
+        position: undefined,
+        item: numItem,
+      })
+    })
+
+    it('forwards optional position', async () => {
+      const canvas = buildMockCanvas()
+      const tool = newQuizTools(canvas).find((t) => t.name === 'create_new_quiz_item')!
+      const item = {
+        interaction_type_slug: 'true-false',
+        item_body: '<p>True or false?</p>',
+        correct_answer: false,
+      }
+      await tool.handler({ course_id: 1, assignment_id: 42, points_possible: 1, position: 3, item })
+      expect(canvas.newQuizzes.createItem).toHaveBeenCalledWith(1, 42, {
+        points_possible: 1,
+        position: 3,
+        item,
+      })
+    })
+  })
+
+  describe('update_new_quiz_item', () => {
+    it('delegates with item when provided', async () => {
+      const canvas = buildMockCanvas()
+      const tool = newQuizTools(canvas).find((t) => t.name === 'update_new_quiz_item')!
+      const item = {
+        interaction_type_slug: 'essay',
+        item_body: '<p>Updated question.</p>',
+        rich_text: false,
+      }
+      await tool.handler({
+        course_id: 1,
+        assignment_id: 42,
+        item_id: 'item-1',
+        points_possible: 8,
+        item,
+      })
+      expect(canvas.newQuizzes.updateItem).toHaveBeenCalledWith(1, 42, 'item-1', {
+        points_possible: 8,
+        position: undefined,
+        item,
+      })
+    })
+
+    it('delegates without item (points/position only)', async () => {
+      const canvas = buildMockCanvas()
+      const tool = newQuizTools(canvas).find((t) => t.name === 'update_new_quiz_item')!
+      await tool.handler({
+        course_id: 1,
+        assignment_id: 42,
+        item_id: 'item-1',
+        points_possible: 3,
+      })
+      expect(canvas.newQuizzes.updateItem).toHaveBeenCalledWith(1, 42, 'item-1', {
+        points_possible: 3,
+        position: undefined,
+        item: undefined,
+      })
+    })
+  })
+
+  // ── LTI not-enabled error mapping ───────────────────────────────────────────
+
+  describe('LTI error mapping via formatError', () => {
+    it('maps "Tool not configured" 404 on /api/quiz/v1/ to LTI not-enabled message', () => {
+      const error = new CanvasApiError('Tool not configured', 404, '/api/quiz/v1/courses/1/quizzes')
+      const result = formatError(error)
+      expect(result).toContain('New Quizzes is not enabled')
+      expect(result).toContain('list_quizzes / get_quiz')
+    })
+
+    it('maps "tool is not configured" (lowercase) 401 to LTI not-enabled message', () => {
+      const error = new CanvasApiError(
+        'tool is not configured',
+        401,
+        '/api/quiz/v1/courses/1/quizzes',
+      )
+      expect(formatError(error)).toContain('New Quizzes is not enabled')
+    })
+
+    it('plain 404 without LTI marker falls through to generic not-found message', () => {
+      const error = new CanvasApiError('Quiz not found', 404, '/api/quiz/v1/courses/1/quizzes')
+      const result = formatError(error)
+      expect(result).not.toContain('New Quizzes is not enabled')
+      expect(result).toBe('Course/assignment/submission not found — check the ID')
+    })
+
+    it('404 with LTI marker on /api/v1/ path does NOT trigger LTI message', () => {
+      // Classic quiz 404 with same message text must not be mis-mapped
+      const error = new CanvasApiError('Tool not configured', 404, '/api/v1/courses/1/quizzes/99')
+      const result = formatError(error)
+      expect(result).not.toContain('New Quizzes is not enabled')
+    })
+
+    it('maps 403 with "Rate Limit Exceeded" to rate-limit message', () => {
+      const error = new CanvasApiError(
+        'Rate Limit Exceeded',
+        403,
+        '/api/quiz/v1/courses/1/quizzes/42/items',
+      )
+      const result = formatError(error)
+      expect(result).toContain('rate-limit hit')
+      expect(result).toContain('retry')
+    })
+
+    it('plain 403 without rate-limit body falls through to permission message', () => {
+      const error = new CanvasApiError('Forbidden', 403, '/api/quiz/v1/courses/1/quizzes')
+      const result = formatError(error)
+      expect(result).toBe("You don't have permission to perform this action in this course")
+    })
+  })
+})

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -147,6 +147,16 @@ function buildFullMockCanvas(): CanvasClient {
       getUpcomingEvents: async () => [],
       getMissingSubmissions: async () => [],
     },
+    newQuizzes: {
+      create: async () => ({}),
+      update: async () => ({}),
+      delete: async () => undefined,
+      listItems: async () => [],
+      getItem: async () => ({}),
+      createItem: async () => ({}),
+      updateItem: async () => ({}),
+      deleteItem: async () => undefined,
+    },
   } as unknown as CanvasClient
 }
 
@@ -156,7 +166,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 107 tools across all domains', () => {
+  it('returns all 115 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 
@@ -289,8 +299,17 @@ describe('getAllTools', () => {
     expect(names).toContain('get_todo_items')
     expect(names).toContain('get_upcoming_events')
     expect(names).toContain('get_missing_submissions')
+    // New Quizzes (8)
+    expect(names).toContain('create_new_quiz')
+    expect(names).toContain('update_new_quiz')
+    expect(names).toContain('delete_new_quiz')
+    expect(names).toContain('list_new_quiz_items')
+    expect(names).toContain('get_new_quiz_item')
+    expect(names).toContain('create_new_quiz_item')
+    expect(names).toContain('update_new_quiz_item')
+    expect(names).toContain('delete_new_quiz_item')
 
-    expect(tools).toHaveLength(107)
+    expect(tools).toHaveLength(115)
   })
 
   it('all tools have openWorldHint: true', () => {
@@ -331,6 +350,12 @@ describe('getAllTools', () => {
       'update_calendar_event',
       'create_course',
       'update_course',
+      'create_new_quiz',
+      'update_new_quiz',
+      'delete_new_quiz',
+      'create_new_quiz_item',
+      'update_new_quiz_item',
+      'delete_new_quiz_item',
     ]
     const tools = getAllTools(buildFullMockCanvas())
     for (const name of writeToolNames) {
@@ -370,6 +395,12 @@ describe('getAllTools', () => {
       'update_calendar_event',
       'create_course',
       'update_course',
+      'create_new_quiz',
+      'update_new_quiz',
+      'delete_new_quiz',
+      'create_new_quiz_item',
+      'update_new_quiz_item',
+      'delete_new_quiz_item',
     ])
     const tools = getAllTools(buildFullMockCanvas())
     for (const tool of tools) {


### PR DESCRIPTION
## Summary

- Adds 8 New Quizzes MCP tools (`create/update/delete_new_quiz`, `list/get/create/update/delete_new_quiz_item`) in `src/tools/new-quizzes.ts`
- `create_new_quiz_item` and `update_new_quiz_item` use `z.discriminatedUnion` over 5 V1 item types (choice, true-false, essay, matching, numeric)
- Extends `formatError()` in `src/tools/errors.ts` with body-based LTI-not-enabled discriminator (detects "Tool not configured" on `/api/quiz/v1/` paths) and 403 rate-limit body check
- Registers `new_quizzes` domain in `src/tools/catalog.ts`
- Regenerates `docs/generated/tool-manifest.json` (107 → 115 tools)

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 686 tests, 61 files, all passing
- [x] `pnpm build` — ESM + CJS build successful
- [x] Annotation table matches spec § 4 exactly
- [x] LTI "Tool not configured" 404 → "New Quizzes is not enabled" message
- [x] Plain 404 without marker → generic "not found" (fall-through confirmed)
- [x] 403 + "Rate Limit Exceeded" → rate-limit message
- [x] Plain 403 → existing permission message (no regression)

Closes #124
Depends on: #127 (BRU-1045, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)