### PR TITLE
chore(deps): override fast-uri to ^3.1.2 for GHSA-v39h-62p7-jpjc

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
   "pnpm": {
     "overrides": {
       "hono": "^4.12.16",
-      "ip-address": "^10.1.1"
+      "ip-address": "^10.1.1",
+      "fast-uri": "^3.1.2"
     }
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   hono: ^4.12.16
   ip-address: ^10.1.1
+  fast-uri: ^3.1.2
 
 importers:
 
@@ -968,8 +969,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2269,7 +2270,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2555,7 +2556,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:


### PR DESCRIPTION
## Summary

- Adds `fast-uri: ^3.1.2` to `pnpm.overrides` in `package.json`
- Resolves high-severity advisory GHSA-v39h-62p7-jpjc (host confusion via percent-encoded authority delimiters)
- Path: `@modelcontextprotocol/sdk@1.29.0 > ajv@8.18.0 > fast-uri@3.1.0`
- `pnpm audit --audit-level=moderate` reports **No known vulnerabilities found**
- 686 tests pass, typecheck clean

Closes BRU-1095.

## Test plan

- [x] `pnpm audit --audit-level=moderate` → No known vulnerabilities found
- [x] `pnpm-lock.yaml` resolves `fast-uri` to `3.1.2`
- [x] `pnpm test` → 686 passed (61 test files)
- [x] `pnpm typecheck` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)