### PR TITLE
fix(ci): shorten server.json description + harden registry-publish job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -56,7 +56,6 @@ jobs:
     needs: [release-please, npm-publish]
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
-    continue-on-error: true
     permissions:
       contents: read
       id-token: write
@@ -113,6 +112,13 @@ jobs:
 
       - name: Login to MCP Registry (OIDC)
         run: mcp-publisher login github-oidc
+
+      - name: Assert description length
+        run: |
+          DESC=$(node -e "const s=require('./server.json');process.stdout.write(s.description)")
+          LEN=${#DESC}
+          if [ "$LEN" -gt 100 ]; then echo "ERROR: server.json description is $LEN chars (limit 100): $DESC" && exit 1; fi
+          echo "OK: description is $LEN chars"
 
       - name: Publish to MCP Registry
         run: mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.bruchris/canvas-lms-mcp",
-  "description": "TypeScript MCP 1.x server for Canvas LMS — 115 tools across courses, assignments, grades, gradebook history, quizzes, New Quizzes (LTI), outcomes, discussions, admin workflows, and more.",
+  "description": "TypeScript MCP server for Canvas LMS — 115 read+write tools across 17 domains.",
   "repository": {
     "url": "https://github.com/bruchris/canvas-lms-mcp",
     "source": "github"


### PR DESCRIPTION
## Summary

- **`server.json`**: Shortens `description` from 186 → 78 chars (`"TypeScript MCP server for Canvas LMS — 115 read+write tools across 17 domains."`), fixing the 422 Unprocessable Entity that has silently blocked MCP Registry publish since v1.15.2
- **`release-please.yml`**: Removes `continue-on-error: true` from `registry-publish` job so future failures surface immediately as a CI gate, not silent skips
- **`release-please.yml`**: Adds an **Assert description length** step that fails fast with a clear error message if `server.json` description exceeds 100 chars before ever calling `mcp-publisher publish`

## Test plan

- [ ] CI passes on this PR
- [ ] After merge: next release-please PR → Release workflow → `registry-publish` job is green
- [ ] `curl 'https://registry.modelcontextprotocol.io/v0/servers?search=bruchris'` returns a non-empty `servers` array

Closes #BRU-1198

🤖 Generated with [Claude Code](https://claude.com/claude-code)