### PR TITLE
ci: authenticate mcp-publisher GitHub API call to avoid rate-limit [BRU-1145]

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Install mcp-publisher
         run: |
-          PUB_VER=$(curl -fsSL https://api.github.com/repos/modelcontextprotocol/registry/releases/latest | jq -r '.tag_name')
+          PUB_VER=$(curl -fsSL -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/modelcontextprotocol/registry/releases/latest | jq -r '.tag_name')
           OS=$(uname -s | tr '[:upper:]' '[:lower:]')
           ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
           curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${PUB_VER}/mcp-publisher_${OS}_${ARCH}.tar.gz" | tar xz


### PR DESCRIPTION
## Summary

- Add `Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}` header to the `curl` call that fetches the latest `mcp-publisher` release tag in the `registry-publish` job
- Raises the per-runner GitHub API rate limit from 60 req/hr (unauthenticated) to 1000 req/hr, preventing silent registry-publish failures on saturated shared runners
- No permissions change needed — the `registry-publish` job already has `contents: read`

## Test plan

- [ ] Verify the diff: only line 107 of `release-please.yml` changes (Authorization header added)
- [ ] Confirm the `registry-publish` job still has `contents: read` + `id-token: write` permissions (no escalation)
- [ ] On next real release, confirm the `Install mcp-publisher` step completes without a rate-limit error

Fixes BRU-1145. Parent: BRU-1144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)