### PR TITLE
feat(init): config writers for JSON/TOML client configs [BRU-1223]

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     }
   },
   "dependencies": {
+    "@iarna/toml": "^2.2.5",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
 
   .:
     dependencies:
+      '@iarna/toml':
+        specifier: ^2.2.5
+        version: 2.2.5
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -472,6 +475,9 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@iarna/toml@2.2.5':
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -2135,6 +2141,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@iarna/toml@2.2.5': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:

--- a/src/init/config-writer.ts
+++ b/src/init/config-writer.ts
@@ -1,0 +1,37 @@
+import type { FileSystem } from './io'
+import type { ClientDescriptor, PathEnv } from './clients'
+import { currentPathEnv } from './clients'
+import { mergeJsonConfig, type McpEntry } from './json-merge'
+import { mergeTomlConfig } from './toml-merge'
+
+export type { McpEntry }
+
+export interface WriteConfigOptions {
+  noBackup?: boolean
+  serverName?: string
+  pathEnv?: PathEnv
+}
+
+export async function writeClientConfigs(
+  fs: FileSystem,
+  targets: ClientDescriptor[],
+  entry: McpEntry,
+  opts: WriteConfigOptions = {},
+): Promise<void> {
+  const env = opts.pathEnv ?? currentPathEnv()
+  const serverName = opts.serverName ?? 'canvas-lms'
+
+  for (const target of targets) {
+    const configPath = target.resolvePath(env)
+
+    if (target.format === 'toml') {
+      await mergeTomlConfig(fs, configPath, target.wrapperKey, serverName, entry, {
+        noBackup: opts.noBackup,
+      })
+    } else {
+      await mergeJsonConfig(fs, configPath, target.wrapperKey, serverName, entry, {
+        noBackup: opts.noBackup,
+      })
+    }
+  }
+}

--- a/src/init/json-merge.ts
+++ b/src/init/json-merge.ts
@@ -1,0 +1,49 @@
+import { posix, win32 } from 'node:path'
+import type { FileSystem } from './io'
+
+export interface McpEntry {
+  command: string
+  args: string[]
+  env: Record<string, string>
+}
+
+function dirOf(path: string): string {
+  return path.includes('\\') ? win32.dirname(path) : posix.dirname(path)
+}
+
+export async function mergeJsonConfig(
+  fs: FileSystem,
+  path: string,
+  wrapperKey: string,
+  serverName: string,
+  entry: McpEntry,
+  opts: { noBackup?: boolean } = {},
+): Promise<void> {
+  const exists = await fs.exists(path)
+  let config: Record<string, unknown> = {}
+
+  if (exists) {
+    const raw = await fs.readFile(path)
+    config = JSON.parse(raw) as Record<string, unknown>
+  }
+
+  const wrapper = config[wrapperKey]
+  config[wrapperKey] = {
+    ...(typeof wrapper === 'object' && wrapper !== null
+      ? (wrapper as Record<string, unknown>)
+      : {}),
+    [serverName]: entry,
+  }
+
+  const updated = `${JSON.stringify(config, null, 2)}\n`
+  const tmpPath = `${path}.tmp`
+
+  await fs.mkdir(dirOf(path), { recursive: true })
+
+  if (exists && !opts.noBackup) {
+    await fs.copyFile(path, `${path}.bak`)
+  }
+
+  await fs.writeFile(tmpPath, updated)
+  await fs.rename(tmpPath, path)
+}

--- a/src/init/toml-merge.ts
+++ b/src/init/toml-merge.ts
@@ -1,0 +1,45 @@
+import { posix, win32 } from 'node:path'
+import TOML from '@iarna/toml'
+import type { FileSystem } from './io'
+import type { McpEntry } from './json-merge'
+
+function dirOf(path: string): string {
+  return path.includes('\\') ? win32.dirname(path) : posix.dirname(path)
+}
+
+export async function mergeTomlConfig(
+  fs: FileSystem,
+  path: string,
+  wrapperKey: string,
+  serverName: string,
+  entry: McpEntry,
+  opts: { noBackup?: boolean } = {},
+): Promise<void> {
+  const exists = await fs.exists(path)
+  let config: TOML.JsonMap = {}
+
+  if (exists) {
+    const raw = await fs.readFile(path)
+    config = TOML.parse(raw)
+  }
+
+  const wrapper = config[wrapperKey]
+  config[wrapperKey] = {
+    ...(typeof wrapper === 'object' && wrapper !== null && !Array.isArray(wrapper)
+      ? (wrapper as TOML.JsonMap)
+      : {}),
+    [serverName]: entry as unknown as TOML.AnyJson,
+  }
+
+  const updated = TOML.stringify(config)
+  const tmpPath = `${path}.tmp`
+
+  await fs.mkdir(dirOf(path), { recursive: true })
+
+  if (exists && !opts.noBackup) {
+    await fs.copyFile(path, `${path}.bak`)
+  }
+
+  await fs.writeFile(tmpPath, updated)
+  await fs.rename(tmpPath, path)
+}

--- a/tests/init/config-writer.test.ts
+++ b/tests/init/config-writer.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import TOML from '@iarna/toml'
+import { createMemoryFileSystem } from '../../src/init/io'
+import { writeClientConfigs, type McpEntry } from '../../src/init/config-writer'
+import { CLIENTS, type PathEnv } from '../../src/init/clients'
+
+const entry: McpEntry = {
+  command: 'npx',
+  args: ['canvas-lms-mcp', '--stdio'],
+  env: { CANVAS_API_TOKEN: 'tok', CANVAS_BASE_URL: 'https://school.instructure.com/api/v1' },
+}
+
+const linuxEnv: PathEnv = { platform: 'linux', home: '/home/alice' }
+const winEnv: PathEnv = {
+  platform: 'win32',
+  home: 'C:\\Users\\Alice',
+  appData: 'C:\\Users\\Alice\\AppData\\Roaming',
+}
+
+describe('writeClientConfigs', () => {
+  let fs: ReturnType<typeof createMemoryFileSystem>
+
+  beforeEach(() => {
+    fs = createMemoryFileSystem()
+  })
+
+  it('writes JSON config for a single JSON client', async () => {
+    const cursor = CLIENTS.find((c) => c.id === 'cursor')!
+    await writeClientConfigs(fs, [cursor], entry, { pathEnv: linuxEnv })
+    const path = cursor.resolvePath(linuxEnv)
+    const config = JSON.parse(await fs.readFile(path)) as Record<string, unknown>
+    expect(config).toMatchObject({ mcpServers: { 'canvas-lms': entry } })
+  })
+
+  it('writes TOML config for the codex client', async () => {
+    const codex = CLIENTS.find((c) => c.id === 'codex')!
+    await writeClientConfigs(fs, [codex], entry, { pathEnv: linuxEnv })
+    const path = codex.resolvePath(linuxEnv)
+    const config = TOML.parse(await fs.readFile(path))
+    expect(config).toMatchObject({ mcp_servers: { 'canvas-lms': { command: 'npx' } } })
+  })
+
+  it('writes all JSON clients in a single call', async () => {
+    const jsonClients = CLIENTS.filter((c) => c.format === 'json')
+    await writeClientConfigs(fs, jsonClients, entry, { pathEnv: linuxEnv })
+    for (const client of jsonClients) {
+      const path = client.resolvePath(linuxEnv)
+      expect(await fs.exists(path)).toBe(true)
+    }
+  })
+
+  it('writes all clients including codex in one call', async () => {
+    const allClients = [...CLIENTS]
+    await writeClientConfigs(fs, allClients, entry, { pathEnv: linuxEnv })
+    for (const client of allClients) {
+      const path = client.resolvePath(linuxEnv)
+      expect(await fs.exists(path)).toBe(true)
+    }
+  })
+
+  it('uses a custom serverName from opts', async () => {
+    const cursor = CLIENTS.find((c) => c.id === 'cursor')!
+    await writeClientConfigs(fs, [cursor], entry, {
+      pathEnv: linuxEnv,
+      serverName: 'my-canvas',
+    })
+    const path = cursor.resolvePath(linuxEnv)
+    const config = JSON.parse(await fs.readFile(path)) as Record<string, unknown>
+    expect(config).toMatchObject({ mcpServers: { 'my-canvas': entry } })
+  })
+
+  it('defaults serverName to canvas-lms', async () => {
+    const cursor = CLIENTS.find((c) => c.id === 'cursor')!
+    await writeClientConfigs(fs, [cursor], entry, { pathEnv: linuxEnv })
+    const path = cursor.resolvePath(linuxEnv)
+    const config = JSON.parse(await fs.readFile(path)) as Record<string, unknown>
+    const servers = config.mcpServers as Record<string, unknown>
+    expect(Object.keys(servers)).toContain('canvas-lms')
+  })
+
+  it('respects noBackup: no .bak created on overwrite', async () => {
+    const cursor = CLIENTS.find((c) => c.id === 'cursor')!
+    const path = cursor.resolvePath(linuxEnv)
+    await writeClientConfigs(fs, [cursor], entry, { pathEnv: linuxEnv })
+    await writeClientConfigs(fs, [cursor], entry, { pathEnv: linuxEnv, noBackup: true })
+    expect(await fs.exists(`${path}.bak`)).toBe(false)
+  })
+
+  it('creates a .bak for a JSON client when overwriting without noBackup', async () => {
+    const cursor = CLIENTS.find((c) => c.id === 'cursor')!
+    const path = cursor.resolvePath(linuxEnv)
+    await writeClientConfigs(fs, [cursor], entry, { pathEnv: linuxEnv })
+    await writeClientConfigs(fs, [cursor], entry, { pathEnv: linuxEnv })
+    expect(await fs.exists(`${path}.bak`)).toBe(true)
+  })
+
+  it('handles Windows paths for win32 platform', async () => {
+    const claudeDesktop = CLIENTS.find((c) => c.id === 'claude-desktop')!
+    await writeClientConfigs(fs, [claudeDesktop], entry, { pathEnv: winEnv })
+    const path = claudeDesktop.resolvePath(winEnv)
+    const config = JSON.parse(await fs.readFile(path)) as Record<string, unknown>
+    expect(config).toMatchObject({ mcpServers: { 'canvas-lms': entry } })
+  })
+
+  it('is idempotent across repeated runs', async () => {
+    const cursor = CLIENTS.find((c) => c.id === 'cursor')!
+    await writeClientConfigs(fs, [cursor], entry, { pathEnv: linuxEnv })
+    const after1 = await fs.readFile(cursor.resolvePath(linuxEnv))
+    await writeClientConfigs(fs, [cursor], entry, { pathEnv: linuxEnv, noBackup: true })
+    const after2 = await fs.readFile(cursor.resolvePath(linuxEnv))
+    expect(after2).toBe(after1)
+  })
+})

--- a/tests/init/json-merge.test.ts
+++ b/tests/init/json-merge.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createMemoryFileSystem } from '../../src/init/io'
+import { mergeJsonConfig, type McpEntry } from '../../src/init/json-merge'
+
+const entry: McpEntry = {
+  command: 'npx',
+  args: ['canvas-lms-mcp', '--stdio'],
+  env: { CANVAS_API_TOKEN: 'tok', CANVAS_BASE_URL: 'https://school.instructure.com/api/v1' },
+}
+
+describe('mergeJsonConfig', () => {
+  let fs: ReturnType<typeof createMemoryFileSystem>
+
+  beforeEach(() => {
+    fs = createMemoryFileSystem()
+  })
+
+  it('creates a new config file when none exists', async () => {
+    await mergeJsonConfig(fs, '/home/alice/.cursor/mcp.json', 'mcpServers', 'canvas-lms', entry)
+    const raw = await fs.readFile('/home/alice/.cursor/mcp.json')
+    const config = JSON.parse(raw) as Record<string, unknown>
+    expect(config).toMatchObject({ mcpServers: { 'canvas-lms': entry } })
+    expect(await fs.exists('/home/alice/.cursor/mcp.json.bak')).toBe(false)
+  })
+
+  it('preserves pre-existing keys when merging', async () => {
+    await fs.mkdir('/home/alice/.cursor', { recursive: true })
+    await fs.writeFile(
+      '/home/alice/.cursor/mcp.json',
+      JSON.stringify({ mcpServers: { 'other-server': { command: 'other' } } }, null, 2) + '\n',
+    )
+    await mergeJsonConfig(fs, '/home/alice/.cursor/mcp.json', 'mcpServers', 'canvas-lms', entry)
+    const config = JSON.parse(await fs.readFile('/home/alice/.cursor/mcp.json')) as Record<
+      string,
+      unknown
+    >
+    expect(config).toMatchObject({
+      mcpServers: { 'other-server': { command: 'other' }, 'canvas-lms': entry },
+    })
+  })
+
+  it('preserves top-level keys outside the wrapper', async () => {
+    await fs.mkdir('/home/alice/.cursor', { recursive: true })
+    await fs.writeFile(
+      '/home/alice/.cursor/mcp.json',
+      JSON.stringify({ version: 1, mcpServers: {} }, null, 2) + '\n',
+    )
+    await mergeJsonConfig(fs, '/home/alice/.cursor/mcp.json', 'mcpServers', 'canvas-lms', entry)
+    const config = JSON.parse(await fs.readFile('/home/alice/.cursor/mcp.json')) as Record<
+      string,
+      unknown
+    >
+    expect(config.version).toBe(1)
+    expect(config.mcpServers).toMatchObject({ 'canvas-lms': entry })
+  })
+
+  it('is idempotent: second write produces identical output', async () => {
+    await mergeJsonConfig(fs, '/home/alice/.cursor/mcp.json', 'mcpServers', 'canvas-lms', entry)
+    const first = await fs.readFile('/home/alice/.cursor/mcp.json')
+    await mergeJsonConfig(fs, '/home/alice/.cursor/mcp.json', 'mcpServers', 'canvas-lms', entry, {
+      noBackup: true,
+    })
+    const second = await fs.readFile('/home/alice/.cursor/mcp.json')
+    expect(second).toBe(first)
+  })
+
+  it('creates a .bak backup when overwriting an existing file', async () => {
+    await fs.mkdir('/home/alice/.cursor', { recursive: true })
+    const original = JSON.stringify({ mcpServers: {} }, null, 2) + '\n'
+    await fs.writeFile('/home/alice/.cursor/mcp.json', original)
+    await mergeJsonConfig(fs, '/home/alice/.cursor/mcp.json', 'mcpServers', 'canvas-lms', entry)
+    expect(await fs.exists('/home/alice/.cursor/mcp.json.bak')).toBe(true)
+    expect(await fs.readFile('/home/alice/.cursor/mcp.json.bak')).toBe(original)
+  })
+
+  it('skips the .bak when noBackup is true', async () => {
+    await fs.mkdir('/home/alice/.cursor', { recursive: true })
+    await fs.writeFile('/home/alice/.cursor/mcp.json', JSON.stringify({ mcpServers: {} }) + '\n')
+    await mergeJsonConfig(fs, '/home/alice/.cursor/mcp.json', 'mcpServers', 'canvas-lms', entry, {
+      noBackup: true,
+    })
+    expect(await fs.exists('/home/alice/.cursor/mcp.json.bak')).toBe(false)
+  })
+
+  it('creates missing parent directories', async () => {
+    await mergeJsonConfig(
+      fs,
+      '/home/alice/.config/Claude/claude_desktop_config.json',
+      'mcpServers',
+      'canvas-lms',
+      entry,
+    )
+    expect(await fs.exists('/home/alice/.config/Claude/claude_desktop_config.json')).toBe(true)
+  })
+
+  it('leaves no .tmp file after a successful write', async () => {
+    await mergeJsonConfig(fs, '/home/alice/.cursor/mcp.json', 'mcpServers', 'canvas-lms', entry)
+    expect(await fs.exists('/home/alice/.cursor/mcp.json.tmp')).toBe(false)
+  })
+
+  it('handles Windows-style paths', async () => {
+    await mergeJsonConfig(
+      fs,
+      'C:\\Users\\Alice\\AppData\\Roaming\\Claude\\claude_desktop_config.json',
+      'mcpServers',
+      'canvas-lms',
+      entry,
+    )
+    const raw = await fs.readFile(
+      'C:\\Users\\Alice\\AppData\\Roaming\\Claude\\claude_desktop_config.json',
+    )
+    expect(JSON.parse(raw)).toMatchObject({ mcpServers: { 'canvas-lms': entry } })
+  })
+
+  it('creates a fresh mcpServers wrapper when config has none', async () => {
+    await fs.mkdir('/home/alice/.cursor', { recursive: true })
+    await fs.writeFile('/home/alice/.cursor/mcp.json', '{"version":2}\n')
+    await mergeJsonConfig(fs, '/home/alice/.cursor/mcp.json', 'mcpServers', 'canvas-lms', entry)
+    const config = JSON.parse(await fs.readFile('/home/alice/.cursor/mcp.json')) as Record<
+      string,
+      unknown
+    >
+    expect(config).toMatchObject({ version: 2, mcpServers: { 'canvas-lms': entry } })
+  })
+})

--- a/tests/init/toml-merge.test.ts
+++ b/tests/init/toml-merge.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import TOML from '@iarna/toml'
+import { createMemoryFileSystem } from '../../src/init/io'
+import { mergeTomlConfig } from '../../src/init/toml-merge'
+import type { McpEntry } from '../../src/init/json-merge'
+
+const entry: McpEntry = {
+  command: 'npx',
+  args: ['canvas-lms-mcp', '--stdio'],
+  env: { CANVAS_API_TOKEN: 'tok', CANVAS_BASE_URL: 'https://school.instructure.com/api/v1' },
+}
+
+describe('mergeTomlConfig', () => {
+  let fs: ReturnType<typeof createMemoryFileSystem>
+
+  beforeEach(() => {
+    fs = createMemoryFileSystem()
+  })
+
+  it('creates a new TOML config file when none exists', async () => {
+    await mergeTomlConfig(fs, '/home/alice/.codex/config.toml', 'mcp_servers', 'canvas-lms', entry)
+    const raw = await fs.readFile('/home/alice/.codex/config.toml')
+    const config = TOML.parse(raw)
+    expect(config).toMatchObject({
+      mcp_servers: { 'canvas-lms': { command: 'npx' } },
+    })
+    expect(await fs.exists('/home/alice/.codex/config.toml.bak')).toBe(false)
+  })
+
+  it('preserves pre-existing mcp_servers entries', async () => {
+    await fs.mkdir('/home/alice/.codex', { recursive: true })
+    const initial = TOML.stringify({ mcp_servers: { 'other-server': { command: 'other' } } })
+    await fs.writeFile('/home/alice/.codex/config.toml', initial)
+    await mergeTomlConfig(fs, '/home/alice/.codex/config.toml', 'mcp_servers', 'canvas-lms', entry)
+    const config = TOML.parse(await fs.readFile('/home/alice/.codex/config.toml'))
+    expect(config).toMatchObject({
+      mcp_servers: { 'other-server': { command: 'other' }, 'canvas-lms': { command: 'npx' } },
+    })
+  })
+
+  it('preserves top-level keys outside the wrapper', async () => {
+    await fs.mkdir('/home/alice/.codex', { recursive: true })
+    const initial = TOML.stringify({ model: 'gpt-4', mcp_servers: {} })
+    await fs.writeFile('/home/alice/.codex/config.toml', initial)
+    await mergeTomlConfig(fs, '/home/alice/.codex/config.toml', 'mcp_servers', 'canvas-lms', entry)
+    const config = TOML.parse(await fs.readFile('/home/alice/.codex/config.toml'))
+    expect(config.model).toBe('gpt-4')
+    expect(config.mcp_servers).toMatchObject({ 'canvas-lms': { command: 'npx' } })
+  })
+
+  it('is idempotent: second write produces identical output', async () => {
+    await mergeTomlConfig(fs, '/home/alice/.codex/config.toml', 'mcp_servers', 'canvas-lms', entry)
+    const first = await fs.readFile('/home/alice/.codex/config.toml')
+    await mergeTomlConfig(
+      fs,
+      '/home/alice/.codex/config.toml',
+      'mcp_servers',
+      'canvas-lms',
+      entry,
+      { noBackup: true },
+    )
+    const second = await fs.readFile('/home/alice/.codex/config.toml')
+    expect(second).toBe(first)
+  })
+
+  it('creates a .bak backup when overwriting an existing file', async () => {
+    await fs.mkdir('/home/alice/.codex', { recursive: true })
+    const original = TOML.stringify({ mcp_servers: {} })
+    await fs.writeFile('/home/alice/.codex/config.toml', original)
+    await mergeTomlConfig(fs, '/home/alice/.codex/config.toml', 'mcp_servers', 'canvas-lms', entry)
+    expect(await fs.exists('/home/alice/.codex/config.toml.bak')).toBe(true)
+    expect(await fs.readFile('/home/alice/.codex/config.toml.bak')).toBe(original)
+  })
+
+  it('skips the .bak when noBackup is true', async () => {
+    await fs.mkdir('/home/alice/.codex', { recursive: true })
+    await fs.writeFile('/home/alice/.codex/config.toml', TOML.stringify({ mcp_servers: {} }))
+    await mergeTomlConfig(
+      fs,
+      '/home/alice/.codex/config.toml',
+      'mcp_servers',
+      'canvas-lms',
+      entry,
+      { noBackup: true },
+    )
+    expect(await fs.exists('/home/alice/.codex/config.toml.bak')).toBe(false)
+  })
+
+  it('creates missing parent directories', async () => {
+    await mergeTomlConfig(fs, '/home/alice/.codex/config.toml', 'mcp_servers', 'canvas-lms', entry)
+    expect(await fs.exists('/home/alice/.codex/config.toml')).toBe(true)
+  })
+
+  it('leaves no .tmp file after a successful write', async () => {
+    await mergeTomlConfig(fs, '/home/alice/.codex/config.toml', 'mcp_servers', 'canvas-lms', entry)
+    expect(await fs.exists('/home/alice/.codex/config.toml.tmp')).toBe(false)
+  })
+
+  it('handles Windows-style paths', async () => {
+    await mergeTomlConfig(
+      fs,
+      'C:\\Users\\Alice\\.codex\\config.toml',
+      'mcp_servers',
+      'canvas-lms',
+      entry,
+    )
+    const raw = await fs.readFile('C:\\Users\\Alice\\.codex\\config.toml')
+    const config = TOML.parse(raw)
+    expect(config).toMatchObject({ mcp_servers: { 'canvas-lms': { command: 'npx' } } })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `src/init/json-merge.ts`: reads existing JSON config (or empty object), merges `mcpServers.<serverName>` entry without touching unrelated keys, atomic write via `.tmp` → rename, creates `.bak` if file existed (skippable with `noBackup`)
- Adds `src/init/toml-merge.ts`: same contract for Codex CLI's TOML config using `@iarna/toml`
- Adds `src/init/config-writer.ts`: top-level `writeClientConfigs(fs, targets, entry, opts)` that dispatches to json- or toml-merge based on `ClientDescriptor.format`
- Adds `@iarna/toml 2.2.5` as a runtime dependency
- 29 new tests (json-merge: 9, toml-merge: 8, config-writer: 10) — 729 total tests passing

Closes BRU-1254. Part of the init wizard series (BRU-1223).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 729 tests pass (65 test files)
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean
- [x] Empty config → creates new file with correct structure
- [x] Populated config → preserves unrelated keys
- [x] Idempotent re-run → no diff on second invocation with same input
- [x] Backup file created on overwrite, skipped on first write and when `noBackup: true`
- [x] Windows-style paths (`C:\Users\...`) handled correctly
- [x] Missing parent directories created automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)