### PR TITLE
feat(init): wizard orchestration with Canvas token validation [BRU-1223]

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,11 +89,13 @@
   "dependencies": {
     "@iarna/toml": "^2.2.5",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "prompts": "^2.4.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.9.1",
+    "@types/prompts": "^2.4.9",
     "@typescript-eslint/eslint-plugin": "^8.59.4",
     "@typescript-eslint/parser": "^8.59.4",
     "@vitest/coverage-v8": "^4.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
+      prompts:
+        specifier: ^2.4.2
+        version: 2.4.2
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -30,6 +33,9 @@ importers:
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
+      '@types/prompts':
+        specifier: ^2.4.9
+        version: 2.4.9
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.59.4
         version: 8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@6.0.3))(eslint@10.4.0)(typescript@6.0.3)
@@ -756,6 +762,9 @@ packages:
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
+  '@types/prompts@2.4.9':
+    resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
+
   '@typescript-eslint/eslint-plugin@8.59.4':
     resolution: {integrity: sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1307,6 +1316,10 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -1552,6 +1565,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -1643,6 +1660,9 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2341,6 +2361,11 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
+  '@types/prompts@2.4.9':
+    dependencies:
+      '@types/node': 25.9.1
+      kleur: 3.0.3
+
   '@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@6.0.3))(eslint@10.4.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -2978,6 +3003,8 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  kleur@3.0.3: {}
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -3170,6 +3197,11 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -3324,6 +3356,8 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
+
+  sisteransi@1.0.5: {}
 
   source-map-js@1.2.1: {}
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,26 +1,39 @@
 #!/usr/bin/env node
-// init wizard entry — Task 1 stub. Subsequent tasks (BRU-?) wire the wizard
-// (prompts, Canvas /users/self validation) and config writers.
+// init wizard entry — argv → wizard (prompts + Canvas validation) → config writer.
 
+import prompts from 'prompts'
 import { helpText, parseInitArgs } from './init/argv'
+import { currentPathEnv } from './init/clients'
+import { writeClientConfigs } from './init/config-writer'
+import { nodeFileSystem } from './init/io'
+import { pingUsersSelf } from './init/validate'
+import { runWizard, type WizardDeps } from './init/wizard'
 
 async function main() {
   const args = process.argv.slice(2)
   if (args[0] === 'init') args.shift()
-  const result = parseInitArgs(args)
-  if (!result.ok) {
-    console.error(`Error: ${result.message}`)
+  const parsed = parseInitArgs(args)
+  if (!parsed.ok) {
+    console.error(`Error: ${parsed.message}`)
     process.exit(2)
   }
-  if (result.config.showHelp) {
+  if (parsed.config.showHelp) {
     console.log(helpText())
     process.exit(0)
   }
-  console.log('canvas-lms-mcp init: setup wizard coming soon.')
-  console.log(
-    'For now, configure your MCP client manually — see https://github.com/bruchris/canvas-lms-mcp#setup',
-  )
-  process.exit(0)
+
+  const deps: WizardDeps = {
+    fs: nodeFileSystem,
+    env: currentPathEnv(),
+    prompts: async (question) =>
+      (await prompts(question as Parameters<typeof prompts>[0])) as Record<string, unknown>,
+    pingUsersSelf,
+    writeClientConfigs,
+    log: (message) => console.log(message),
+  }
+
+  const result = await runWizard(deps, { initialConfig: parsed.config })
+  process.exit(result.exitCode)
 }
 
 main().catch((error) => {

--- a/src/init/clients.ts
+++ b/src/init/clients.ts
@@ -1,5 +1,6 @@
 import { homedir } from 'node:os'
 import { posix as posixPath, win32 as winPath } from 'node:path'
+import type { FileSystem } from './io'
 
 export type ClientId =
   | 'claude-desktop'
@@ -127,4 +128,19 @@ export function currentPathEnv(): PathEnv {
     home: homedir(),
     appData: process.env.APPDATA,
   }
+}
+
+export async function detectInstalled(fs: FileSystem, env: PathEnv): Promise<Set<ClientId>> {
+  const installed = new Set<ClientId>()
+  for (const client of CLIENTS) {
+    let path: string
+    try {
+      path = client.resolvePath(env)
+    } catch {
+      // Missing platform env (e.g., %APPDATA% on Windows) — treat as not installed.
+      continue
+    }
+    if (await fs.exists(path)) installed.add(client.id)
+  }
+  return installed
 }

--- a/src/init/validate.ts
+++ b/src/init/validate.ts
@@ -1,0 +1,34 @@
+import { CanvasApiError, CanvasHttpClient } from '../canvas/client'
+
+export interface ValidateResult {
+  ok: boolean
+  displayName?: string
+  status?: number
+  hint?: string
+}
+
+interface UsersSelfResponse {
+  id?: number
+  name?: string
+}
+
+const SOFT_FAIL_HINT = 'Canvas unreachable, continue anyway?'
+
+export async function pingUsersSelf(token: string, baseUrl: string): Promise<ValidateResult> {
+  const client = new CanvasHttpClient({ token, baseUrl })
+  try {
+    const user = await client.request<UsersSelfResponse>('/users/self')
+    return { ok: true, displayName: user?.name }
+  } catch (error) {
+    if (error instanceof CanvasApiError) {
+      if (error.status === 401) {
+        return { ok: false, status: 401, hint: 'Token is invalid or expired' }
+      }
+      if (error.status >= 500) {
+        return { ok: false, status: error.status, hint: SOFT_FAIL_HINT }
+      }
+      return { ok: false, status: error.status, hint: 'Unexpected error' }
+    }
+    return { ok: false, hint: SOFT_FAIL_HINT }
+  }
+}

--- a/src/init/wizard.ts
+++ b/src/init/wizard.ts
@@ -1,0 +1,256 @@
+import type { InitConfig } from './argv'
+import {
+  CLIENTS,
+  detectInstalled,
+  getClient,
+  type ClientDescriptor,
+  type ClientId,
+  type PathEnv,
+} from './clients'
+import type { McpEntry, WriteConfigOptions } from './config-writer'
+import type { FileSystem } from './io'
+import type { ValidateResult } from './validate'
+
+export interface WizardDeps {
+  fs: FileSystem
+  env: PathEnv
+  prompts: (question: unknown) => Promise<Record<string, unknown>>
+  pingUsersSelf: (token: string, baseUrl: string) => Promise<ValidateResult>
+  writeClientConfigs: (
+    fs: FileSystem,
+    targets: ClientDescriptor[],
+    entry: McpEntry,
+    opts?: WriteConfigOptions,
+  ) => Promise<void>
+  log: (message: string) => void
+}
+
+export interface WizardOptions {
+  initialConfig: InitConfig
+}
+
+export interface WizardResult {
+  exitCode: number
+  message?: string
+}
+
+const MAX_TOKEN_ATTEMPTS = 3
+
+export async function runWizard(deps: WizardDeps, opts: WizardOptions): Promise<WizardResult> {
+  const cfg = opts.initialConfig
+
+  // Step 1: base URL
+  const baseUrl = await resolveBaseUrl(deps, cfg)
+  if (!baseUrl.ok) return { exitCode: 2, message: baseUrl.message }
+
+  // Step 2: token + Step 3: validate (with retry on hard fail, soft-fail confirm).
+  const tokenStep = await resolveTokenAndValidate(deps, cfg, baseUrl.value)
+  if (!tokenStep.ok) return { exitCode: 2, message: tokenStep.message }
+
+  // Step 4: clients
+  const clientStep = await resolveClients(deps, cfg)
+  if (!clientStep.ok) return { exitCode: 2, message: clientStep.message }
+  const targets = clientStep.value
+
+  // Step 5: write
+  const entry = buildEntry(tokenStep.value, baseUrl.value, cfg.pin)
+  if (cfg.dryRun) {
+    deps.log('Dry-run: skipping config writes. Would have written:')
+    for (const target of targets) {
+      const path = target.resolvePath(deps.env)
+      deps.log(`  - ${target.name} -> ${path}`)
+    }
+    return { exitCode: 0 }
+  }
+
+  await deps.writeClientConfigs(deps.fs, targets, entry, {
+    serverName: cfg.serverName,
+    noBackup: cfg.noBackup,
+    pathEnv: deps.env,
+  })
+
+  // Step 6: summary
+  deps.log('')
+  deps.log('Done. Wrote canvas-lms entry to:')
+  for (const target of targets) {
+    deps.log(`  - ${target.name} (${target.resolvePath(deps.env)})`)
+  }
+  deps.log('Restart your MCP clients to pick up the new server.')
+  return { exitCode: 0 }
+}
+
+interface StepOk<T> {
+  ok: true
+  value: T
+}
+interface StepErr {
+  ok: false
+  message: string
+}
+
+function err(message: string): StepErr {
+  return { ok: false, message }
+}
+
+export function normalizeBaseUrl(input: string): string {
+  let url = input.trim().replace(/\/+$/, '')
+  if (!/\/api\/v\d+$/i.test(url)) {
+    url = `${url}/api/v1`
+  }
+  return url
+}
+
+async function resolveBaseUrl(
+  deps: WizardDeps,
+  cfg: InitConfig,
+): Promise<StepOk<string> | StepErr> {
+  if (cfg.baseUrl) return { ok: true, value: normalizeBaseUrl(cfg.baseUrl) }
+  if (cfg.nonInteractive) {
+    deps.log('Error: --base-url is required in non-interactive mode.')
+    return err('--base-url is required')
+  }
+
+  const ans = await deps.prompts({
+    type: 'text',
+    name: 'baseUrl',
+    message: 'Canvas base URL (e.g., https://school.instructure.com):',
+    validate: (v: string) => (isUrlLike(v) ? true : 'Enter an http(s):// URL'),
+  })
+  const raw = typeof ans.baseUrl === 'string' ? ans.baseUrl : ''
+  if (!raw) return err('Cancelled — no base URL provided.')
+  return { ok: true, value: normalizeBaseUrl(raw) }
+}
+
+function isUrlLike(value: string): boolean {
+  try {
+    const u = new URL(value)
+    return u.protocol === 'http:' || u.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+async function resolveTokenAndValidate(
+  deps: WizardDeps,
+  cfg: InitConfig,
+  baseUrl: string,
+): Promise<StepOk<string> | StepErr> {
+  let token = cfg.token
+
+  for (let attempt = 0; attempt < MAX_TOKEN_ATTEMPTS; attempt++) {
+    if (!token) {
+      if (cfg.nonInteractive) {
+        deps.log('Error: --token is required in non-interactive mode.')
+        return err('--token is required')
+      }
+      const ans = await deps.prompts({
+        type: 'password',
+        name: 'token',
+        message: attempt === 0 ? 'Canvas API token:' : 'Canvas API token (re-enter):',
+      })
+      token = typeof ans.token === 'string' ? ans.token : ''
+      if (!token) return err('Cancelled — no token provided.')
+    }
+
+    deps.log(`Validating token against ${baseUrl}/users/self ...`)
+    const result = await deps.pingUsersSelf(token, baseUrl)
+    if (result.ok) {
+      const who = result.displayName ?? 'unknown user'
+      deps.log(`  Authenticated as ${who}.`)
+      return { ok: true, value: token }
+    }
+
+    if (result.status !== undefined && result.status !== 401) {
+      // 5xx etc. — soft failure.
+      if (cfg.nonInteractive) {
+        deps.log(`Error: ${result.hint ?? 'validation failed'} (status ${result.status})`)
+        return err('validation failed')
+      }
+      const proceed = await confirmContinue(deps, result.hint ?? 'Canvas unreachable')
+      if (proceed) return { ok: true, value: token }
+      return err('Cancelled by user.')
+    }
+
+    if (result.status === undefined) {
+      // Network / unknown — soft failure.
+      if (cfg.nonInteractive) {
+        deps.log(`Error: ${result.hint ?? 'network failure'}`)
+        return err('network failure')
+      }
+      const proceed = await confirmContinue(deps, result.hint ?? 'Canvas unreachable')
+      if (proceed) return { ok: true, value: token }
+      return err('Cancelled by user.')
+    }
+
+    // 401 — hard failure, re-prompt.
+    deps.log(`  Token is invalid or expired${result.hint ? `: ${result.hint}` : ''}`)
+    if (cfg.nonInteractive) return err('token rejected by Canvas')
+    token = undefined
+  }
+
+  deps.log(`Error: token rejected ${MAX_TOKEN_ATTEMPTS} times. Aborting.`)
+  return err('too many failed token attempts')
+}
+
+async function confirmContinue(deps: WizardDeps, hint: string): Promise<boolean> {
+  const ans = await deps.prompts({
+    type: 'confirm',
+    name: 'proceed',
+    message: `${hint} Continue anyway?`,
+    initial: false,
+  })
+  return ans.proceed === true
+}
+
+async function resolveClients(
+  deps: WizardDeps,
+  cfg: InitConfig,
+): Promise<StepOk<ClientDescriptor[]> | StepErr> {
+  if (cfg.clients.length > 0) {
+    const targets = cfg.clients
+      .map((id) => getClient(id))
+      .filter((c): c is ClientDescriptor => c !== undefined)
+    return { ok: true, value: targets }
+  }
+
+  if (cfg.nonInteractive) {
+    deps.log('Error: --client is required in non-interactive mode.')
+    return err('--client is required')
+  }
+
+  const installed = await detectInstalled(deps.fs, deps.env)
+  const choices = CLIENTS.map((c) => ({
+    title: installed.has(c.id) ? `${c.name} (detected)` : c.name,
+    value: c.id,
+    selected: installed.has(c.id),
+  }))
+  const ans = await deps.prompts({
+    type: 'multiselect',
+    name: 'clients',
+    message: 'Which MCP clients do you want to configure?',
+    choices,
+    min: 1,
+    instructions: false,
+  })
+  const ids = Array.isArray(ans.clients) ? (ans.clients as ClientId[]) : []
+  if (ids.length === 0) {
+    deps.log('Error: no clients selected. Aborting.')
+    return err('no clients selected')
+  }
+  const targets = ids
+    .map((id) => getClient(id))
+    .filter((c): c is ClientDescriptor => c !== undefined)
+  return { ok: true, value: targets }
+}
+
+function buildEntry(token: string, baseUrl: string, pin: string | undefined): McpEntry {
+  const pkg = pin ? `canvas-lms-mcp@${pin}` : 'canvas-lms-mcp'
+  return {
+    command: 'npx',
+    args: ['-y', pkg],
+    env: {
+      CANVAS_API_TOKEN: token,
+      CANVAS_BASE_URL: baseUrl,
+    },
+  }
+}

--- a/tests/init/clients.test.ts
+++ b/tests/init/clients.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { CLIENTS, CLIENT_IDS, getClient, type PathEnv } from '../../src/init/clients'
+import {
+  CLIENTS,
+  CLIENT_IDS,
+  detectInstalled,
+  getClient,
+  type PathEnv,
+} from '../../src/init/clients'
+import { createMemoryFileSystem } from '../../src/init/io'
 
 const linuxEnv: PathEnv = { platform: 'linux', home: '/home/alice' }
 const macEnv: PathEnv = { platform: 'darwin', home: '/Users/alice' }
@@ -106,5 +113,42 @@ describe('clients path resolution — Windows', () => {
     const winNoAppData: PathEnv = { ...winEnv, appData: undefined }
     expect(() => getClient('cursor')!.resolvePath(winNoAppData)).not.toThrow()
     expect(() => getClient('claude-code')!.resolvePath(winNoAppData)).not.toThrow()
+  })
+})
+
+describe('detectInstalled', () => {
+  it('returns an empty set when no client config files exist', async () => {
+    const fs = createMemoryFileSystem()
+    const installed = await detectInstalled(fs, linuxEnv)
+    expect(installed.size).toBe(0)
+  })
+
+  it('flags a client as installed when its config file exists', async () => {
+    const cursor = getClient('cursor')!
+    const fs = createMemoryFileSystem({
+      [cursor.resolvePath(linuxEnv)]: '{}',
+    })
+    const installed = await detectInstalled(fs, linuxEnv)
+    expect(installed.has('cursor')).toBe(true)
+    expect(installed.has('vscode')).toBe(false)
+  })
+
+  it('skips a Windows client gracefully when APPDATA is unset', async () => {
+    const winNoAppData: PathEnv = { ...winEnv, appData: undefined }
+    const fs = createMemoryFileSystem()
+    const installed = await detectInstalled(fs, winNoAppData)
+    expect(installed.has('claude-desktop')).toBe(false)
+    expect(installed.has('vscode')).toBe(false)
+  })
+
+  it('detects multiple installed clients at once', async () => {
+    const cursor = getClient('cursor')!
+    const vscode = getClient('vscode')!
+    const fs = createMemoryFileSystem({
+      [cursor.resolvePath(linuxEnv)]: '{}',
+      [vscode.resolvePath(linuxEnv)]: '{}',
+    })
+    const installed = await detectInstalled(fs, linuxEnv)
+    expect([...installed].sort()).toEqual(['cursor', 'vscode'])
   })
 })

--- a/tests/init/validate.test.ts
+++ b/tests/init/validate.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { pingUsersSelf } from '../../src/init/validate'
+
+const ORIGINAL_FETCH = globalThis.fetch
+
+describe('pingUsersSelf', () => {
+  beforeEach(() => {
+    // Each test installs its own fetch stub via mockFetch().
+  })
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH
+    vi.restoreAllMocks()
+  })
+
+  const mockFetch = (impl: (url: string, init?: RequestInit) => Promise<Response>) => {
+    globalThis.fetch = vi.fn(impl) as unknown as typeof fetch
+  }
+
+  it('returns ok with displayName when Canvas responds 200', async () => {
+    mockFetch(
+      async () =>
+        new Response(JSON.stringify({ id: 1, name: 'Jane Smith' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    )
+
+    const result = await pingUsersSelf('valid-token', 'https://school.instructure.com/api/v1')
+
+    expect(result.ok).toBe(true)
+    expect(result.displayName).toBe('Jane Smith')
+  })
+
+  it('strips trailing slashes from baseUrl before requesting', async () => {
+    let calledUrl = ''
+    mockFetch(async (url) => {
+      calledUrl = url
+      return new Response(JSON.stringify({ name: 'X' }), { status: 200 })
+    })
+
+    await pingUsersSelf('t', 'https://school.instructure.com/api/v1/')
+
+    expect(calledUrl).toBe('https://school.instructure.com/api/v1/users/self')
+  })
+
+  it('sends the token as a Bearer authorization header', async () => {
+    let authHeader: string | null = null
+    mockFetch(async (_url, init) => {
+      const headers = new Headers(init?.headers)
+      authHeader = headers.get('Authorization')
+      return new Response(JSON.stringify({ name: 'X' }), { status: 200 })
+    })
+
+    await pingUsersSelf('s3cret', 'https://school.instructure.com/api/v1')
+
+    expect(authHeader).toBe('Bearer s3cret')
+  })
+
+  it('returns ok=false with 401 and an "invalid or expired" hint on 401', async () => {
+    mockFetch(
+      async () =>
+        new Response(JSON.stringify({ errors: [{ message: 'Invalid access token' }] }), {
+          status: 401,
+        }),
+    )
+
+    const result = await pingUsersSelf('bad', 'https://school.instructure.com/api/v1')
+
+    expect(result.ok).toBe(false)
+    expect(result.status).toBe(401)
+    expect(result.hint).toMatch(/invalid or expired/i)
+  })
+
+  it('treats 5xx as a soft failure with a "continue anyway?" hint', async () => {
+    mockFetch(async () => new Response('{}', { status: 503 }))
+
+    const result = await pingUsersSelf('t', 'https://school.instructure.com/api/v1')
+
+    expect(result.ok).toBe(false)
+    expect(result.status).toBe(503)
+    expect(result.hint).toMatch(/canvas unreachable.*continue anyway/i)
+  })
+
+  it('treats network/fetch failures as a soft failure with "continue anyway?"', async () => {
+    mockFetch(async () => {
+      throw new TypeError('fetch failed')
+    })
+
+    const result = await pingUsersSelf('t', 'https://school.instructure.com/api/v1')
+
+    expect(result.ok).toBe(false)
+    expect(result.status).toBeUndefined()
+    expect(result.hint).toMatch(/canvas unreachable.*continue anyway/i)
+  })
+
+  it('returns ok=false with status and "Unexpected error" for other non-2xx codes', async () => {
+    mockFetch(async () => new Response('{}', { status: 403 }))
+
+    const result = await pingUsersSelf('t', 'https://school.instructure.com/api/v1')
+
+    expect(result.ok).toBe(false)
+    expect(result.status).toBe(403)
+    expect(result.hint).toMatch(/unexpected/i)
+  })
+
+  it('returns ok=true even when Canvas omits a name field', async () => {
+    mockFetch(async () => new Response(JSON.stringify({ id: 1 }), { status: 200 }))
+
+    const result = await pingUsersSelf('t', 'https://school.instructure.com/api/v1')
+
+    expect(result.ok).toBe(true)
+    expect(result.displayName).toBeUndefined()
+  })
+})

--- a/tests/init/wizard.test.ts
+++ b/tests/init/wizard.test.ts
@@ -1,0 +1,479 @@
+import { describe, expect, it } from 'vitest'
+import { runWizard, type WizardDeps } from '../../src/init/wizard'
+import type { InitConfig } from '../../src/init/argv'
+import { createMemoryFileSystem } from '../../src/init/io'
+import { CLIENTS, type ClientId, type PathEnv } from '../../src/init/clients'
+import type { McpEntry, WriteConfigOptions } from '../../src/init/config-writer'
+import type { ClientDescriptor } from '../../src/init/clients'
+import type { ValidateResult } from '../../src/init/validate'
+
+const linuxEnv: PathEnv = { platform: 'linux', home: '/home/alice' }
+
+interface PromptCall {
+  question: unknown
+  response: Record<string, unknown>
+}
+
+function scriptedPrompts(responses: Array<Record<string, unknown>>) {
+  const calls: PromptCall[] = []
+  const fn = async (question: unknown): Promise<Record<string, unknown>> => {
+    const response = responses.shift()
+    if (!response) throw new Error('scriptedPrompts: no scripted response left')
+    calls.push({ question, response })
+    return response
+  }
+  return { fn, calls, remaining: () => responses.length }
+}
+
+function baseConfig(overrides: Partial<InitConfig> = {}): InitConfig {
+  return {
+    clients: [],
+    token: undefined,
+    baseUrl: undefined,
+    serverName: 'canvas-lms',
+    pin: undefined,
+    nonInteractive: false,
+    dryRun: false,
+    noBackup: false,
+    showHelp: false,
+    ...overrides,
+  }
+}
+
+interface WriterCall {
+  targets: ClientDescriptor[]
+  entry: McpEntry
+  opts: WriteConfigOptions
+}
+
+function recordingWriter() {
+  const calls: WriterCall[] = []
+  const fn = async (
+    _fs: unknown,
+    targets: ClientDescriptor[],
+    entry: McpEntry,
+    opts: WriteConfigOptions = {},
+  ): Promise<void> => {
+    calls.push({ targets, entry, opts })
+  }
+  return { fn, calls }
+}
+
+function makeDeps(overrides: Partial<WizardDeps> = {}): WizardDeps {
+  return {
+    fs: createMemoryFileSystem(),
+    env: linuxEnv,
+    prompts: async () => ({}),
+    pingUsersSelf: async (): Promise<ValidateResult> => ({ ok: true, displayName: 'Jane Smith' }),
+    writeClientConfigs: async () => undefined,
+    log: () => undefined,
+    ...overrides,
+  }
+}
+
+describe('runWizard — interactive flow', () => {
+  it('runs the happy path: prompts for url, token, clients; writes; exits 0', async () => {
+    const prompts = scriptedPrompts([
+      { baseUrl: 'https://school.instructure.com' },
+      { token: 's3cret' },
+      { clients: ['cursor', 'claude-desktop'] },
+    ])
+    const writer = recordingWriter()
+    const logs: string[] = []
+
+    const result = await runWizard(
+      makeDeps({
+        prompts: prompts.fn,
+        writeClientConfigs: writer.fn,
+        log: (m) => logs.push(m),
+      }),
+      { initialConfig: baseConfig() },
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(writer.calls).toHaveLength(1)
+    expect(writer.calls[0].targets.map((c) => c.id).sort()).toEqual(['claude-desktop', 'cursor'])
+    expect(writer.calls[0].entry).toEqual({
+      command: 'npx',
+      args: ['-y', 'canvas-lms-mcp'],
+      env: {
+        CANVAS_API_TOKEN: 's3cret',
+        CANVAS_BASE_URL: 'https://school.instructure.com/api/v1',
+      },
+    })
+    expect(prompts.remaining()).toBe(0)
+    expect(logs.some((l) => /Authenticated as Jane Smith/.test(l))).toBe(true)
+  })
+
+  it('normalizes the base URL — strips trailing slash and appends /api/v1', async () => {
+    const prompts = scriptedPrompts([
+      { baseUrl: 'https://school.instructure.com/' },
+      { token: 't' },
+      { clients: ['cursor'] },
+    ])
+    const writer = recordingWriter()
+
+    await runWizard(makeDeps({ prompts: prompts.fn, writeClientConfigs: writer.fn }), {
+      initialConfig: baseConfig(),
+    })
+
+    expect(writer.calls[0].entry.env.CANVAS_BASE_URL).toBe('https://school.instructure.com/api/v1')
+  })
+
+  it('does not double-append /api/v1 when the user already typed it', async () => {
+    const prompts = scriptedPrompts([
+      { baseUrl: 'https://school.instructure.com/api/v1' },
+      { token: 't' },
+      { clients: ['cursor'] },
+    ])
+    const writer = recordingWriter()
+
+    await runWizard(makeDeps({ prompts: prompts.fn, writeClientConfigs: writer.fn }), {
+      initialConfig: baseConfig(),
+    })
+
+    expect(writer.calls[0].entry.env.CANVAS_BASE_URL).toBe('https://school.instructure.com/api/v1')
+  })
+
+  it('skips the URL prompt when --base-url was supplied', async () => {
+    const prompts = scriptedPrompts([{ token: 't' }, { clients: ['cursor'] }])
+    const writer = recordingWriter()
+
+    await runWizard(makeDeps({ prompts: prompts.fn, writeClientConfigs: writer.fn }), {
+      initialConfig: baseConfig({
+        baseUrl: 'https://school.instructure.com',
+      }),
+    })
+
+    expect(prompts.remaining()).toBe(0)
+    expect(writer.calls[0].entry.env.CANVAS_BASE_URL).toBe('https://school.instructure.com/api/v1')
+  })
+
+  it('re-prompts the token on a 401 hard failure', async () => {
+    const prompts = scriptedPrompts([
+      { baseUrl: 'https://school.instructure.com' },
+      { token: 'bad' },
+      { token: 'good' },
+      { clients: ['cursor'] },
+    ])
+    let attempt = 0
+    const ping = async (): Promise<ValidateResult> => {
+      attempt++
+      if (attempt === 1) return { ok: false, status: 401, hint: 'Token is invalid or expired' }
+      return { ok: true, displayName: 'Jane' }
+    }
+    const writer = recordingWriter()
+    const logs: string[] = []
+
+    const result = await runWizard(
+      makeDeps({
+        prompts: prompts.fn,
+        pingUsersSelf: ping,
+        writeClientConfigs: writer.fn,
+        log: (m) => logs.push(m),
+      }),
+      { initialConfig: baseConfig() },
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(attempt).toBe(2)
+    expect(writer.calls[0].entry.env.CANVAS_API_TOKEN).toBe('good')
+    expect(logs.some((l) => /invalid or expired/i.test(l))).toBe(true)
+  })
+
+  it('aborts after too many failed token attempts', async () => {
+    const prompts = scriptedPrompts([
+      { baseUrl: 'https://school.instructure.com' },
+      { token: 'bad1' },
+      { token: 'bad2' },
+      { token: 'bad3' },
+    ])
+    const ping = async (): Promise<ValidateResult> => ({
+      ok: false,
+      status: 401,
+      hint: 'Token is invalid or expired',
+    })
+    const writer = recordingWriter()
+
+    const result = await runWizard(
+      makeDeps({ prompts: prompts.fn, pingUsersSelf: ping, writeClientConfigs: writer.fn }),
+      { initialConfig: baseConfig() },
+    )
+
+    expect(result.exitCode).not.toBe(0)
+    expect(writer.calls).toHaveLength(0)
+  })
+
+  it('asks "continue anyway?" on soft failure and proceeds when confirmed', async () => {
+    const prompts = scriptedPrompts([
+      { baseUrl: 'https://school.instructure.com' },
+      { token: 't' },
+      { proceed: true },
+      { clients: ['cursor'] },
+    ])
+    const ping = async (): Promise<ValidateResult> => ({
+      ok: false,
+      hint: 'Canvas unreachable, continue anyway?',
+    })
+    const writer = recordingWriter()
+
+    const result = await runWizard(
+      makeDeps({ prompts: prompts.fn, pingUsersSelf: ping, writeClientConfigs: writer.fn }),
+      { initialConfig: baseConfig() },
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(writer.calls).toHaveLength(1)
+  })
+
+  it('aborts on soft failure when the user declines to continue', async () => {
+    const prompts = scriptedPrompts([
+      { baseUrl: 'https://school.instructure.com' },
+      { token: 't' },
+      { proceed: false },
+    ])
+    const ping = async (): Promise<ValidateResult> => ({
+      ok: false,
+      hint: 'Canvas unreachable, continue anyway?',
+    })
+    const writer = recordingWriter()
+
+    const result = await runWizard(
+      makeDeps({ prompts: prompts.fn, pingUsersSelf: ping, writeClientConfigs: writer.fn }),
+      { initialConfig: baseConfig() },
+    )
+
+    expect(result.exitCode).not.toBe(0)
+    expect(writer.calls).toHaveLength(0)
+  })
+
+  it('uses --client values from argv and skips the client multi-select', async () => {
+    const prompts = scriptedPrompts([{ baseUrl: 'https://school.instructure.com' }, { token: 't' }])
+    const writer = recordingWriter()
+
+    await runWizard(makeDeps({ prompts: prompts.fn, writeClientConfigs: writer.fn }), {
+      initialConfig: baseConfig({ clients: ['claude-desktop' satisfies ClientId] }),
+    })
+
+    expect(prompts.remaining()).toBe(0)
+    expect(writer.calls[0].targets.map((c) => c.id)).toEqual(['claude-desktop'])
+  })
+
+  it('aborts with a clear error when the user picks zero clients', async () => {
+    const prompts = scriptedPrompts([
+      { baseUrl: 'https://school.instructure.com' },
+      { token: 't' },
+      { clients: [] },
+    ])
+    const writer = recordingWriter()
+
+    const result = await runWizard(
+      makeDeps({ prompts: prompts.fn, writeClientConfigs: writer.fn }),
+      { initialConfig: baseConfig() },
+    )
+
+    expect(result.exitCode).not.toBe(0)
+    expect(writer.calls).toHaveLength(0)
+  })
+
+  it('passes serverName and noBackup through to the writer', async () => {
+    const prompts = scriptedPrompts([
+      { baseUrl: 'https://school.instructure.com' },
+      { token: 't' },
+      { clients: ['cursor'] },
+    ])
+    const writer = recordingWriter()
+
+    await runWizard(makeDeps({ prompts: prompts.fn, writeClientConfigs: writer.fn }), {
+      initialConfig: baseConfig({ serverName: 'my-canvas', noBackup: true }),
+    })
+
+    expect(writer.calls[0].opts.serverName).toBe('my-canvas')
+    expect(writer.calls[0].opts.noBackup).toBe(true)
+  })
+
+  it('builds args with the pinned semver when --pin is set', async () => {
+    const prompts = scriptedPrompts([
+      { baseUrl: 'https://school.instructure.com' },
+      { token: 't' },
+      { clients: ['cursor'] },
+    ])
+    const writer = recordingWriter()
+
+    await runWizard(makeDeps({ prompts: prompts.fn, writeClientConfigs: writer.fn }), {
+      initialConfig: baseConfig({ pin: '1.15.6' }),
+    })
+
+    expect(writer.calls[0].entry.args).toEqual(['-y', 'canvas-lms-mcp@1.15.6'])
+  })
+
+  it('skips the writer in --dry-run but reports what would have happened', async () => {
+    const prompts = scriptedPrompts([
+      { baseUrl: 'https://school.instructure.com' },
+      { token: 't' },
+      { clients: ['cursor'] },
+    ])
+    const writer = recordingWriter()
+    const logs: string[] = []
+
+    const result = await runWizard(
+      makeDeps({
+        prompts: prompts.fn,
+        writeClientConfigs: writer.fn,
+        log: (m) => logs.push(m),
+      }),
+      { initialConfig: baseConfig({ dryRun: true }) },
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(writer.calls).toHaveLength(0)
+    expect(logs.some((l) => /dry[- ]run/i.test(l))).toBe(true)
+  })
+})
+
+describe('runWizard — non-interactive flow', () => {
+  it('writes without any prompts when all required flags are supplied', async () => {
+    const prompts = scriptedPrompts([])
+    const writer = recordingWriter()
+
+    const result = await runWizard(
+      makeDeps({ prompts: prompts.fn, writeClientConfigs: writer.fn }),
+      {
+        initialConfig: baseConfig({
+          nonInteractive: true,
+          baseUrl: 'https://school.instructure.com',
+          token: 'tok',
+          clients: ['claude-desktop' satisfies ClientId],
+        }),
+      },
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(prompts.calls).toHaveLength(0)
+    expect(writer.calls).toHaveLength(1)
+    expect(writer.calls[0].entry.env.CANVAS_API_TOKEN).toBe('tok')
+  })
+
+  it('errors out if the base URL is missing in non-interactive mode', async () => {
+    const prompts = scriptedPrompts([])
+    const writer = recordingWriter()
+
+    const result = await runWizard(
+      makeDeps({ prompts: prompts.fn, writeClientConfigs: writer.fn }),
+      {
+        initialConfig: baseConfig({
+          nonInteractive: true,
+          token: 'tok',
+          clients: ['cursor'],
+        }),
+      },
+    )
+
+    expect(result.exitCode).not.toBe(0)
+    expect(prompts.calls).toHaveLength(0)
+    expect(writer.calls).toHaveLength(0)
+  })
+
+  it('errors out if the token is missing in non-interactive mode', async () => {
+    const prompts = scriptedPrompts([])
+    const writer = recordingWriter()
+
+    const result = await runWizard(
+      makeDeps({ prompts: prompts.fn, writeClientConfigs: writer.fn }),
+      {
+        initialConfig: baseConfig({
+          nonInteractive: true,
+          baseUrl: 'https://school.instructure.com',
+          clients: ['cursor'],
+        }),
+      },
+    )
+
+    expect(result.exitCode).not.toBe(0)
+    expect(writer.calls).toHaveLength(0)
+  })
+
+  it('errors out if no clients are supplied in non-interactive mode', async () => {
+    const prompts = scriptedPrompts([])
+    const writer = recordingWriter()
+
+    const result = await runWizard(
+      makeDeps({ prompts: prompts.fn, writeClientConfigs: writer.fn }),
+      {
+        initialConfig: baseConfig({
+          nonInteractive: true,
+          baseUrl: 'https://school.instructure.com',
+          token: 'tok',
+        }),
+      },
+    )
+
+    expect(result.exitCode).not.toBe(0)
+    expect(writer.calls).toHaveLength(0)
+  })
+
+  it('still validates the token in non-interactive mode and errors on 401', async () => {
+    const prompts = scriptedPrompts([])
+    const writer = recordingWriter()
+
+    const result = await runWizard(
+      makeDeps({
+        prompts: prompts.fn,
+        pingUsersSelf: async () => ({ ok: false, status: 401, hint: 'invalid' }),
+        writeClientConfigs: writer.fn,
+      }),
+      {
+        initialConfig: baseConfig({
+          nonInteractive: true,
+          baseUrl: 'https://school.instructure.com',
+          token: 'bad',
+          clients: ['cursor'],
+        }),
+      },
+    )
+
+    expect(result.exitCode).not.toBe(0)
+    expect(writer.calls).toHaveLength(0)
+  })
+})
+
+describe('runWizard — output', () => {
+  it('uses ASCII-friendly summary output (no emoji)', async () => {
+    const prompts = scriptedPrompts([
+      { baseUrl: 'https://school.instructure.com' },
+      { token: 't' },
+      { clients: ['cursor'] },
+    ])
+    const writer = recordingWriter()
+    const logs: string[] = []
+
+    await runWizard(
+      makeDeps({
+        prompts: prompts.fn,
+        writeClientConfigs: writer.fn,
+        log: (m) => logs.push(m),
+      }),
+      { initialConfig: baseConfig() },
+    )
+
+    const all = logs.join('\n')
+    // eslint-disable-next-line no-control-regex
+    expect(all).toMatch(/^[\x00-\x7F\n]*$/)
+  })
+
+  it('mentions the cursor client by name in the summary', async () => {
+    const prompts = scriptedPrompts([
+      { baseUrl: 'https://school.instructure.com' },
+      { token: 't' },
+      { clients: ['cursor'] },
+    ])
+    const cursor = CLIENTS.find((c) => c.id === 'cursor')!
+    const logs: string[] = []
+
+    await runWizard(makeDeps({ prompts: prompts.fn, log: (m) => logs.push(m) }), {
+      initialConfig: baseConfig(),
+    })
+
+    expect(logs.some((l) => l.includes(cursor.name))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Task B from the [init wizard MVP design](https://github.com/bruchris/canvas-lms-mcp/blob/main/docs/superpowers/specs/2026-05-22-init-wizard-decision.md). Wires the wizard end-to-end so `npx canvas-lms-mcp init` actually works.

Builds on top of #147 (Task A — config writers, now merged). The diff in this PR is Task B only.

## Changes

- **`src/init/validate.ts`** — `pingUsersSelf(token, baseUrl)` reuses `CanvasHttpClient`. Maps responses:
  - `200` -> `{ok: true, displayName}`
  - `401` -> `{ok: false, status: 401, hint: 'Token is invalid or expired'}` (hard fail)
  - `5xx` / network error -> `{ok: false, hint: 'Canvas unreachable, continue anyway?'}` (soft fail per design)
  - other status -> `{ok: false, status, hint: 'Unexpected error'}`
- **`src/init/wizard.ts`** — interactive orchestration. Base URL normalized (trailing-slash strip + `/api/v1` append, no double-append). Masked token, re-prompted up to 3 times on 401. Soft-fail "continue anyway?" confirmation. Multi-select with `detectInstalled` pre-checks. Honors `--non-interactive`, `--dry-run`, `--no-backup`, `--server-name`, `--pin`, `--client`. All deps injected so tests don't depend on `prompts` runtime or network.
- **`src/init/clients.ts`** — adds `detectInstalled(fs, env): Set<ClientId>`.
- **`src/init.ts`** — wires real `prompts`, `nodeFileSystem`, and live network into the wizard; exits with the wizard's exit code.
- **deps**: `prompts` (runtime) + `@types/prompts` (dev).

## Behaviour matrix

| Scenario | Result |
|---|---|
| `--help` | Prints help, exits 0 |
| `--non-interactive` with all flags | Skips prompts, validates, writes, exits 0 |
| `--non-interactive` missing `--base-url`/`--token`/`--client` | Prints clear error, exits 2 |
| Interactive, 401 token | Re-prompts up to 3 times, then aborts |
| Interactive, 5xx Canvas | "Continue anyway?" confirm |
| `--dry-run` | Runs wizard, skips writer, lists what would have been written |
| `--pin 1.15.6` | Writer entry args = `["-y", "canvas-lms-mcp@1.15.6"]` |

## Coverage

- `validate.ts`: **100%** statements/branches/functions/lines (target ≥90%)
- `wizard.ts`: **85%** statements, **86%** lines (target ≥80%)
- 20 wizard tests + 8 validate tests + 4 detectInstalled tests added. Full suite: **761 passing**.

## Validation

```
pnpm typecheck  # clean
pnpm test       # 761 passed
pnpm lint       # clean
pnpm build      # success
```

Smoke-tested:
- `pnpm exec tsx src/init.ts --help` — prints help
- `pnpm exec tsx src/init.ts --non-interactive` — clear error, exit 2
- `pnpm exec tsx src/init.ts --non-interactive --base-url http://127.0.0.1:1 --token fake --client cursor --dry-run` — validates, soft-fails on unreachable Canvas, aborts

## Test plan

- [ ] CI green
- [ ] Reviewer verifies wizard tests cover the prompted flow without depending on `prompts` runtime behaviour
- [ ] Reviewer verifies `validate.ts` error mapping matches the spec (401 hard / 5xx + network soft / other "Unexpected error")
- [ ] Reviewer verifies `--dry-run` skips writes but reports what would have been written
- [ ] Reviewer verifies base URL normalization handles `https://x/`, `https://x`, and `https://x/api/v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)