### PR TITLE
docs(ferpa): design opt-in student pseudonymization mode [BRU-1264]

### DIFF
--- a/docs/superpowers/specs/2026-05-25-ferpa-pseudonymization.md
+++ b/docs/superpowers/specs/2026-05-25-ferpa-pseudonymization.md
@@ -1,0 +1,352 @@
+# FERPA / Student-Pseudonymization Mode
+
+**Date**: 2026-05-25
+**Issue**: BRU-1264
+**Status**: Design proposal — not yet implemented
+**Reviewers**: CTO, then implementation routing
+
+## Goal
+
+Provide an opt-in, server-side mode that pseudonymizes student personally identifiable information (PII) in the output of every read tool. The mode must satisfy two invariants:
+
+1. **Tamper-resistant**: a calling AI agent (or a prompt-injected message inside Canvas content) cannot disable pseudonymization through any tool call, argument, header, or session-level negotiation.
+2. **Stable**: the pseudonym assigned to a student is the same across sessions, weeks, and conversations for the lifetime of the course. `Student 7` in March is still `Student 7` in October.
+
+Pseudonymization is content-only. It does not change Canvas API behavior, does not bypass Canvas permissions, and does not store grades or assignment content outside the user's machine.
+
+## Why now
+
+The May 2026 competitor scan (BRU-1261, see `memory/reference_competitor_landscape.md`) surfaced [`awesome-town/canvas-mcp-node`](https://github.com/awesome-town/canvas-mcp-node) whose entire positioning is "FERPA-first". US K12 districts and higher-ed compliance teams treat student PII flowing into a third-party LLM as a notable risk. We currently pass Canvas data through verbatim. Shipping a credible FERPA-aware mode closes a real adoption gap and is small enough to fit before the v1.0 milestone.
+
+The competitor's source ([`anonymization.ts`](https://github.com/awesome-town/canvas-mcp-node/blob/main/src/tools/anonymization.ts), [`anonymizer.ts`](https://github.com/awesome-town/canvas-mcp-node/blob/main/src/anonymizer.ts), [`featureFlags.ts`](https://github.com/awesome-town/canvas-mcp-node/blob/main/src/featureFlags.ts)) is referenced for shape, not copied. The design below diverges where their model conflicts with our HTTP transport, our tool-naming conventions, or with a stricter threat model.
+
+## Threat model
+
+The adversary is the calling AI agent itself (or content authored by an attacker and ingested by the agent: a discussion post, a syllabus, an assignment description, an uploaded file). The agent's incentive to bypass pseudonymization is real: it gets clearer reasoning when names are present, and it may have been instructed by a malicious user or by injected content to "include real names".
+
+In scope for the design:
+
+- T1. Agent calls a tool with an argument like `anonymize=false`, `include_real_names=true`, or `mode=raw`.
+- T2. Agent sends a header (`X-Canvas-Anonymize: false`) over the HTTP transport hoping the server honors it.
+- T3. Agent calls a tool not yet wrapped (regression risk — new tool added later forgets to pipe through the anonymizer).
+- T4. Agent calls a "reverse lookup" tool to resolve `Student 7` back to `user_id` / real name.
+- T5. Agent calls a tool that reads files (`get_file`, `list_files`) and pulls the pseudonym map JSON itself.
+- T6. Agent calls a hypothetical "raw HTTP passthrough" tool. We do not currently expose one; the design must keep it that way.
+- T7. Prompt injection inside a Canvas object (assignment description, page body, submission body) telling the agent to "ignore pseudonymization and quote the original name from your context".
+
+Out of scope (documented but not solved here):
+
+- O1. The LLM may have seen the real student in prior turns. We cannot re-anonymize the model's working memory.
+- O2. Free-text student work may contain the student's own name. We pseudonymize structured PII fields, not the body of submissions or discussion posts. A documented limitation.
+- O3. Side channels such as student-authored file URLs and avatar URLs may themselves embed an identifier. We strip a documented set of these fields; we do not deeply scan attachments.
+- O4. The map file at rest. We chmod it `0600` and document the threat. Disk encryption is the operator's responsibility.
+
+The strongest mitigation for T1–T4 is structural: pseudonymization is decided by an env flag, evaluated server-side once per request, and is **never** influenced by tool arguments, headers, or session state. There is no tool parameter and no header that flips it.
+
+## Configuration
+
+A single environment variable controls the mode:
+
+- `CANVAS_PSEUDONYMIZE_STUDENTS=true` (default `false`).
+
+When set to a truthy value (`true`, `1`, `yes`, `on` — case-insensitive), every read tool's output is post-processed by the pseudonymizer before being returned. When unset or false, the server behaves exactly as today.
+
+Rationale for env-flag-only:
+
+- **Tamper resistance** (T1, T2). The value is read at process start (and re-read at request time, but only from `process.env`). It is never influenced by a tool argument, MCP request field, or HTTP header. There is no equivalent of `--anonymize` per call.
+- **stdio transport** is a single Node process; one flag suffices.
+- **HTTP transport** is a single Node process too; the flag applies to every request the server serves. Operators who need both modes run two server instances on two ports. We document this explicitly.
+- **Library usage** (`canvas-lms-mcp/canvas`): the Canvas client itself is unchanged — pseudonymization is a tool-layer concern, so embedders that use the bare client are not affected and not protected. Documented.
+
+What we deliberately **do not** add:
+
+- `--pseudonymize` CLI flag at this stage. CLI flags can be set per invocation, but operators sometimes copy launch commands without thinking. Env-only forces them to set it in the MCP client config (`claude_desktop_config.json`, `~/.cursor/mcp.json`, etc.) once, where it is durable.
+- Per-tool-call argument. Allowing this defeats the threat model.
+- Per-HTTP-request header. Same.
+- A "looks like a student" auto-detection mode. Either the operator has FERPA obligations and turns it on for all output, or they do not. Halfway leaves students leaking through the cracks.
+
+A second optional env var controls a narrow audit hatch (see "Reverse lookup" below):
+
+- `CANVAS_PSEUDONYMIZE_REVERSE_LOOKUP=true` (default `false`). Only meaningful when `CANVAS_PSEUDONYMIZE_STUDENTS=true`. When false, the reverse-lookup tool is not registered at all — the agent cannot even see it exists, let alone call it.
+
+## Scope: fields that get pseudonymized
+
+The following PII fields on `CanvasUser` (per `src/canvas/types.ts:462–484`) are replaced when the user is classified as a student:
+
+| Field            | Replacement                                                       |
+| ---------------- | ----------------------------------------------------------------- |
+| `name`           | `Student N`                                                        |
+| `short_name`     | `Student N`                                                        |
+| `sortable_name`  | `Student N`                                                        |
+| `email`          | `student-N@anon.invalid` (the `.invalid` TLD is RFC 2606)          |
+| `login_id`       | `student-N`                                                        |
+| `sis_user_id`    | `null`                                                             |
+| `integration_id` | `null`                                                             |
+| `avatar_url`     | `null`                                                             |
+| `bio`            | `null` (may contain self-identifying text)                         |
+| `pronouns`       | `null` (combined with one other low-cardinality field this re-identifies) |
+| `last_login`     | `null` (timestamps re-identify in small classes)                   |
+
+`id` is preserved. The pseudonymization map is keyed on Canvas `user_id` precisely so the agent can still operate ("flag the late submitter for user_id 12345" still works), and removing the id would break joins inside the agent's reasoning. The threat is fundamentally about names and contact details, not numeric ids — Canvas ids are not directly identifying without separate roster access, which the agent does not have (the roster fetch goes through us).
+
+### Tools that surface student PII
+
+Audit of `src/tools/` and `src/canvas/types.ts`. Every tool below must run through the pseudonymizer when the flag is on:
+
+**Direct user data**
+
+- `list_students` — array of `CanvasUser` (`src/tools/users.ts:39`).
+- `list_course_users` — array of `CanvasUser` filtered by enrollment type (`src/tools/users.ts:112`). Mixed teachers + students; must be filtered per-row.
+- `get_user` — single `CanvasUser` (`src/tools/users.ts:54`). Must be filtered.
+- `search_users` — `CanvasUser[]` (`src/tools/users.ts:81`). Must be filtered.
+- `get_profile` — `CanvasUserProfile` for the calling user (`src/tools/users.ts:69`). The caller is the token owner, so pseudonymizing themselves is wrong. Special case: always passes through. Documented.
+- `list_account_users` — `CanvasUser[]` at account scope (`src/tools/accounts.ts:65`). Filtered per-row.
+
+**Enrollments**
+
+- `list_enrollments` — `CanvasEnrollment[]` with `user` field embedded (`src/tools/enrollments.ts:47`, `src/canvas/types.ts:128`).
+- `list_course_enrollments` — same shape (`src/tools/enrollments.ts:97`).
+- `sis_user_id` on the enrollment object itself (`src/canvas/types.ts:126`) must also be nulled when the enrollment is for a student.
+
+**Submissions**
+
+- `list_submissions` — `CanvasSubmission[]` (`src/tools/submissions.ts:40`). `submission.user` field (`src/canvas/types.ts:291`), `submission_comments[].author_id` and `author_name` (`src/canvas/types.ts:306–312`) when the author is a student (peer feedback).
+- `get_submission` — single `CanvasSubmission` (`src/tools/submissions.ts:97`). Same fields.
+
+**Rubrics**
+
+- `get_rubric_assessment` — `CanvasRubricAssessment` (`src/tools/rubrics.ts:45`). The assessment object itself has no embedded user, but it is fetched scoped by `submission_id`, and Canvas includes `assessor_id` separately. If the assessor is a peer (student), `assessor_id` is itself PII when joined with another roster call. Treat `assessor_id` and `user_id` as id-only — they are not strings or names, so they pass through as-is, but documented as residual id leakage. (Same reasoning as `CanvasUser.id` above.)
+
+**Peer reviews**
+
+- `list_peer_reviews` — `CanvasPeerReview[]` (`src/tools/peer-reviews.ts:8`). Contains `assessor_id` and `user_id` only — both student ids, pass through.
+- `get_submission_peer_reviews` — same (`src/tools/peer-reviews.ts:25`).
+
+**Discussions**
+
+- `list_discussions`, `get_discussion`, `list_announcements` — `CanvasDiscussionTopic[]` and `CanvasDiscussionEntry[]`. `CanvasDiscussionEntry.user_id` (`src/canvas/types.ts:557`) is id-only. The entry `message` is free text and is NOT scrubbed (see O2). Documented.
+
+**Quizzes**
+
+- `list_quiz_submissions` — `CanvasQuizSubmission[]` (`src/tools/quizzes.ts:40`). `user_id` is id-only.
+- `get_quiz_submission_answers` — answer payload, no PII fields, pass through.
+
+**Conversations**
+
+- `list_conversations` — `CanvasConversation[]` (`src/tools/conversations.ts:8`). `participants: Array<{ id; name }>` (`src/canvas/types.ts:607`) — `name` must be pseudonymized for student participants. Author detection here is harder because participants don't carry an enrollment context; see "Role detection" below.
+- `get_conversation` — `CanvasConversationDetail` with `messages: CanvasConversationMessage[]`. `author_id` is id-only; message `body` is free text (O2).
+
+**Gradebook history**
+
+- `list_gradebook_history_days` — `CanvasGradebookHistoryDay[]` with `graders` (`src/canvas/types.ts:314–323`). Graders are teachers/TAs by definition; pass through.
+- `list_gradebook_history_submissions` and `get_gradebook_history_feed` — `CanvasGradebookHistorySubmissionVersion` has `user_name` and `current_grader` / `new_grader` / `previous_grader` (`src/canvas/types.ts:325–342`). `user_name` is the student; pseudonymize. Grader names are staff; pass through.
+
+**Analytics**
+
+- `get_student_analytics` — `CanvasStudentActivitySummary` (`src/tools/analytics.ts:84`). Keyed by student id, no embedded names. Pass through (id-only).
+- `get_course_analytics` — aggregate per-day; no PII.
+
+**Outcomes**
+
+- `get_outcome_results` and `get_outcome_rollups` — `linked.users?: CanvasUser[]` (`src/canvas/types.ts:702`, `730`, `741`). When students appear in `linked.users`, run through pseudonymizer per-row.
+
+**Groups**
+
+- `list_group_members` — Canvas returns user objects per member. Pseudonymize per-row.
+
+**Dashboard / Student tools**
+
+- `get_my_courses`, `get_my_grades`, `get_my_submissions`, `get_my_upcoming_assignments`, `get_dashboard_cards`, `get_todo_items`, `get_upcoming_events`, `get_missing_submissions` — these are calls about the token-owner ("me"). When the operator is the student (a student running their own MCP), pseudonymizing themselves makes no sense and produces gibberish. We document that `CANVAS_PSEUDONYMIZE_STUDENTS=true` is intended for **teacher / staff** tokens; with a student token the flag should be off. We do **not** silently exempt them — the operator chose the flag; we respect it. If real-world testing shows this is too footgunny, we can add a separate `CANVAS_PSEUDONYMIZE_SELF=false` later.
+
+**Calendar, modules, pages, files, accounts, assignments**
+
+- These do not return student PII directly. They are not wrapped, with one exception: `list_files` and `get_file` may show a `user_id` of the uploader. This is id-only, pass through.
+
+**Hard-no list (intentionally NOT pseudonymized)**
+
+- `get_profile` (self).
+- Teacher / TA / admin / designer users anywhere in any payload.
+- Free-text bodies (assignment description, page body, discussion post body, submission body, comment body). Documented as O2.
+
+### Pseudonymizer surface
+
+A single class lives at `src/pseudonym/pseudonymizer.ts`:
+
+```
+class Pseudonymizer {
+  isEnabled(): boolean                                  // reads env once per request
+  anonymizeUser(courseId, user): CanvasUser              // student → pseudo, staff → unchanged
+  anonymizeUsers(courseId, users): CanvasUser[]
+  anonymizeEnrollment(courseId, enrollment): CanvasEnrollment
+  anonymizeSubmission(courseId, submission): CanvasSubmission
+  anonymizeConversation(conversation): CanvasConversation       // no courseId → cross-course pool
+  anonymizeOutcomeResults(courseId, response): CanvasOutcomeResultsResponse
+  reverseLookup(courseId, pseudonym): { user_id, name } | null  // only when reverse-lookup env on
+}
+```
+
+The tool layer calls these methods; the Canvas client layer never imports the pseudonymizer. This keeps the library usage path (`canvas-lms-mcp/canvas`) free of FERPA logic.
+
+To prevent **T3** (a new tool added later that forgets to wrap), the design includes:
+
+- A lint-style unit test in `tests/pseudonymizer.coverage.test.ts` that enumerates all registered tools and asserts that any tool whose declared output schema contains a `user` / `users` / `participants` / `user_name` / `submission_comments` field is on a known list of "pseudonymizer-wrapped" tools. Adding a new such tool without wrapping it fails CI. The list is hand-maintained but small enough to keep honest.
+- A short section in `CLAUDE.md` "How to Add a New Tool" calling out the pseudonymizer wrap.
+
+## Pseudonym storage
+
+The map persists per `(canvas-base-url, course_id)` tuple. The base URL is included because students from `school-a.instructure.com` course 101 and `school-b.instructure.com` course 101 are unrelated; sharing pseudonyms across them would either collide or leak the existence of separate institutions.
+
+**Location**
+
+- Default: `${XDG_DATA_HOME:-~/.local/share}/canvas-lms-mcp/pseudonyms/<host>/<course_id>.json` on Linux, `~/Library/Application Support/canvas-lms-mcp/pseudonyms/<host>/<course_id>.json` on macOS, `%APPDATA%\canvas-lms-mcp\pseudonyms\<host>\<course_id>.json` on Windows.
+- Override: `CANVAS_PSEUDONYM_DIR` env var (absolute path). Inside that directory, the `<host>/<course_id>.json` layout is unchanged.
+- `<host>` is the normalized hostname of `CANVAS_BASE_URL` (lower-cased, port stripped, no path). Slashes in hostname are not possible; no path-traversal risk.
+
+We deliberately do NOT put it in `~/.canvas-lms-mcp/` flat, because cross-platform conventions matter for an npm-distributed tool. The HTTP transport when run as a hosted service should set `CANVAS_PSEUDONYM_DIR` to a path inside a persistent volume.
+
+**File shape**
+
+```json
+{
+  "version": 1,
+  "host": "school.instructure.com",
+  "course_id": 12345,
+  "generated_at": "2026-05-25T14:00:00Z",
+  "next_pseudonym_index": 28,
+  "students": {
+    "98765": { "pseudonym": "Student 1", "status": "active",     "first_seen": "2026-02-03T..." },
+    "98766": { "pseudonym": "Student 2", "status": "active",     "first_seen": "2026-02-03T..." },
+    "98770": { "pseudonym": "Student 3", "status": "historical", "first_seen": "2026-02-10T...", "marked_historical_at": "2026-05-01T..." }
+  }
+}
+```
+
+**File permissions**
+
+- Directory created with `0o700`; file written with `0o600`. On Windows these modes are best-effort but documented.
+- The file is written via temp-file + rename for atomicity.
+
+**Allocation policy**
+
+- Pseudonyms are integer indices starting at 1 and increasing monotonically. `next_pseudonym_index` is the next free integer; allocation always uses it then increments.
+- Removed students are marked `status: "historical"`. Their `user_id` and pseudonym are **never** reused. If `Student 3` drops the course in week 4, future enrollees become `Student 28`, `Student 29`, etc. — never `Student 3`. Reusing pseudonyms would silently re-identify the dropped student in downstream artifacts that referenced "Student 3" at week 3.
+- Re-enrollment: if a `user_id` previously marked historical appears again, we restore their original pseudonym (`status` flips back to `active`). This is the only case where a historical entry mutates.
+
+**Concurrency**
+
+- Within a single Node process, an in-memory per-course async lock prevents two concurrent tool calls from allocating the same pseudonym twice.
+- Across processes (operator runs stdio and HTTP at the same time pointing at the same dir), we accept eventual consistency: each process loads, allocates, writes. Last writer wins. Collision risk is low in practice (one operator, one or two processes, allocations are minutes apart). If this becomes a real problem we can add an `O_EXCL` lock file later.
+
+**Lifetime and invalidation**
+
+- The map is durable. No TTL.
+- We provide a documented manual procedure to delete the file: "to rotate pseudonyms for course X, stop the server, delete the `<host>/X.json` file, restart". We do **not** expose a tool to delete it (T1 — the agent must not be able to trigger rotation).
+- When a student is removed from the course, we mark `historical` but keep the entry, so a re-enrollment restores the same pseudonym. This is a small privacy trade — a former student still has a stable identifier on disk — and a large pedagogical value: longitudinal tracking across a semester works correctly even if a student drops and re-adds.
+
+## Role detection: who is a student
+
+Canvas enrollment objects carry `type` (`StudentEnrollment`, `TeacherEnrollment`, `TaEnrollment`, `DesignerEnrollment`, `ObserverEnrollment`) and `role` (institution-defined). We treat any user with at least one active `StudentEnrollment` (or `StudentViewEnrollment`) in the course as a student. We treat any user with at least one `TeacherEnrollment` / `TaEnrollment` / `DesignerEnrollment` / admin role as staff. Mixed roles (a TA who is also a student in the same course) default to **student** — conservative-anonymize.
+
+When the user object comes without enrollment context (e.g., `get_user`, conversation participants, a submission with `?include[]=user` but no `?include[]=enrollments`), we ensure the wrapping tool requests `?include[]=enrollments` when scoped by course, and we fall back to the safe-anonymize policy when the role cannot be determined. The principle: **unknown → student → pseudonymize**. False positives (a teacher accidentally pseudonymized) are visible, fixable, and not a privacy incident. False negatives (a student accidentally exposed) are a privacy incident.
+
+For conversations, where there is no course context at all (a Canvas conversation may span courses), we cannot reliably classify. We pseudonymize **all** participants when the flag is on, using a separate "global" map at `pseudonyms/<host>/_conversations.json`. The operator using a teacher token may find that another teacher in a conversation is pseudonymized; that is the conservative outcome and is documented. If this turns out to be too noisy in practice, we can fall back to "do not pseudonymize conversation participants at all", but the design starts conservative.
+
+## Output shape
+
+Pseudonymization happens **in place**. The pseudonymized `CanvasUser` looks structurally identical to a real one — same fields, same types, different values. No `_pseudonym` shadow field, no `_real_name` field, no "metadata" envelope.
+
+Rationale:
+
+- The shape is what the agent's tool-use schema expects. Adding shadow fields means every consumer (including external skills, code that parses our tool output, future MCP clients) must learn about them.
+- A shadow field is a footgun: an agent reading `{ name: "Student 7", _real_name: "Alice Smith" }` will absolutely include `_real_name` in its summary. The only way to prevent this is to never produce it. Hence: no shadow fields, ever, when the flag is on.
+- When the flag is off, output is unchanged from today. No `_pseudonym` field appears on real names.
+
+The one piece of metadata we **do** add, but at the response envelope level rather than inside the user object, is a one-time warning on every tool response when the flag is on:
+
+```
+"_meta": {
+  "pseudonymized": true,
+  "note": "Student names and contact info in this response have been replaced with stable pseudonyms (CANVAS_PSEUDONYMIZE_STUDENTS=true). Real names are not available to this tool."
+}
+```
+
+This sits in the MCP tool response `meta` field (per the SDK), not in the data payload. The agent sees it once per call and can mention it in the user-facing summary ("I'm working from pseudonymized data; Student 7 had three late submissions"). It cannot extract a real name from it because no real name is present.
+
+## HTTP transport implications
+
+`src/http.ts:75–82` constructs a fresh MCP server per request with per-request credentials (`token` from the `X-Canvas-Token` header, `baseUrl` from server config). For pseudonymization, this means:
+
+- The pseudonymizer **must** be keyed by `(baseUrl, course_id)` — not by token. Two different teachers calling the same hosted server for the same course should see the **same** pseudonym for the same student. That is the whole point of stability.
+- The pseudonymizer instance can be a process-wide singleton (one Node process, one filesystem, one map per course per host). It is constructed once at startup and re-used across requests.
+- The env flag `CANVAS_PSEUDONYMIZE_STUDENTS` is process-wide. A hosted deployment that needs both modes must run two pods/processes. We document this as a deliberate choice.
+- The `X-Canvas-Token` header is irrelevant to pseudonymization — we never read it for that purpose, never log it, and the pseudonymizer never sees the token. Pseudonymization status is decided before the request is dispatched to a tool handler.
+- No header (`X-Canvas-Anonymize`, etc.) can flip the mode. CORS allow-list in `src/http.ts:23` does not include any such header, and we do not add one.
+
+For stdio, the same singleton lives in the long-running process; cleanup happens at process exit.
+
+A note on the per-request token + shared map: if Teacher A in Period 1 and Teacher B in Period 2 both teach course 12345 with different tokens and the same students, they will see the same `Student N` pseudonyms — which is the correct, stable outcome. If two tokens belong to **different Canvas accounts** (different `baseUrl`), they get different files entirely. The base URL is the privacy boundary.
+
+## Stretch: reverse lookup
+
+A separate tool, registered only when `CANVAS_PSEUDONYMIZE_REVERSE_LOOKUP=true` AND `CANVAS_PSEUDONYMIZE_STUDENTS=true`:
+
+```
+resolve_pseudonym(course_id, pseudonym) → { user_id, real_name, real_email }
+```
+
+Design choices:
+
+- **Not registered at all** when the env flag is off. The agent cannot enumerate it via `tools/list`. This is stronger than "registered but errors out": if the tool is absent from the schema, prompt-injection attempts to call it fail at the MCP protocol layer before they reach our handler.
+- When registered, the tool is `readOnlyHint: true` but is annotated in its description with "Use only when a teacher explicitly asks to identify a specific student in an artifact". We cannot enforce this on the agent, but we set the expectation in the schema.
+- All calls to `resolve_pseudonym` are logged to stderr (and to a configurable audit file via `CANVAS_PSEUDONYM_AUDIT_LOG`) with timestamp, course_id, pseudonym requested. This is the only audit we add; pseudonymization itself is silent.
+- The map file is the source of truth for the reverse direction. Lookup is O(students-in-course) via a single linear scan or a reverse index built on load.
+
+We deliberately do not provide:
+
+- A "bulk reveal" tool returning the whole map. The agent must ask for one student at a time, which limits damage from a single tool call.
+- A web/HTTP endpoint exposing the map. Hosted operators who want to debug must SSH or kubectl-exec to the box.
+
+## What we are not doing
+
+- No GUI / web UI for managing the map. CLI + file edits only.
+- No remote storage of the map (S3, Postgres, etc.) for v1. Filesystem only. We may add a pluggable backend later if hosted deployments demand it.
+- No encryption-at-rest of the map (operator's job; disk encryption or volume encryption).
+- No detection or scrubbing of names inside free-text fields (submission body, discussion message). This is a documented limitation and the largest residual privacy gap. A future spec could explore NER-based scrubbing; v1 does not.
+- No automatic deletion of historical entries.
+- No `--anonymize` CLI flag. Env only.
+
+## Implementation outline (for the follow-up implementation task)
+
+1. New module `src/pseudonym/` (analogous to `src/canvas/`):
+   - `pseudonymizer.ts` — class with the methods above.
+   - `store.ts` — filesystem read/write/atomic-rename.
+   - `roles.ts` — `classifyRole(user, enrollments)` helper.
+   - `paths.ts` — XDG / platform-aware path resolution.
+2. `src/server.ts` constructs the `Pseudonymizer` and passes it into `getAllTools(canvas, pseudonymizer)` in `src/tools/index.ts`.
+3. Each affected tool module gains a wrap at the response boundary. Most are one-liners: `return pseudonymizer.anonymizeUsers(courseId, users)`.
+4. New tool `resolve_pseudonym` lives in `src/tools/pseudonym.ts`, registered conditionally.
+5. Tests:
+   - `tests/pseudonymizer.test.ts` — allocation, persistence, re-enrollment, historical marking, concurrency, file modes, base-URL keying.
+   - `tests/pseudonymizer.coverage.test.ts` — the "every PII-bearing tool is wrapped" lint test.
+   - `tests/tools/*.test.ts` updates — each affected tool gets a "with flag on, names are pseudonyms" case.
+6. Documentation:
+   - `README.md` — new "FERPA mode" section with the env vars, the threat model summary, and the residual limitations (T2 free-text, O1 LLM memory).
+   - `CLAUDE.md` — checklist item for "if your new tool returns student PII, wrap it".
+
+## Open questions for CTO before implementation
+
+1. **Naming**: `CANVAS_PSEUDONYMIZE_STUDENTS` vs the competitor's `CANVAS_MCP_ALLOW_DEANONYMIZE` (inverted polarity). Mine is positive ("turn on protection"); theirs is negative ("turn off protection"). Positive is clearer for compliance teams reading config but easier to forget. Confirm preference.
+2. **Self-pseudonymization** for `get_profile` and `get_my_*` tools. Spec says "exempt `get_profile`, pseudonymize the rest, document that the flag is for teacher tokens". Acceptable, or should I add `CANVAS_PSEUDONYMIZE_SELF=false` from day one?
+3. **Pseudonym pattern**. `Student 1` is human-readable but predictable across courses. Competitor uses the same. Alternative: stable random suffix (`Student a3f2`) per course, harder to confuse across courses but harder to read. Recommend `Student N`. Confirm.
+4. **Conversation participants**. Spec says "pseudonymize all participants conservatively, using a global `_conversations.json` map". Alternative: skip conversations entirely. The conservative choice may surprise teachers who chat with each other and expect colleague names. Confirm.
+5. **Reverse-lookup audit log**. Should be opt-in via `CANVAS_PSEUDONYM_AUDIT_LOG=/path/file.log`, or always log to stderr? Stderr is cheap and visible to the operator; a file is durable but creates yet another piece of state. Recommend stderr by default, file-path optional.
+6. **Coverage lint test**. The "every PII tool is wrapped" CI check requires a hand-maintained allowlist of "pseudonymizer-wrapped" tools. If we add 5 tools a quarter, this is fine. If the rate is higher, we should generate the list. Acceptable starting point?
+7. **Library users** (`canvas-lms-mcp/canvas` import). Spec leaves the Canvas client free of FERPA logic. An embedder using the raw client gets none of the protection. Documented as a non-feature; confirm we are OK with that boundary.
+8. **HTTP hosted deployments**. Spec says "to run both modes, run two processes". Alternative: per-deployment flag with a separate `/mcp-anon` endpoint. Two processes is simpler and matches the threat model. Confirm.
+
+## Acceptance check (against issue criteria)
+
+- [x] Document lives in `docs/superpowers/specs/2026-05-25-ferpa-pseudonymization.md`.
+- [x] Sections cover scope, storage, configuration, role detection, output shape, HTTP transport, stretch reverse-lookup, open questions.
+- [x] Threat model is explicit: T1 tool-arg, T2 header, T3 unwrapped-tool, T4 reverse-lookup, T5 read-the-map-file, T6 raw-HTTP, T7 prompt-injection.
+- [x] No code changes; design only.


### PR DESCRIPTION
## Summary

Design document only — no code changes. Proposes an opt-in, server-side mode that pseudonymizes student PII in every read tool's output. The threat model treats the calling AI agent itself as the adversary: pseudonymization is controlled by an environment variable (`CANVAS_PSEUDONYMIZE_STUDENTS=true`) and cannot be flipped by any tool argument, MCP request field, or HTTP header.

Key design choices documented:

- Env-flag only, evaluated server-side — no per-call override surface.
- Per-`(canvas-host, course_id)` map persisted on disk, stable across restarts. Historical entries kept (never renumber) so re-enrollment restores the original pseudonym.
- In-place replacement of `name`, `short_name`, `sortable_name`, `email`, `login_id`, `sis_user_id`, `integration_id`, `avatar_url`, `bio`, `pronouns`, `last_login` — no shadow fields that the agent could leak.
- HTTP transport: process-wide singleton; operators needing both modes run two processes.
- Optional reverse-lookup tool, conditionally registered (not visible in `tools/list` when off), gated by a second env var.
- Enumeration of every tool that surfaces student PII (users, enrollments, submissions, peer-reviews, conversations, gradebook history, outcomes, groups) and the wrapping plan for each.
- Eight open questions for CTO before any implementation task is created.

## Test plan

- [ ] CTO review of `docs/superpowers/specs/2026-05-25-ferpa-pseudonymization.md`.
- [ ] CTO answers the eight open questions at the bottom of the doc.
- [ ] Follow-up implementation task created with answers folded in.

Refs: BRU-1264, BRU-1261 (research). Inspiration from `awesome-town/canvas-mcp-node` (referenced, not copied).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>