### PR TITLE
ci: add MCP Registry publish step to release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -51,6 +51,72 @@ jobs:
       - name: Publish to npm with Trusted Publisher OIDC
         run: npm publish --access public --no-git-checks --provenance --registry https://registry.npmjs.org/
 
+  registry-publish:
+    name: Publish to MCP Registry
+    needs: [release-please, npm-publish]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: version
+        run: |
+          TAG="${{ needs.release-please.outputs.tag_name }}"
+          VERSION="${TAG##*-v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+
+      - name: Wait for npm propagation
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # Poll the npm registry up to 12 times (6 min ceiling) before calling
+          # mcp-publisher, which fetches the package to verify it exists on npm.
+          echo "Polling npm for canvas-lms-mcp@$VERSION"
+          for i in $(seq 1 12); do
+            if curl -fsSL "https://registry.npmjs.org/canvas-lms-mcp/$VERSION" >/dev/null 2>&1; then
+              echo "Attempt $i: version $VERSION visible on npm"
+              exit 0
+            fi
+            echo "Attempt $i: not yet visible, waiting 30s..."
+            sleep 30
+          done
+          echo "ERROR: npm did not surface canvas-lms-mcp@$VERSION within 6 minutes"
+          exit 1
+
+      - name: Sync server.json version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          node -e "
+            const fs = require('fs');
+            const s = JSON.parse(fs.readFileSync('server.json', 'utf8'));
+            s.version = process.env.VERSION;
+            s.packages.forEach(p => { p.version = process.env.VERSION; });
+            fs.writeFileSync('server.json', JSON.stringify(s, null, 2) + '\n');
+          "
+          echo "server.json synced to version $VERSION"
+
+      - name: Install mcp-publisher
+        run: |
+          PUB_VER=$(curl -fsSL https://api.github.com/repos/modelcontextprotocol/registry/releases/latest | jq -r '.tag_name')
+          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+          ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${PUB_VER}/mcp-publisher_${OS}_${ARCH}.tar.gz" | tar xz
+          sudo mv mcp-publisher /usr/local/bin/
+          mcp-publisher --version
+
+      - name: Login to MCP Registry (OIDC)
+        run: mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: mcp-publisher publish
+
   enhance-notes:
     name: AI Release Notes
     needs: release-please

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org)
 [![npm downloads](https://img.shields.io/npm/dw/canvas-lms-mcp)](https://www.npmjs.com/package/canvas-lms-mcp)
+[![MCP Registry](https://img.shields.io/badge/MCP%20Registry-io.github.bruchris%2Fcanvas--lms--mcp-blue)](https://registry.modelcontextprotocol.io/v0/servers/io.github.bruchris%2Fcanvas-lms-mcp)
 
 MCP server for [Canvas LMS](https://www.instructure.com/canvas). Read courses, assignments, submissions, rubrics, quizzes; grade, comment, manage course content, and handle Canvas admin workflows from any AI agent.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,54 @@
+# Releasing canvas-lms-mcp
+
+## How releases work
+
+Releases are fully automated via [release-please](https://github.com/googleapis/release-please). Push conventional commits to `main`; release-please opens a PR bumping the version and updating CHANGELOG.md. Merging that PR triggers the Release workflow, which:
+
+1. **`release-please`** — creates the GitHub release and tag (e.g. `canvas-lms-mcp-v1.16.0`).
+2. **`npm-publish`** — publishes to npm via OIDC Trusted Publisher (no token stored in secrets).
+3. **`registry-publish`** — publishes to the MCP Registry at `registry.modelcontextprotocol.io` as `io.github.bruchris/canvas-lms-mcp`.
+4. **`enhance-notes`** — enriches the GitHub release body with AI-written highlights.
+
+## MCP Registry publish
+
+### Authentication
+
+The `registry-publish` job uses **GitHub OIDC** (`mcp-publisher login github-oidc`). No token or secret is required — GitHub Actions mints a short-lived OIDC token automatically when the job has `id-token: write` permission. The MCP Registry trusts GitHub's OIDC issuer and maps the `io.github.bruchris/*` namespace to the `bruchris` GitHub account.
+
+**No `MCP_REGISTRY_TOKEN` secret is needed.** OIDC is the recommended approach for CI.
+
+### First-time setup
+
+OIDC publish is gated on the registry recognising the GitHub repository. On first publish from a new repo, the registry may require a one-time GitHub App authorisation. If the first automated publish fails with an authorisation error:
+
+1. Install the [MCP Publisher CLI](https://github.com/modelcontextprotocol/registry/releases/latest) locally.
+2. From the repo root, run:
+   ```bash
+   mcp-publisher login
+   mcp-publisher publish
+   ```
+   This opens a browser to authorise the `bruchris` GitHub account with the registry.
+3. Subsequent CI runs will succeed via OIDC without any manual step.
+
+### server.json
+
+`server.json` at the repo root is the manifest read by `mcp-publisher publish`. The `version` field is synced to the release tag by the workflow's "Sync server.json version" step before publishing, so the checked-in file always reflects the latest published version.
+
+### Failure policy
+
+`registry-publish` runs with `continue-on-error: true`. If it fails after `npm-publish` succeeded, the npm package is still live and is the source of truth. Re-run the failed job from the Actions tab; the propagation poll re-checks npm visibility before retrying the registry step.
+
+## Manual publish (dry-run / backfill)
+
+To publish a specific tag to the MCP Registry without going through CI, install `mcp-publisher` locally and run:
+
+```bash
+git checkout canvas-lms-mcp-v1.16.0
+# edit server.json version to match, then:
+mcp-publisher login
+mcp-publisher publish
+```
+
+## npm publish
+
+npm publish uses OIDC Trusted Publishing configured in the [npm package settings](https://www.npmjs.com/package/canvas-lms-mcp) under "Trusted Publisher". No `NPM_TOKEN` secret is stored; the `npm-publish` job's `id-token: write` permission supplies the OIDC grant.

--- a/server.json
+++ b/server.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.bruchris/canvas-lms-mcp",
+  "description": "TypeScript MCP 1.x server for Canvas LMS — 115 tools across courses, assignments, grades, gradebook history, quizzes, New Quizzes (LTI), outcomes, discussions, admin workflows, and more.",
+  "repository": {
+    "url": "https://github.com/bruchris/canvas-lms-mcp",
+    "source": "github"
+  },
+  "version": "1.15.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "canvas-lms-mcp",
+      "version": "1.15.1",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "CANVAS_API_TOKEN",
+          "description": "Canvas personal access token (Account → Settings → Approved Integrations → New Access Token)",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "CANVAS_BASE_URL",
+          "description": "Canvas instance API URL, e.g. https://school.instructure.com/api/v1",
+          "isRequired": true,
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `registry-publish` job to `.github/workflows/release-please.yml`, gated on `npm-publish` success, with `continue-on-error: true` so a registry failure never blocks a successful npm release
- Polls `registry.npmjs.org` up to 12×30s before calling `mcp-publisher` to avoid the CDN propagation race (same pattern as vishalsachdev/canvas-mcp PR #107, adapted for npm instead of PyPI)
- Authenticates via GitHub OIDC (`mcp-publisher login github-oidc`) — no token secret required; `id-token: write` permission is sufficient
- Syncs `server.json` version to the release tag before publishing (same approach as chrischall/canvas-parent-mcp)
- Adds `server.json` manifest for namespace `io.github.bruchris/canvas-lms-mcp`
- Adds `docs/RELEASING.md` release runbook documenting both npm and registry steps, including first-time OIDC setup instructions
- Adds MCP Registry badge to README

## Test plan

- [ ] CI on this PR passes (non-publish workflows only — publish only fires on tag push)
- [ ] On next release: `registry-publish` job runs, propagation poll succeeds, server appears at `https://registry.modelcontextprotocol.io/v0/servers?search=canvas` as `io.github.bruchris/canvas-lms-mcp`
- [ ] If `registry-publish` fails: release is not blocked (npm is still live), job can be re-run from Actions tab

Closes #BRU-1144

🤖 Generated with [Claude Code](https://claude.com/claude-code)