### PR TITLE
feat(pseudonym): add Pseudonymizer core + FERPA mode [BRU-1266]

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -102,3 +102,4 @@ Every tool must declare MCP annotations:
 3. Create `src/tools/<domain>.ts` exporting `(canvas: CanvasClient) => ToolDefinition[]` with Zod input schemas and annotations
 4. Register the domain in `getAllTools()` in `src/tools/index.ts`
 5. Write tests in `tests/<domain>.test.ts` using mocked Canvas responses
+6. **If the tool returns student PII (a `CanvasUser`, a `participants` array, or a `user_name` field), wrap it.** Inside the tool handler, route the response through the matching `pseudonymizer.anonymize*` method (`anonymizeUser` / `anonymizeUsers` / `anonymizeEnrollment` / `anonymizeSubmission` / `anonymizeConversation` / `anonymizeOutcomeResults`) AND add the tool's name to `PSEUDONYMIZER_WRAPPED_TOOLS` in `src/pseudonym/coverage.ts`. CI (`tests/pseudonym/coverage.test.ts`) fails until both are done.

--- a/README.md
+++ b/README.md
@@ -206,7 +206,39 @@ const courses = await canvas.courses.list()
 | `CANVAS_API_TOKEN` | Yes | Canvas personal access token |
 | `CANVAS_BASE_URL` | Yes | Canvas instance URL (e.g., `https://school.instructure.com`) |
 | `CANVAS_ALLOWED_ORIGIN` | No | CORS origin for HTTP mode (default: `http://localhost:3000`) |
+| `CANVAS_PSEUDONYMIZE_STUDENTS` | No | Set to `true` to enable [FERPA mode](#ferpa-mode-student-pseudonymization) |
+| `CANVAS_PSEUDONYMIZE_REVERSE_LOOKUP` | No | Set to `true` (with `CANVAS_PSEUDONYMIZE_STUDENTS=true`) to register the `resolve_pseudonym` audit tool |
+| `CANVAS_PSEUDONYM_DIR` | No | Absolute path that overrides the default pseudonym map directory |
+| `CANVAS_PSEUDONYM_AUDIT_LOG` | No | Path to an append-only file that mirrors `resolve_pseudonym` audit lines (stderr is always written) |
 
+## FERPA mode (student pseudonymization)
+
+Opt-in, server-side mode that replaces student names and contact info in tool output with stable pseudonyms (`Student 1`, `Student 2`, …) so structured PII never reaches the LLM. Designed for teacher / staff tokens — students running their own MCP should leave the flag off, otherwise their own data is replaced too.
+
+```bash
+CANVAS_PSEUDONYMIZE_STUDENTS=true canvas-lms-mcp serve --base-url https://school.instructure.com
+```
+
+What it does:
+
+- Replaces `name`, `short_name`, `sortable_name`, `email`, `login_id`, `sis_user_id`, `integration_id`, `avatar_url`, `bio`, `pronouns`, and `last_login` on student users.
+- Maps are stable per `(canvas-base-url, course_id)` and persisted to disk under `${XDG_DATA_HOME:-~/.local/share}/canvas-lms-mcp/pseudonyms` (Linux), `~/Library/Application Support/canvas-lms-mcp/pseudonyms` (macOS), or `%APPDATA%\canvas-lms-mcp\pseudonyms` (Windows). Override the location with `CANVAS_PSEUDONYM_DIR`.
+- `Student 7` in March is still `Student 7` in October. Dropped students are marked historical; their slot is never reused.
+- Tool responses carry `_meta.pseudonymized: true` so the agent can mention it in summaries.
+- Cannot be toggled per tool call, per HTTP header, or per session. The env flag is the only switch.
+
+What it does NOT do:
+
+- It does not scrub free text inside submission bodies, discussion messages, or page bodies — a student writing "Hi, I'm Alice" in their submission still says so. Document this for your end users.
+- It cannot re-anonymize the LLM's working memory. If the agent saw real names in a prior turn, they remain in its context.
+- It does not protect the bare `canvas-lms-mcp/canvas` library import — pseudonymization is a tool-layer concern. Embedders that use the raw Canvas client get raw data.
+- HTTP transports are process-wide: to run both modes side by side, run two server instances.
+
+Conversation participants are pseudonymized as `Person N` from a cross-course pool. If you chat with a colleague, they appear as `Person 1` rather than their name — conservative because conversations span courses and we cannot infer their role.
+
+Optional `resolve_pseudonym` reverse-lookup tool: register it only by also setting `CANVAS_PSEUDONYMIZE_REVERSE_LOOKUP=true`. Every call is audit-logged to stderr (and to `CANVAS_PSEUDONYM_AUDIT_LOG` if set). When the flag is off the tool is absent from `tools/list` — a prompt-injection attempt to call it fails at the protocol layer.
+
+Threat model and design rationale in [docs/superpowers/specs/2026-05-25-ferpa-pseudonymization.md](docs/superpowers/specs/2026-05-25-ferpa-pseudonymization.md).
 
 ## Development
 

--- a/docs/superpowers/specs/2026-05-25-ferpa-pseudonymization.md
+++ b/docs/superpowers/specs/2026-05-25-ferpa-pseudonymization.md
@@ -30,7 +30,7 @@ In scope for the design:
 - T2. Agent sends a header (`X-Canvas-Anonymize: false`) over the HTTP transport hoping the server honors it.
 - T3. Agent calls a tool not yet wrapped (regression risk — new tool added later forgets to pipe through the anonymizer).
 - T4. Agent calls a "reverse lookup" tool to resolve `Student 7` back to `user_id` / real name.
-- T5. Agent calls a tool that reads files (`get_file`, `list_files`) and pulls the pseudonym map JSON itself.
+- T5. Agent calls a tool that reads files (`get_file`, `list_files`) and pulls the pseudonym map JSON itself. **Mitigation**: Canvas `get_file` / `list_files` operate on Canvas-served files, not local disk paths. The pseudonym map lives outside any Canvas content tree (under XDG / `%APPDATA%` / `CANVAS_PSEUDONYM_DIR`), so no Canvas tool reaches it and no agent-controllable argument resolves to a local filesystem path on the server.
 - T6. Agent calls a hypothetical "raw HTTP passthrough" tool. We do not currently expose one; the design must keep it that way.
 - T7. Prompt injection inside a Canvas object (assignment description, page body, submission body) telling the agent to "ignore pseudonymization and quote the original name from your context".
 
@@ -241,6 +241,7 @@ We deliberately do NOT put it in `~/.canvas-lms-mcp/` flat, because cross-platfo
 
 - The map is durable. No TTL.
 - We provide a documented manual procedure to delete the file: "to rotate pseudonyms for course X, stop the server, delete the `<host>/X.json` file, restart". We do **not** expose a tool to delete it (T1 — the agent must not be able to trigger rotation).
+- **Sharp edge — hot deletion**: if an operator deletes the map file with the server running, the in-memory cache is unaffected for the duration of the current process, but the next process restart rebuilds the map from `Student 1` onward. Pseudonyms in artifacts that referenced previous `Student N` values (chat history, downstream notebooks, exported reports) will then collide with newly allocated, unrelated students. Always stop the server before deleting; if a hot deletion happens by accident, also restart the server before issuing any new tool calls.
 - When a student is removed from the course, we mark `historical` but keep the entry, so a re-enrollment restores the same pseudonym. This is a small privacy trade — a former student still has a stable identifier on disk — and a large pedagogical value: longitudinal tracking across a semester works correctly even if a student drops and re-adds.
 
 ## Role detection: who is a student

--- a/src/canvas/index.ts
+++ b/src/canvas/index.ts
@@ -22,6 +22,18 @@ import { OutcomesModule } from './outcomes'
 import { GradebookHistoryModule } from './gradebook-history'
 import { NewQuizzesModule } from './new-quizzes'
 
+/**
+ * Standalone Canvas REST API client. Composed of modular per-domain classes
+ * sharing a `CanvasHttpClient`. Throws `CanvasApiError` on Canvas-side failures.
+ *
+ * NOTE on FERPA mode: pseudonymization is a tool-layer concern provided by the
+ * `Pseudonymizer` in `src/pseudonym/`. Library consumers that import this
+ * client directly (`canvas-lms-mcp/canvas`) bypass the MCP tool wrappers and
+ * therefore receive raw Canvas responses with real student names and contact
+ * info. If you need pseudonymized output, either use the MCP server entry
+ * points (`canvas-lms-mcp` stdio / `canvas-lms-mcp serve` HTTP) or wrap your
+ * own calls with a `Pseudonymizer` instance.
+ */
 export class CanvasClient {
   private client: CanvasHttpClient
   courses: CoursesModule

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,5 +1,6 @@
 import { createServer } from 'node:http'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import { Pseudonymizer } from './pseudonym/pseudonymizer'
 import { createCanvasMCPServer } from './server'
 import { parseArgs } from './cli'
 
@@ -8,6 +9,13 @@ export function createHttpHandler(defaultConfig: {
   baseUrl?: string
   allowedOrigin?: string
 }) {
+  // Process-wide pseudonymizer keyed on the configured base URL. Pseudonyms
+  // are stable across requests because every fresh MCP server reuses this
+  // instance and its on-disk map.
+  const pseudonymizer = defaultConfig.baseUrl
+    ? new Pseudonymizer({ baseUrl: defaultConfig.baseUrl })
+    : undefined
+
   return async (
     req: import('node:http').IncomingMessage,
     res: import('node:http').ServerResponse,
@@ -72,8 +80,10 @@ export function createHttpHandler(defaultConfig: {
       return
     }
 
-    // Fresh MCP server per request (per-request credentials)
-    const { server } = createCanvasMCPServer({ token, baseUrl })
+    // Fresh MCP server per request (per-request credentials); the pseudonymizer
+    // is the singleton constructed above so pseudonyms remain stable across
+    // requests for this host.
+    const { server } = createCanvasMCPServer({ token, baseUrl, pseudonymizer })
 
     try {
       const transport = new StreamableHTTPServerTransport({

--- a/src/pseudonym/coverage.ts
+++ b/src/pseudonym/coverage.ts
@@ -1,0 +1,49 @@
+// CI coverage list: which registered tools surface student PII and therefore
+// MUST run their response through the Pseudonymizer when the flag is on.
+//
+// This list is hand-maintained. When adding a tool whose response contains a
+// `CanvasUser`, a participants array, or a `user_name` field, add the tool
+// name here AND wrap its handler with the appropriate `pseudonymizer.*` call.
+//
+// `tests/pseudonymizer.coverage.test.ts` enforces two invariants:
+//   1. Every name in this list is registered on the running server.
+//   2. The canonical "PII-bearing tools" expectation (in the test itself)
+//      matches this list, so adding a PII tool without updating the list
+//      fails CI.
+//
+// See `docs/superpowers/specs/2026-05-25-ferpa-pseudonymization.md` §
+// "Tools that surface student PII" for the original audit.
+
+export const PSEUDONYMIZER_WRAPPED_TOOLS: readonly string[] = [
+  // src/tools/users.ts
+  'list_students',
+  'get_user',
+  'search_users',
+  'list_course_users',
+
+  // src/tools/accounts.ts
+  'list_account_users',
+
+  // src/tools/enrollments.ts
+  'list_enrollments',
+  'list_course_enrollments',
+
+  // src/tools/submissions.ts
+  'list_submissions',
+  'get_submission',
+
+  // src/tools/conversations.ts
+  'list_conversations',
+  'get_conversation',
+
+  // src/tools/gradebook-history.ts
+  'list_gradebook_history_submissions',
+  'get_gradebook_history_feed',
+
+  // src/tools/outcomes.ts
+  'get_outcome_results',
+  'get_outcome_rollups',
+
+  // src/tools/groups.ts
+  'list_group_members',
+] as const

--- a/src/pseudonym/paths.ts
+++ b/src/pseudonym/paths.ts
@@ -1,0 +1,83 @@
+// Cross-platform path resolution for the pseudonym map directory.
+//
+// Override: `CANVAS_PSEUDONYM_DIR` (absolute path).
+// Default:
+//   - Linux:   `${XDG_DATA_HOME:-~/.local/share}/canvas-lms-mcp/pseudonyms`
+//   - macOS:   `~/Library/Application Support/canvas-lms-mcp/pseudonyms`
+//   - Windows: `%APPDATA%\canvas-lms-mcp\pseudonyms` (falls back to `%USERPROFILE%\AppData\Roaming\...`)
+// Inside the chosen directory the layout is `<host>/<course_id>.json`.
+
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+const APP_NAME = 'canvas-lms-mcp'
+const PSEUDONYMS_SUBDIR = 'pseudonyms'
+
+export interface ResolvePathsEnv {
+  CANVAS_PSEUDONYM_DIR?: string
+  XDG_DATA_HOME?: string
+  APPDATA?: string
+  USERPROFILE?: string
+  HOME?: string
+}
+
+/**
+ * Resolve the directory that holds pseudonym maps.
+ *
+ * Honors `CANVAS_PSEUDONYM_DIR` when set; otherwise uses the platform default.
+ * Pass an explicit `platform`/`env` for tests; defaults to the current process.
+ */
+export function resolvePseudonymDir(
+  options: { platform?: NodeJS.Platform; env?: ResolvePathsEnv; home?: string } = {},
+): string {
+  const env = options.env ?? (process.env as ResolvePathsEnv)
+  const platform = options.platform ?? process.platform
+  const home = options.home ?? homedir()
+
+  const override = env.CANVAS_PSEUDONYM_DIR
+  if (override && override.length > 0) {
+    return override
+  }
+
+  if (platform === 'win32') {
+    const appData =
+      env.APPDATA ?? (env.USERPROFILE ? join(env.USERPROFILE, 'AppData', 'Roaming') : null)
+    const base = appData ?? join(home, 'AppData', 'Roaming')
+    return join(base, APP_NAME, PSEUDONYMS_SUBDIR)
+  }
+
+  if (platform === 'darwin') {
+    return join(home, 'Library', 'Application Support', APP_NAME, PSEUDONYMS_SUBDIR)
+  }
+
+  const xdg = env.XDG_DATA_HOME
+  const base = xdg && xdg.length > 0 ? xdg : join(home, '.local', 'share')
+  return join(base, APP_NAME, PSEUDONYMS_SUBDIR)
+}
+
+/**
+ * Normalize a Canvas base URL into a filesystem-safe host identifier.
+ * Lower-cases, strips port, strips path. Returns null for unparseable URLs.
+ */
+export function normalizeHost(baseUrl: string): string | null {
+  try {
+    const parsed = new URL(baseUrl)
+    return parsed.hostname.toLowerCase()
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Full path to the map file for a (host, course_id) pair.
+ */
+export function mapFilePath(rootDir: string, host: string, courseId: number | string): string {
+  return join(rootDir, host, `${courseId}.json`)
+}
+
+/**
+ * Full path to the cross-course conversations map.
+ */
+export function conversationsFilePath(rootDir: string, host: string): string {
+  return join(rootDir, host, '_conversations.json')
+}

--- a/src/pseudonym/pseudonymizer.ts
+++ b/src/pseudonym/pseudonymizer.ts
@@ -1,0 +1,460 @@
+// Pseudonymizer — opt-in, server-side replacement of student PII in tool output.
+//
+// Tamper-resistant: the on/off decision is made from `process.env` only, never
+// from tool arguments, MCP request fields, or HTTP headers.
+//
+// Stable: each Canvas user_id maps to the same `Student N` for the lifetime of
+// the course's pseudonym file. Re-enrollment restores the original pseudonym;
+// dropped students are marked `historical` and their slot is NEVER reused.
+//
+// See `docs/superpowers/specs/2026-05-25-ferpa-pseudonymization.md` for the
+// full threat model and rationale.
+
+import type {
+  CanvasConversation,
+  CanvasConversationDetail,
+  CanvasEnrollment,
+  CanvasOutcomeResultsResponse,
+  CanvasOutcomeRollupsResponse,
+  CanvasSubmission,
+  CanvasSubmissionComment,
+  CanvasUser,
+} from '../canvas/types'
+import { conversationsFilePath, mapFilePath, normalizeHost, resolvePseudonymDir } from './paths'
+import { classifyRole, shouldPseudonymize, type Role } from './roles'
+import {
+  emptyConversationMap,
+  emptyCourseMap,
+  loadMap,
+  saveMap,
+  type ConversationMap,
+  type CourseMap,
+  type StudentEntry,
+} from './store'
+
+export interface PseudonymizerConfig {
+  /** Canvas base URL — used to key the per-host map directory. */
+  baseUrl: string
+  /** Root directory for map files. Defaults to platform/XDG location. */
+  rootDir?: string
+  /** Env reader; defaults to `process.env`. Injection point for tests. */
+  env?: NodeJS.ProcessEnv
+  /** Audit log writer for `resolve_pseudonym` calls; defaults to `console.error`. */
+  auditLog?: (line: string) => void
+}
+
+export interface ReverseLookupResult {
+  user_id: number
+  pseudonym: string
+  status: 'active' | 'historical'
+}
+
+/**
+ * Result of the pseudonymizer's per-request status check. The fields here are
+ * the inputs the tool-response wrapper needs to attach `_meta.pseudonymized`.
+ */
+export interface PseudonymizationStatus {
+  enabled: boolean
+  reverseLookupEnabled: boolean
+}
+
+const TRUTHY_ENV_VALUES = new Set(['true', '1', 'yes', 'on'])
+
+function isEnvTruthy(value: string | undefined): boolean {
+  if (!value) return false
+  return TRUTHY_ENV_VALUES.has(value.trim().toLowerCase())
+}
+
+/**
+ * Single-process pseudonymizer. One instance per running server. Construct
+ * once at startup and re-use across requests; an HTTP server that creates a
+ * fresh MCP server per request still shares this singleton.
+ */
+export class Pseudonymizer {
+  private readonly host: string | null
+  private readonly rootDir: string
+  private readonly env: NodeJS.ProcessEnv
+  private readonly auditLog: (line: string) => void
+
+  // In-memory caches of loaded maps, keyed by `<host>/<courseId>` or
+  // `<host>/_conversations`. Loaded lazily; written through on mutation.
+  private readonly courseMaps = new Map<string, CourseMap>()
+  private readonly conversationMaps = new Map<string, ConversationMap>()
+
+  // Per-target async locks. A second mutator awaits the prior promise so that
+  // pseudonym allocation cannot race within a single Node process. Cross-
+  // process concurrency falls back to last-writer-wins (documented).
+  private readonly locks = new Map<string, Promise<unknown>>()
+
+  constructor(config: PseudonymizerConfig) {
+    this.host = normalizeHost(config.baseUrl)
+    this.rootDir = config.rootDir ?? resolvePseudonymDir({ env: config.env })
+    this.env = config.env ?? process.env
+    this.auditLog = config.auditLog ?? ((line) => console.error(line))
+  }
+
+  /**
+   * True when `CANVAS_PSEUDONYMIZE_STUDENTS` is set to a truthy value. Read
+   * from env on every call so that test setup can flip the flag mid-process.
+   */
+  isEnabled(): boolean {
+    return isEnvTruthy(this.env.CANVAS_PSEUDONYMIZE_STUDENTS)
+  }
+
+  /**
+   * True when reverse lookup is enabled. Only meaningful when `isEnabled()`.
+   */
+  isReverseLookupEnabled(): boolean {
+    return this.isEnabled() && isEnvTruthy(this.env.CANVAS_PSEUDONYMIZE_REVERSE_LOOKUP)
+  }
+
+  status(): PseudonymizationStatus {
+    return {
+      enabled: this.isEnabled(),
+      reverseLookupEnabled: this.isReverseLookupEnabled(),
+    }
+  }
+
+  /**
+   * Pseudonymize a single user when classified as student/unknown. Staff and
+   * unknown-host (unparseable base URL) calls pass through unchanged.
+   */
+  async anonymizeUser(
+    courseId: number | string,
+    user: CanvasUser,
+    enrollments?: ReadonlyArray<CanvasEnrollment>,
+  ): Promise<CanvasUser> {
+    if (!this.isEnabled() || !this.host) return user
+    const role = classifyRole(user, enrollments)
+    if (!shouldPseudonymize(role)) return user
+    const entry = await this.assignPseudonym(this.host, courseId, user.id)
+    return applyPseudonymToUser(user, entry.pseudonym)
+  }
+
+  async anonymizeUsers(
+    courseId: number | string,
+    users: ReadonlyArray<CanvasUser>,
+  ): Promise<CanvasUser[]> {
+    if (!this.isEnabled() || !this.host) return [...users]
+    const out: CanvasUser[] = []
+    for (const u of users) {
+      out.push(await this.anonymizeUser(courseId, u))
+    }
+    return out
+  }
+
+  /**
+   * Pseudonymize an enrollment in place: scrubs `sis_user_id` and rewrites
+   * the embedded `user` when present.
+   */
+  async anonymizeEnrollment(
+    courseId: number | string,
+    enrollment: CanvasEnrollment,
+  ): Promise<CanvasEnrollment> {
+    if (!this.isEnabled() || !this.host) return enrollment
+    const role = enrollment.user
+      ? classifyRole(enrollment.user, [enrollment])
+      : classifyRoleFromEnrollment(enrollment)
+    if (!shouldPseudonymize(role)) return enrollment
+
+    const out: CanvasEnrollment = { ...enrollment, sis_user_id: null }
+    if (enrollment.user) {
+      const entry = await this.assignPseudonym(this.host, courseId, enrollment.user.id)
+      out.user = applyPseudonymToUser(enrollment.user, entry.pseudonym)
+    }
+    return out
+  }
+
+  /**
+   * Pseudonymize a submission: rewrites `submission.user` and any
+   * student-authored `submission_comments` based on the per-course map.
+   * Comment authors whose role cannot be inferred fall back to "if we have
+   * a pseudonym for this user_id, use it; otherwise pass through" — see
+   * design doc, "submission_comments[].author_name when the author is a
+   * student (peer feedback)".
+   */
+  async anonymizeSubmission(
+    courseId: number | string,
+    submission: CanvasSubmission,
+  ): Promise<CanvasSubmission> {
+    if (!this.isEnabled() || !this.host) return submission
+
+    const out: CanvasSubmission = { ...submission }
+
+    if (submission.user) {
+      const role = classifyRole(submission.user)
+      if (shouldPseudonymize(role)) {
+        const entry = await this.assignPseudonym(this.host, courseId, submission.user.id)
+        out.user = applyPseudonymToUser(submission.user, entry.pseudonym)
+      }
+    }
+
+    if (submission.submission_comments && submission.submission_comments.length > 0) {
+      out.submission_comments = await this.anonymizeSubmissionComments(
+        courseId,
+        submission.submission_comments,
+      )
+    }
+
+    return out
+  }
+
+  /**
+   * Pseudonymize all participants in a conversation. Conversations span
+   * courses, so we use a cross-course `_conversations.json` pool keyed only
+   * by host — conservative because we cannot reliably classify role without
+   * a course context.
+   */
+  async anonymizeConversation<T extends CanvasConversation | CanvasConversationDetail>(
+    conversation: T,
+  ): Promise<T> {
+    if (!this.isEnabled() || !this.host) return conversation
+
+    const participants = await Promise.all(
+      conversation.participants.map(async (p) => {
+        const pseudonym = await this.assignConversationPseudonym(this.host as string, p.id)
+        return { ...p, name: pseudonym }
+      }),
+    )
+
+    return { ...conversation, participants } as T
+  }
+
+  /**
+   * Pseudonymize the `linked.users` array of an outcome results / rollups
+   * response.
+   */
+  async anonymizeOutcomeResults<
+    T extends CanvasOutcomeResultsResponse | CanvasOutcomeRollupsResponse,
+  >(courseId: number | string, response: T): Promise<T> {
+    if (!this.isEnabled() || !this.host) return response
+    if (!response.linked?.users || response.linked.users.length === 0) return response
+
+    const users = await this.anonymizeUsers(courseId, response.linked.users)
+    return { ...response, linked: { ...response.linked, users } } as T
+  }
+
+  /**
+   * Look up the real user_id behind a pseudonym. Returns `null` when reverse
+   * lookup is disabled, the host is invalid, or the pseudonym is unknown.
+   * Audit-logs every successful and failed lookup.
+   */
+  async reverseLookup(
+    courseId: number | string,
+    pseudonym: string,
+  ): Promise<ReverseLookupResult | null> {
+    if (!this.isReverseLookupEnabled() || !this.host) return null
+
+    const map = await this.loadCourseMap(this.host, courseId)
+    if (!map) {
+      this.audit(`reverse_lookup miss course=${courseId} pseudonym=${pseudonym} reason=no-map`)
+      return null
+    }
+
+    for (const [userIdStr, entry] of Object.entries(map.students)) {
+      if (entry.pseudonym === pseudonym) {
+        const userId = Number(userIdStr)
+        this.audit(
+          `reverse_lookup hit course=${courseId} pseudonym=${pseudonym} status=${entry.status}`,
+        )
+        return { user_id: userId, pseudonym: entry.pseudonym, status: entry.status }
+      }
+    }
+
+    this.audit(`reverse_lookup miss course=${courseId} pseudonym=${pseudonym} reason=not-found`)
+    return null
+  }
+
+  // --- Internals --------------------------------------------------------------
+
+  /**
+   * Allocate (or restore) the pseudonym for a given (host, courseId, userId).
+   * Holds an in-memory async lock on the target so two concurrent allocations
+   * cannot collide on `next_pseudonym_index`.
+   */
+  private async assignPseudonym(
+    host: string,
+    courseId: number | string,
+    userId: number,
+  ): Promise<StudentEntry> {
+    const key = `${host}/${courseId}`
+    return this.withLock(key, async () => {
+      const map = (await this.loadCourseMap(host, courseId)) ?? emptyCourseMap(host, courseId)
+      const userKey = String(userId)
+      const existing = map.students[userKey]
+
+      if (existing) {
+        // Re-enrollment: restore historical entries to active without changing
+        // the assigned pseudonym.
+        if (existing.status === 'historical') {
+          const restored: StudentEntry = {
+            ...existing,
+            status: 'active',
+          }
+          delete restored.marked_historical_at
+          map.students[userKey] = restored
+          await this.persistCourseMap(host, courseId, map)
+          return restored
+        }
+        return existing
+      }
+
+      const entry: StudentEntry = {
+        pseudonym: `Student ${map.next_pseudonym_index}`,
+        status: 'active',
+        first_seen: new Date().toISOString(),
+      }
+      map.students[userKey] = entry
+      map.next_pseudonym_index += 1
+      await this.persistCourseMap(host, courseId, map)
+      return entry
+    })
+  }
+
+  private async assignConversationPseudonym(host: string, userId: number): Promise<string> {
+    const key = `${host}/_conversations`
+    return this.withLock(key, async () => {
+      const map = (await this.loadConversationMap(host)) ?? emptyConversationMap(host)
+      const userKey = String(userId)
+      const existing = map.participants[userKey]
+      if (existing) return existing.pseudonym
+
+      const entry: StudentEntry = {
+        pseudonym: `Person ${map.next_pseudonym_index}`,
+        status: 'active',
+        first_seen: new Date().toISOString(),
+      }
+      map.participants[userKey] = entry
+      map.next_pseudonym_index += 1
+      await this.persistConversationMap(host, map)
+      return entry.pseudonym
+    })
+  }
+
+  private async anonymizeSubmissionComments(
+    courseId: number | string,
+    comments: ReadonlyArray<CanvasSubmissionComment>,
+  ): Promise<CanvasSubmissionComment[]> {
+    const map = this.host ? ((await this.loadCourseMap(this.host, courseId)) ?? null) : null
+    const out: CanvasSubmissionComment[] = []
+    for (const c of comments) {
+      const pseudonym = map?.students[String(c.author_id)]?.pseudonym
+      if (pseudonym) {
+        out.push({ ...c, author_name: pseudonym })
+      } else {
+        out.push({ ...c })
+      }
+    }
+    return out
+  }
+
+  private async loadCourseMap(host: string, courseId: number | string): Promise<CourseMap | null> {
+    const cacheKey = `${host}/${courseId}`
+    const cached = this.courseMaps.get(cacheKey)
+    if (cached) return cached
+    const path = mapFilePath(this.rootDir, host, courseId)
+    const loaded = await loadMap<CourseMap>(path)
+    if (loaded) this.courseMaps.set(cacheKey, loaded)
+    return loaded
+  }
+
+  private async persistCourseMap(
+    host: string,
+    courseId: number | string,
+    map: CourseMap,
+  ): Promise<void> {
+    const path = mapFilePath(this.rootDir, host, courseId)
+    map.generated_at = new Date().toISOString()
+    await saveMap(path, map)
+    this.courseMaps.set(`${host}/${courseId}`, map)
+  }
+
+  private async loadConversationMap(host: string): Promise<ConversationMap | null> {
+    const cacheKey = `${host}/_conversations`
+    const cached = this.conversationMaps.get(cacheKey)
+    if (cached) return cached
+    const path = conversationsFilePath(this.rootDir, host)
+    const loaded = await loadMap<ConversationMap>(path)
+    if (loaded) this.conversationMaps.set(cacheKey, loaded)
+    return loaded
+  }
+
+  private async persistConversationMap(host: string, map: ConversationMap): Promise<void> {
+    const path = conversationsFilePath(this.rootDir, host)
+    map.generated_at = new Date().toISOString()
+    await saveMap(path, map)
+    this.conversationMaps.set(`${host}/_conversations`, map)
+  }
+
+  /**
+   * Serialize work on a per-key basis. Each new task chains off the previous
+   * one so that callers naturally observe FIFO ordering and do not race on
+   * `next_pseudonym_index`.
+   */
+  private withLock<T>(key: string, task: () => Promise<T>): Promise<T> {
+    const prev = this.locks.get(key) ?? Promise.resolve()
+    const next = prev.then(task, task)
+    this.locks.set(
+      key,
+      next.catch(() => undefined),
+    )
+    return next
+  }
+
+  private audit(line: string): void {
+    const stamped = `[${new Date().toISOString()}] canvas-lms-mcp pseudonym ${line}`
+    try {
+      this.auditLog(stamped)
+    } catch (err) {
+      // Never let a logging failure tear down a tool response.
+      console.error('pseudonym audit log failed:', err)
+    }
+    const filePath = this.env.CANVAS_PSEUDONYM_AUDIT_LOG
+    if (filePath) {
+      // Best-effort append; failures are stderr-logged and swallowed.
+      void appendAuditFile(filePath, stamped)
+    }
+  }
+}
+
+function classifyRoleFromEnrollment(enrollment: CanvasEnrollment): Role {
+  return classifyRole({}, [enrollment])
+}
+
+function applyPseudonymToUser(user: CanvasUser, pseudonym: string): CanvasUser {
+  const out: CanvasUser = {
+    ...user,
+    name: pseudonym,
+    short_name: pseudonym,
+    sortable_name: pseudonym,
+  }
+
+  if (user.email !== undefined) {
+    const slug = pseudonym.toLowerCase().replace(/\s+/g, '-')
+    out.email = `${slug}@anon.invalid`
+  }
+  if (user.login_id !== undefined) {
+    out.login_id = pseudonym.toLowerCase().replace(/\s+/g, '-')
+  }
+
+  // Explicit null-out — these would otherwise leak identity.
+  out.sis_user_id = null
+  out.integration_id = null
+  if (user.avatar_url !== undefined) out.avatar_url = undefined
+  if (user.bio !== undefined) out.bio = null
+  if (user.pronouns !== undefined) out.pronouns = null
+  if (user.last_login !== undefined) out.last_login = null
+
+  return out
+}
+
+async function appendAuditFile(filePath: string, line: string): Promise<void> {
+  try {
+    const { appendFile, mkdir } = await import('node:fs/promises')
+    const { dirname } = await import('node:path')
+    await mkdir(dirname(filePath), { recursive: true, mode: 0o700 })
+    await appendFile(filePath, `${line}\n`, { encoding: 'utf8', mode: 0o600 })
+  } catch (err) {
+    console.error('pseudonym audit file append failed:', err)
+  }
+}

--- a/src/pseudonym/roles.ts
+++ b/src/pseudonym/roles.ts
@@ -1,0 +1,61 @@
+// Role classification for pseudonymization.
+//
+// A user is pseudonymized when classified as `student` or `unknown`. Mixed
+// roles (a TA who is also a student in the same course) classify as student —
+// conservative-anonymize. The principle is unknown → student: false positives
+// (a staff member pseudonymized) are visible and fixable; false negatives
+// (a student leaked) are a privacy incident.
+
+import type { CanvasEnrollment, CanvasUser } from '../canvas/types'
+
+export type Role = 'student' | 'staff' | 'unknown'
+
+const STAFF_TYPES = new Set(['TeacherEnrollment', 'TaEnrollment', 'DesignerEnrollment'])
+
+const STUDENT_TYPES = new Set(['StudentEnrollment', 'StudentViewEnrollment'])
+
+/**
+ * Classify a user as student / staff / unknown based on their enrollments
+ * in a course. Pass `enrollments` explicitly when the user object lacks them
+ * (e.g. when the caller fetched enrollments via a separate API call).
+ *
+ * Rules:
+ *   1. Any active `StudentEnrollment` → `student` (wins over staff).
+ *   2. Any `TeacherEnrollment` / `TaEnrollment` / `DesignerEnrollment` → `staff`.
+ *   3. Otherwise `unknown`.
+ *
+ * `ObserverEnrollment` alone does not classify as either; observers are
+ * typically parents and should not see student PII, but they are not the
+ * subject we are pseudonymizing — treat as unknown (conservative).
+ */
+export function classifyRole(
+  user: Pick<CanvasUser, 'enrollments'>,
+  enrollments?: ReadonlyArray<CanvasEnrollment>,
+): Role {
+  const list = enrollments ?? user.enrollments ?? []
+  if (list.length === 0) return 'unknown'
+
+  let sawStudent = false
+  let sawStaff = false
+  for (const e of list) {
+    const type = e.type
+    if (!type) continue
+    if (STUDENT_TYPES.has(type)) {
+      sawStudent = true
+    } else if (STAFF_TYPES.has(type)) {
+      sawStaff = true
+    }
+  }
+
+  if (sawStudent) return 'student'
+  if (sawStaff) return 'staff'
+  return 'unknown'
+}
+
+/**
+ * Does this role get pseudonymized when the flag is on?
+ * Unknown classifies as needing pseudonymization (conservative).
+ */
+export function shouldPseudonymize(role: Role): boolean {
+  return role !== 'staff'
+}

--- a/src/pseudonym/store.ts
+++ b/src/pseudonym/store.ts
@@ -1,0 +1,121 @@
+// Filesystem read/write for pseudonym maps.
+//
+// On-disk shape (file per <host>/<course_id>.json):
+//
+// {
+//   "version": 1,
+//   "host": "school.instructure.com",
+//   "course_id": 12345,
+//   "generated_at": "2026-05-25T14:00:00Z",
+//   "next_pseudonym_index": 28,
+//   "students": {
+//     "98765": { "pseudonym": "Student 1", "status": "active",     "first_seen": "2026-02-03T..." },
+//     "98770": { "pseudonym": "Student 3", "status": "historical", "first_seen": "2026-02-10T...",
+//                "marked_historical_at": "2026-05-01T..." }
+//   }
+// }
+//
+// Writes are atomic: write to <file>.tmp-<rand> then rename over the target.
+// Directory created 0o700, file created 0o600 (best-effort on Windows).
+
+import { mkdir, readFile, rename, writeFile, chmod } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+export const CURRENT_MAP_VERSION = 1
+
+export type StudentStatus = 'active' | 'historical'
+
+export interface StudentEntry {
+  pseudonym: string
+  status: StudentStatus
+  first_seen: string
+  marked_historical_at?: string
+}
+
+export interface CourseMap {
+  version: number
+  host: string
+  course_id: number | string
+  generated_at: string
+  next_pseudonym_index: number
+  /** Keyed by Canvas user_id as a string. */
+  students: Record<string, StudentEntry>
+}
+
+export interface ConversationMap {
+  version: number
+  host: string
+  generated_at: string
+  next_pseudonym_index: number
+  participants: Record<string, StudentEntry>
+}
+
+/** Create an empty CourseMap for a fresh allocation cycle. */
+export function emptyCourseMap(host: string, courseId: number | string): CourseMap {
+  return {
+    version: CURRENT_MAP_VERSION,
+    host,
+    course_id: courseId,
+    generated_at: new Date().toISOString(),
+    next_pseudonym_index: 1,
+    students: {},
+  }
+}
+
+/** Create an empty cross-course conversations map. */
+export function emptyConversationMap(host: string): ConversationMap {
+  return {
+    version: CURRENT_MAP_VERSION,
+    host,
+    generated_at: new Date().toISOString(),
+    next_pseudonym_index: 1,
+    participants: {},
+  }
+}
+
+/**
+ * Load a JSON map from disk. Returns `null` when the file does not exist.
+ * Throws on permission errors or malformed JSON — those are operator-fixable
+ * misconfigurations and silent fallback would mask them.
+ */
+export async function loadMap<T>(filePath: string): Promise<T | null> {
+  try {
+    const raw = await readFile(filePath, 'utf8')
+    return JSON.parse(raw) as T
+  } catch (err) {
+    if (isNoEntError(err)) return null
+    throw err
+  }
+}
+
+/**
+ * Write a JSON map to disk atomically. Creates parent directories with 0o700
+ * and writes the file with 0o600. On Windows these modes are best-effort —
+ * `fs.chmod` succeeds but POSIX semantics do not apply; documented in the
+ * design doc.
+ */
+export async function saveMap(filePath: string, data: unknown): Promise<void> {
+  const dir = dirname(filePath)
+  await mkdir(dir, { recursive: true, mode: 0o700 })
+
+  const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+  const json = JSON.stringify(data, null, 2)
+
+  await writeFile(tmpPath, json, { encoding: 'utf8', mode: 0o600 })
+  // Best-effort tighten in case the umask widened the mode. Ignore failures.
+  try {
+    await chmod(tmpPath, 0o600)
+  } catch {
+    // Windows or restricted FS — fall through; mode is best-effort.
+  }
+  await rename(tmpPath, filePath)
+}
+
+function isNoEntError(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code?: string }).code === 'ENOENT'
+  )
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,17 +1,28 @@
 import { version } from '../package.json'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { CanvasClient } from './canvas'
+import { Pseudonymizer } from './pseudonym/pseudonymizer'
 import { registerAllTools } from './tools'
 import { registerAllResources } from './resources'
 
 export interface CanvasMCPServerConfig {
   token: string
   baseUrl: string
+  /**
+   * Optional pseudonymizer instance. Passed through to the tool layer so the
+   * `_meta.pseudonymized` envelope and the `resolve_pseudonym` tool registration
+   * are driven by it. Defaults to a fresh instance keyed on `baseUrl` — the
+   * default is sufficient for stdio. HTTP transports should construct their own
+   * process-wide singleton (one map per host/course on disk) and reuse it
+   * across requests.
+   */
+  pseudonymizer?: Pseudonymizer
 }
 
 export interface CanvasMCPServer {
   server: McpServer
   canvas: CanvasClient
+  pseudonymizer: Pseudonymizer
 }
 
 export function createCanvasMCPServer(config: CanvasMCPServerConfig): CanvasMCPServer {
@@ -20,13 +31,15 @@ export function createCanvasMCPServer(config: CanvasMCPServerConfig): CanvasMCPS
     baseUrl: config.baseUrl,
   })
 
+  const pseudonymizer = config.pseudonymizer ?? new Pseudonymizer({ baseUrl: config.baseUrl })
+
   const server = new McpServer({
     name: 'canvas-lms-mcp',
     version,
   })
 
-  registerAllTools(server, canvas)
+  registerAllTools(server, canvas, pseudonymizer)
   registerAllResources(server, canvas)
 
-  return { server, canvas }
+  return { server, canvas, pseudonymizer }
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,16 +1,27 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { CanvasClient } from '../canvas'
 import { CanvasApiError } from '../canvas/client'
+import type { Pseudonymizer } from '../pseudonym/pseudonymizer'
 import type { ToolDefinition } from './types'
 import { toolDomainCatalog } from './catalog'
 import { formatError } from './errors'
+import { pseudonymTools } from './pseudonym'
 
-export function getAllTools(canvas: CanvasClient): ToolDefinition[] {
-  return toolDomainCatalog.flatMap((registration) => registration.getTools(canvas))
+const PSEUDONYM_META_NOTE =
+  'Student names and contact info in this response have been replaced with stable pseudonyms (CANVAS_PSEUDONYMIZE_STUDENTS=true). Real names are not available to this tool.'
+
+export function getAllTools(canvas: CanvasClient, pseudonymizer?: Pseudonymizer): ToolDefinition[] {
+  const domainTools = toolDomainCatalog.flatMap((registration) => registration.getTools(canvas))
+  const conditional = pseudonymizer ? pseudonymTools(pseudonymizer) : []
+  return [...domainTools, ...conditional]
 }
 
-export function registerAllTools(server: McpServer, canvas: CanvasClient): void {
-  const tools = getAllTools(canvas)
+export function registerAllTools(
+  server: McpServer,
+  canvas: CanvasClient,
+  pseudonymizer?: Pseudonymizer,
+): void {
+  const tools = getAllTools(canvas, pseudonymizer)
   for (const tool of tools) {
     server.tool(tool.name, tool.description, tool.inputSchema, tool.annotations, async (params) => {
       try {
@@ -19,9 +30,16 @@ export function registerAllTools(server: McpServer, canvas: CanvasClient): void 
           result === undefined
             ? 'Operation completed successfully.'
             : JSON.stringify(result, null, 2)
-        return {
+        const response: {
+          content: { type: 'text'; text: string }[]
+          _meta?: Record<string, unknown>
+        } = {
           content: [{ type: 'text' as const, text }],
         }
+        if (pseudonymizer?.isEnabled()) {
+          response._meta = { pseudonymized: true, note: PSEUDONYM_META_NOTE }
+        }
+        return response
       } catch (error) {
         if (error instanceof CanvasApiError) {
           // CanvasApiError — expected, no need to log

--- a/src/tools/pseudonym.ts
+++ b/src/tools/pseudonym.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod'
+import type { Pseudonymizer } from '../pseudonym/pseudonymizer'
+import type { ToolDefinition } from './types'
+
+/**
+ * Tools that depend on the pseudonymizer. Currently the single conditional
+ * `resolve_pseudonym` reverse-lookup tool.
+ *
+ * Registration is conditional on env vars:
+ *  - `CANVAS_PSEUDONYMIZE_STUDENTS=true` AND
+ *  - `CANVAS_PSEUDONYMIZE_REVERSE_LOOKUP=true`
+ *
+ * When either is unset, the tool is NOT registered — it is absent from
+ * `tools/list` entirely. That is stronger than "registered but errors out":
+ * the MCP protocol layer refuses the call before it reaches us.
+ */
+export function pseudonymTools(pseudonymizer: Pseudonymizer): ToolDefinition[] {
+  if (!pseudonymizer.isReverseLookupEnabled()) return []
+
+  return [
+    {
+      name: 'resolve_pseudonym',
+      description:
+        'Resolve a stable pseudonym (e.g. "Student 7") back to a Canvas user_id within a course. Use only when a teacher has explicitly asked to identify a specific student in an artifact. Every call is audit-logged.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID the pseudonym was assigned in'),
+        pseudonym: z.string().describe('The pseudonym to resolve, e.g. "Student 7"'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+        const pseudonym = params.pseudonym as string
+        const result = await pseudonymizer.reverseLookup(courseId, pseudonym)
+        if (!result) {
+          return {
+            found: false,
+            note: 'No pseudonym matched in the course map. Check the course_id and the exact pseudonym spelling.',
+          }
+        }
+        return {
+          found: true,
+          user_id: result.user_id,
+          pseudonym: result.pseudonym,
+          status: result.status,
+          note: 'Reverse lookup is audit-logged. Use the returned user_id only for the explicit identification the teacher asked for.',
+        }
+      },
+    },
+  ]
+}

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -207,10 +207,12 @@ describe('createHttpHandler', () => {
       const req = createMockReq({ method: 'POST', url: '/mcp' })
       const res = createMockRes()
       await handler(req, res)
-      expect(createCanvasMCPServer).toHaveBeenCalledWith({
-        token: 'test-token',
-        baseUrl: 'https://canvas.example.com/api/v1',
-      })
+      expect(createCanvasMCPServer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: 'test-token',
+          baseUrl: 'https://canvas.example.com/api/v1',
+        }),
+      )
     })
   })
 })

--- a/tests/pseudonym/coverage.test.ts
+++ b/tests/pseudonym/coverage.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest'
+import type { CanvasClient } from '../../src/canvas'
+import { PSEUDONYMIZER_WRAPPED_TOOLS } from '../../src/pseudonym/coverage'
+import { Pseudonymizer } from '../../src/pseudonym/pseudonymizer'
+import { getAllTools } from '../../src/tools'
+
+// Mirror of the catalog list — kept in sync with src/pseudonym/coverage.ts so
+// that adding a PII-bearing tool requires touching BOTH files. If a future
+// developer wires up a new tool that returns CanvasUser / participants /
+// user_name and forgets to update either list, CI fails here.
+const EXPECTED_PII_BEARING_TOOLS = new Set([
+  'list_students',
+  'get_user',
+  'search_users',
+  'list_course_users',
+  'list_account_users',
+  'list_enrollments',
+  'list_course_enrollments',
+  'list_submissions',
+  'get_submission',
+  'list_conversations',
+  'get_conversation',
+  'list_gradebook_history_submissions',
+  'get_gradebook_history_feed',
+  'get_outcome_results',
+  'get_outcome_rollups',
+  'list_group_members',
+])
+
+function buildMinimalCanvas(): CanvasClient {
+  const noop = async () => ({})
+  const list = async () => []
+  return {
+    courses: { list, get: noop, getSyllabus: noop, create: noop, update: noop },
+    assignments: { list, get: noop, listGroups: list, create: noop, update: noop, delete: noop },
+    submissions: { list, get: noop, grade: noop, comment: noop, listMy: list },
+    rubrics: { list, get: noop, getAssessment: noop, submitAssessment: noop, create: noop },
+    quizzes: {
+      list,
+      get: noop,
+      listSubmissions: list,
+      listQuestions: list,
+      getSubmissionAnswers: list,
+      scoreQuestion: noop,
+    },
+    files: { list, listFolders: list, get: noop, upload: noop, delete: noop, download: noop },
+    gradebookHistory: { listDays: list, getDay: list, listSubmissions: list, getFeed: list },
+    users: {
+      listStudents: list,
+      get: noop,
+      getProfile: noop,
+      searchUsers: list,
+      listCourseUsers: list,
+      getUpcomingAssignments: list,
+    },
+    groups: { list, listMembers: list },
+    enrollments: { list, listForCourse: list, enroll: noop, remove: noop, listMyGrades: list },
+    discussions: {
+      list,
+      get: noop,
+      listAnnouncements: list,
+      postEntry: noop,
+      create: noop,
+      update: noop,
+      delete: noop,
+    },
+    modules: {
+      list,
+      get: noop,
+      listItems: list,
+      getCourseStructure: async () => ({
+        modules: [],
+        summary: { total_modules: 0, total_items: 0, items_by_type: {} },
+      }),
+      create: noop,
+      update: noop,
+      createItem: noop,
+    },
+    pages: { list, get: noop, create: noop, update: noop, delete: noop },
+    calendar: { list, createEvent: noop, updateEvent: noop },
+    conversations: {
+      list,
+      get: noop,
+      getUnreadCount: async () => ({ unread_count: 0 }),
+      send: list,
+    },
+    peerReviews: { listForAssignment: list, listForSubmission: list, create: noop, delete: noop },
+    accounts: {
+      get: noop,
+      list,
+      listSubAccounts: list,
+      listCourses: list,
+      listUsers: list,
+      getReports: list,
+    },
+    analytics: {
+      searchContentType: list,
+      getCourseActivity: list,
+      getStudentActivity: noop,
+      getCourseActivityStream: list,
+    },
+    outcomes: {
+      getRootOutcomeGroup: noop,
+      listOutcomeGroups: list,
+      listOutcomeGroupLinks: list,
+      getOutcomeGroup: noop,
+      listGroupOutcomes: list,
+      listGroupSubgroups: list,
+      getOutcome: noop,
+      getOutcomeAlignments: list,
+      getOutcomeResults: async () => ({ outcome_results: [] }),
+      getOutcomeRollups: async () => ({ rollups: [] }),
+      getOutcomeContributingScores: async () => ({ scores: [] }),
+      getOutcomeMasteryDistribution: async () => ({ outcomes: [] }),
+    },
+    dashboard: {
+      getDashboardCards: list,
+      getTodoItems: list,
+      getUpcomingEvents: list,
+      getMissingSubmissions: list,
+    },
+    newQuizzes: {
+      create: noop,
+      update: noop,
+      delete: noop,
+      listItems: list,
+      getItem: noop,
+      createItem: noop,
+      updateItem: noop,
+      deleteItem: noop,
+    },
+  } as unknown as CanvasClient
+}
+
+describe('pseudonymizer coverage lint', () => {
+  it('every name in PSEUDONYMIZER_WRAPPED_TOOLS is a registered tool', () => {
+    const tools = getAllTools(buildMinimalCanvas())
+    const names = new Set(tools.map((t) => t.name))
+    const missing = PSEUDONYMIZER_WRAPPED_TOOLS.filter((n) => !names.has(n))
+    expect(missing).toEqual([])
+  })
+
+  it('PSEUDONYMIZER_WRAPPED_TOOLS matches the expected PII-bearing-tool set exactly', () => {
+    // Both sides hand-maintained; mismatch = a tool was added/wrapped without
+    // updating the other list (or vice versa).
+    const wrapped = new Set(PSEUDONYMIZER_WRAPPED_TOOLS)
+    const onlyInWrap = [...wrapped].filter((n) => !EXPECTED_PII_BEARING_TOOLS.has(n))
+    const onlyInExpected = [...EXPECTED_PII_BEARING_TOOLS].filter((n) => !wrapped.has(n))
+    expect({ onlyInWrap, onlyInExpected }).toEqual({ onlyInWrap: [], onlyInExpected: [] })
+  })
+
+  it('resolve_pseudonym is only registered when reverse lookup env is on', () => {
+    const canvas = buildMinimalCanvas()
+
+    const off = new Pseudonymizer({ baseUrl: 'https://h.example/api/v1', env: {} })
+    expect(getAllTools(canvas, off).find((t) => t.name === 'resolve_pseudonym')).toBeUndefined()
+
+    const partial = new Pseudonymizer({
+      baseUrl: 'https://h.example/api/v1',
+      env: { CANVAS_PSEUDONYMIZE_STUDENTS: 'true' },
+    })
+    expect(getAllTools(canvas, partial).find((t) => t.name === 'resolve_pseudonym')).toBeUndefined()
+
+    const on = new Pseudonymizer({
+      baseUrl: 'https://h.example/api/v1',
+      env: {
+        CANVAS_PSEUDONYMIZE_STUDENTS: 'true',
+        CANVAS_PSEUDONYMIZE_REVERSE_LOOKUP: 'true',
+      },
+    })
+    expect(getAllTools(canvas, on).find((t) => t.name === 'resolve_pseudonym')).toBeDefined()
+  })
+})

--- a/tests/pseudonym/paths.test.ts
+++ b/tests/pseudonym/paths.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import {
+  resolvePseudonymDir,
+  normalizeHost,
+  mapFilePath,
+  conversationsFilePath,
+} from '../../src/pseudonym/paths'
+
+describe('resolvePseudonymDir', () => {
+  it('honors CANVAS_PSEUDONYM_DIR override on every platform', () => {
+    for (const platform of ['linux', 'darwin', 'win32'] as const) {
+      const dir = resolvePseudonymDir({
+        platform,
+        env: { CANVAS_PSEUDONYM_DIR: '/custom/path' },
+        home: '/home/test',
+      })
+      expect(dir).toBe('/custom/path')
+    }
+  })
+
+  it('uses XDG_DATA_HOME on Linux when set', () => {
+    const dir = resolvePseudonymDir({
+      platform: 'linux',
+      env: { XDG_DATA_HOME: '/xdg/data' },
+      home: '/home/test',
+    })
+    expect(dir).toContain('xdg')
+    expect(dir).toContain('canvas-lms-mcp')
+    expect(dir).toContain('pseudonyms')
+  })
+
+  it('falls back to ~/.local/share on Linux without XDG', () => {
+    const dir = resolvePseudonymDir({
+      platform: 'linux',
+      env: {},
+      home: '/home/test',
+    })
+    expect(dir.replace(/\\/g, '/')).toBe('/home/test/.local/share/canvas-lms-mcp/pseudonyms')
+  })
+
+  it('uses Application Support on macOS', () => {
+    const dir = resolvePseudonymDir({
+      platform: 'darwin',
+      env: {},
+      home: '/Users/test',
+    })
+    expect(dir.replace(/\\/g, '/')).toBe(
+      '/Users/test/Library/Application Support/canvas-lms-mcp/pseudonyms',
+    )
+  })
+
+  it('uses %APPDATA% on Windows', () => {
+    const dir = resolvePseudonymDir({
+      platform: 'win32',
+      env: { APPDATA: 'C:\\Users\\test\\AppData\\Roaming' },
+      home: 'C:\\Users\\test',
+    })
+    expect(dir.replace(/\\/g, '/')).toBe('C:/Users/test/AppData/Roaming/canvas-lms-mcp/pseudonyms')
+  })
+
+  it('falls back to USERPROFILE on Windows when APPDATA missing', () => {
+    const dir = resolvePseudonymDir({
+      platform: 'win32',
+      env: { USERPROFILE: 'C:\\Users\\test' },
+      home: 'C:\\Users\\test',
+    })
+    expect(dir.replace(/\\/g, '/')).toContain('AppData/Roaming/canvas-lms-mcp/pseudonyms')
+  })
+
+  it('treats empty CANVAS_PSEUDONYM_DIR as unset', () => {
+    const dir = resolvePseudonymDir({
+      platform: 'linux',
+      env: { CANVAS_PSEUDONYM_DIR: '' },
+      home: '/home/test',
+    })
+    expect(dir).not.toBe('')
+    expect(dir).toContain('canvas-lms-mcp')
+  })
+})
+
+describe('normalizeHost', () => {
+  it('returns lower-cased hostname without port', () => {
+    expect(normalizeHost('https://School.Instructure.COM:443/api/v1')).toBe(
+      'school.instructure.com',
+    )
+  })
+
+  it('strips path and trailing slash', () => {
+    expect(normalizeHost('https://school.instructure.com/api/v1')).toBe('school.instructure.com')
+  })
+
+  it('returns null for unparseable URLs', () => {
+    expect(normalizeHost('not a url')).toBeNull()
+  })
+})
+
+describe('mapFilePath / conversationsFilePath', () => {
+  it('joins host and course_id into a .json file', () => {
+    const p = mapFilePath('/root', 'school.instructure.com', 12345)
+    expect(p.replace(/\\/g, '/')).toBe('/root/school.instructure.com/12345.json')
+  })
+
+  it('uses _conversations.json for the cross-course pool', () => {
+    const p = conversationsFilePath('/root', 'school.instructure.com')
+    expect(p.replace(/\\/g, '/')).toBe('/root/school.instructure.com/_conversations.json')
+  })
+})

--- a/tests/pseudonym/pseudonymizer.test.ts
+++ b/tests/pseudonym/pseudonymizer.test.ts
@@ -1,0 +1,461 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Pseudonymizer } from '../../src/pseudonym/pseudonymizer'
+import { mapFilePath } from '../../src/pseudonym/paths'
+import type { CourseMap } from '../../src/pseudonym/store'
+import type { CanvasEnrollment, CanvasSubmission, CanvasUser } from '../../src/canvas/types'
+
+const BASE_URL = 'https://school.instructure.com/api/v1'
+const HOST = 'school.instructure.com'
+const COURSE_ID = 101
+
+function studentEnrollment(): CanvasEnrollment {
+  return {
+    id: 1,
+    user_id: 0,
+    course_id: COURSE_ID,
+    type: 'StudentEnrollment',
+    enrollment_state: 'active',
+    role: 'StudentEnrollment',
+    role_id: 1,
+  } as CanvasEnrollment
+}
+
+function teacherEnrollment(): CanvasEnrollment {
+  return {
+    id: 2,
+    user_id: 0,
+    course_id: COURSE_ID,
+    type: 'TeacherEnrollment',
+    enrollment_state: 'active',
+    role: 'TeacherEnrollment',
+    role_id: 2,
+  } as CanvasEnrollment
+}
+
+function student(id: number, name: string, extra: Partial<CanvasUser> = {}): CanvasUser {
+  return {
+    id,
+    name,
+    sortable_name: name,
+    short_name: name.split(' ')[0],
+    email: `${name.replace(/\s+/g, '.').toLowerCase()}@example.edu`,
+    login_id: name.replace(/\s+/g, '.').toLowerCase(),
+    sis_user_id: `SIS-${id}`,
+    bio: 'A real bio',
+    pronouns: 'they/them',
+    last_login: '2026-05-20T10:00:00Z',
+    avatar_url: 'https://canvas.example/avatars/x.png',
+    enrollments: [{ ...studentEnrollment(), user_id: id }],
+    ...extra,
+  }
+}
+
+function teacher(id: number, name: string): CanvasUser {
+  return {
+    id,
+    name,
+    sortable_name: name,
+    short_name: name.split(' ')[0],
+    email: `${name}@example.edu`,
+    enrollments: [{ ...teacherEnrollment(), user_id: id }],
+  }
+}
+
+let tmpRoot: string
+let env: NodeJS.ProcessEnv
+
+beforeEach(async () => {
+  tmpRoot = await mkdtemp(join(tmpdir(), 'pseudonymizer-'))
+  env = { CANVAS_PSEUDONYMIZE_STUDENTS: 'true' }
+})
+
+afterEach(async () => {
+  await rm(tmpRoot, { recursive: true, force: true })
+})
+
+function make(overrides: Partial<{ env: NodeJS.ProcessEnv; rootDir: string }> = {}) {
+  return new Pseudonymizer({
+    baseUrl: BASE_URL,
+    rootDir: overrides.rootDir ?? tmpRoot,
+    env: overrides.env ?? env,
+    auditLog: () => undefined,
+  })
+}
+
+describe('isEnabled / isReverseLookupEnabled', () => {
+  it('is disabled when CANVAS_PSEUDONYMIZE_STUDENTS unset', () => {
+    const p = make({ env: {} })
+    expect(p.isEnabled()).toBe(false)
+    expect(p.isReverseLookupEnabled()).toBe(false)
+  })
+
+  it.each(['true', '1', 'yes', 'on', 'TRUE', 'Yes'])('treats %s as truthy', (val) => {
+    const p = make({ env: { CANVAS_PSEUDONYMIZE_STUDENTS: val } })
+    expect(p.isEnabled()).toBe(true)
+  })
+
+  it.each(['false', '0', 'no', 'off', '', 'maybe'])('treats %s as falsy', (val) => {
+    const p = make({ env: { CANVAS_PSEUDONYMIZE_STUDENTS: val } })
+    expect(p.isEnabled()).toBe(false)
+  })
+
+  it('requires both env vars for reverse lookup', () => {
+    expect(make({ env: { CANVAS_PSEUDONYMIZE_STUDENTS: 'true' } }).isReverseLookupEnabled()).toBe(
+      false,
+    )
+    expect(
+      make({ env: { CANVAS_PSEUDONYMIZE_REVERSE_LOOKUP: 'true' } }).isReverseLookupEnabled(),
+    ).toBe(false)
+    expect(
+      make({
+        env: { CANVAS_PSEUDONYMIZE_STUDENTS: 'true', CANVAS_PSEUDONYMIZE_REVERSE_LOOKUP: 'true' },
+      }).isReverseLookupEnabled(),
+    ).toBe(true)
+  })
+})
+
+describe('pass-through when disabled', () => {
+  it('returns users unchanged when the flag is off', async () => {
+    const p = make({ env: {} })
+    const u = student(1, 'Alice Smith')
+    const out = await p.anonymizeUser(COURSE_ID, u)
+    expect(out).toBe(u)
+  })
+
+  it('returns users unchanged when the base URL is unparseable', async () => {
+    const p = new Pseudonymizer({
+      baseUrl: 'not a url',
+      rootDir: tmpRoot,
+      env,
+      auditLog: () => undefined,
+    })
+    const u = student(1, 'Alice Smith')
+    expect(await p.anonymizeUser(COURSE_ID, u)).toBe(u)
+  })
+})
+
+describe('anonymizeUser', () => {
+  it('replaces name and contact fields with stable pseudonym', async () => {
+    const p = make()
+    const out = await p.anonymizeUser(COURSE_ID, student(1, 'Alice Smith'))
+    expect(out.name).toBe('Student 1')
+    expect(out.short_name).toBe('Student 1')
+    expect(out.sortable_name).toBe('Student 1')
+    expect(out.email).toBe('student-1@anon.invalid')
+    expect(out.login_id).toBe('student-1')
+    expect(out.sis_user_id).toBeNull()
+    expect(out.bio).toBeNull()
+    expect(out.pronouns).toBeNull()
+    expect(out.last_login).toBeNull()
+    expect(out.avatar_url).toBeUndefined()
+  })
+
+  it('passes staff (teacher) users through unchanged', async () => {
+    const p = make()
+    const t = teacher(99, 'Prof Jones')
+    expect(await p.anonymizeUser(COURSE_ID, t)).toBe(t)
+  })
+
+  it('pseudonymizes users with no enrollments (unknown → student)', async () => {
+    const p = make()
+    const u: CanvasUser = { id: 5, name: 'Mystery Person' }
+    const out = await p.anonymizeUser(COURSE_ID, u)
+    expect(out.name).toBe('Student 1')
+  })
+
+  it('treats mixed (TA + Student) enrollments as student', async () => {
+    const p = make()
+    const u = student(7, 'Mixed Role')
+    u.enrollments = [
+      { ...teacherEnrollment(), user_id: 7, type: 'TaEnrollment' },
+      { ...studentEnrollment(), user_id: 7 },
+    ]
+    const out = await p.anonymizeUser(COURSE_ID, u)
+    expect(out.name).toBe('Student 1')
+  })
+
+  it('reuses the same pseudonym across calls (stability)', async () => {
+    const p = make()
+    const first = await p.anonymizeUser(COURSE_ID, student(1, 'Alice'))
+    const second = await p.anonymizeUser(COURSE_ID, student(1, 'Alice renamed in Canvas'))
+    expect(first.name).toBe(second.name)
+  })
+
+  it('assigns distinct pseudonyms to distinct students in arrival order', async () => {
+    const p = make()
+    const a = await p.anonymizeUser(COURSE_ID, student(1, 'Alice'))
+    const b = await p.anonymizeUser(COURSE_ID, student(2, 'Bob'))
+    const c = await p.anonymizeUser(COURSE_ID, student(3, 'Carol'))
+    expect([a.name, b.name, c.name]).toEqual(['Student 1', 'Student 2', 'Student 3'])
+  })
+})
+
+describe('anonymizeUsers (array)', () => {
+  it('pseudonymizes a list and pass-through teachers', async () => {
+    const p = make()
+    const out = await p.anonymizeUsers(COURSE_ID, [
+      student(1, 'Alice'),
+      teacher(99, 'Prof Jones'),
+      student(2, 'Bob'),
+    ])
+    expect(out.map((u) => u.name)).toEqual(['Student 1', 'Prof Jones', 'Student 2'])
+  })
+})
+
+describe('persistence', () => {
+  it('writes the map to disk and reuses pseudonyms across instances', async () => {
+    const p1 = make()
+    await p1.anonymizeUser(COURSE_ID, student(1, 'Alice'))
+    await p1.anonymizeUser(COURSE_ID, student(2, 'Bob'))
+
+    const file = mapFilePath(tmpRoot, HOST, COURSE_ID)
+    const raw = await readFile(file, 'utf8')
+    const map = JSON.parse(raw) as CourseMap
+    expect(map.next_pseudonym_index).toBe(3)
+    expect(Object.keys(map.students)).toEqual(['1', '2'])
+
+    const p2 = make()
+    const reloaded = await p2.anonymizeUser(COURSE_ID, student(1, 'Alice'))
+    expect(reloaded.name).toBe('Student 1')
+  })
+
+  it('keys files per base-URL host', async () => {
+    const pA = new Pseudonymizer({
+      baseUrl: 'https://school-a.instructure.com/api/v1',
+      rootDir: tmpRoot,
+      env,
+      auditLog: () => undefined,
+    })
+    const pB = new Pseudonymizer({
+      baseUrl: 'https://school-b.instructure.com/api/v1',
+      rootDir: tmpRoot,
+      env,
+      auditLog: () => undefined,
+    })
+    await pA.anonymizeUser(COURSE_ID, student(1, 'Alice'))
+    await pB.anonymizeUser(COURSE_ID, student(1, 'Different Alice'))
+
+    const { readdir } = await import('node:fs/promises')
+    const entries = await readdir(tmpRoot)
+    expect(entries.sort()).toEqual(['school-a.instructure.com', 'school-b.instructure.com'])
+  })
+})
+
+describe('historical / re-enrollment', () => {
+  it('marks dropped students historical when their entry is manually edited (round-trip)', async () => {
+    const p = make()
+    // Allocate Student 1, then simulate drop by writing the on-disk map manually.
+    await p.anonymizeUser(COURSE_ID, student(1, 'Alice'))
+    const file = mapFilePath(tmpRoot, HOST, COURSE_ID)
+    const map = JSON.parse(await readFile(file, 'utf8')) as CourseMap
+    expect(map.students['1']?.pseudonym).toBe('Student 1')
+
+    // Manual operator edit: mark Alice historical.
+    map.students['1'] = {
+      ...map.students['1']!,
+      status: 'historical',
+      marked_historical_at: '2026-05-01T00:00:00Z',
+    }
+    const { writeFile } = await import('node:fs/promises')
+    await writeFile(file, JSON.stringify(map), 'utf8')
+
+    // New student joins — must get next index, NOT Alice's slot.
+    const p2 = make()
+    const newStudent = await p2.anonymizeUser(COURSE_ID, student(2, 'Bob'))
+    expect(newStudent.name).toBe('Student 2')
+
+    // Re-enroll Alice — must restore Student 1, status active.
+    const restored = await p2.anonymizeUser(COURSE_ID, student(1, 'Alice'))
+    expect(restored.name).toBe('Student 1')
+    const after = JSON.parse(await readFile(file, 'utf8')) as CourseMap
+    expect(after.students['1']?.status).toBe('active')
+    expect(after.students['1']?.marked_historical_at).toBeUndefined()
+  })
+})
+
+describe('concurrency', () => {
+  it('serializes concurrent allocations so each user gets a unique pseudonym', async () => {
+    const p = make()
+    const students = Array.from({ length: 25 }, (_, i) => student(i + 1, `Student${i + 1}`))
+    const results = await Promise.all(students.map((s) => p.anonymizeUser(COURSE_ID, s)))
+    const pseudonyms = new Set(results.map((r) => r.name))
+    expect(pseudonyms.size).toBe(25)
+    // Pseudonyms are exactly Student 1..25 in some order.
+    expect([...pseudonyms].sort()).toEqual(
+      Array.from({ length: 25 }, (_, i) => `Student ${i + 1}`).sort(),
+    )
+  })
+})
+
+describe('anonymizeEnrollment', () => {
+  it('nulls sis_user_id and rewrites embedded user for student enrollment', async () => {
+    const p = make()
+    const e: CanvasEnrollment = {
+      ...studentEnrollment(),
+      user_id: 1,
+      sis_user_id: 'SIS-1',
+      user: student(1, 'Alice'),
+    }
+    const out = await p.anonymizeEnrollment(COURSE_ID, e)
+    expect(out.sis_user_id).toBeNull()
+    expect(out.user?.name).toBe('Student 1')
+  })
+
+  it('passes teacher enrollment through unchanged', async () => {
+    const p = make()
+    const e: CanvasEnrollment = {
+      ...teacherEnrollment(),
+      user_id: 99,
+      sis_user_id: 'SIS-99',
+      user: teacher(99, 'Prof Jones'),
+    }
+    const out = await p.anonymizeEnrollment(COURSE_ID, e)
+    expect(out.sis_user_id).toBe('SIS-99')
+    expect(out.user?.name).toBe('Prof Jones')
+  })
+})
+
+describe('anonymizeSubmission', () => {
+  it('rewrites submission.user and student-authored comments by reusing the course pseudonym', async () => {
+    const p = make()
+    // First, allocate Student 1 for user 1 (so the comment author is known).
+    await p.anonymizeUser(COURSE_ID, student(1, 'Alice'))
+
+    const submission: CanvasSubmission = {
+      id: 10,
+      assignment_id: 5,
+      user_id: 1,
+      submitted_at: '2026-05-20T00:00:00Z',
+      score: null,
+      grade: null,
+      body: null,
+      url: null,
+      attempt: 1,
+      workflow_state: 'submitted',
+      user: student(1, 'Alice'),
+      submission_comments: [
+        { id: 50, author_id: 1, author_name: 'Alice', comment: 'My work', created_at: '...' },
+        { id: 51, author_id: 99, author_name: 'Prof Jones', comment: 'Good', created_at: '...' },
+      ],
+    }
+
+    const out = await p.anonymizeSubmission(COURSE_ID, submission)
+    expect(out.user?.name).toBe('Student 1')
+    expect(out.submission_comments?.[0]?.author_name).toBe('Student 1')
+    // Author 99 has no pseudonym in the map — pass through unchanged.
+    expect(out.submission_comments?.[1]?.author_name).toBe('Prof Jones')
+  })
+})
+
+describe('anonymizeConversation', () => {
+  it('rewrites all participants using the cross-course pool', async () => {
+    const p = make()
+    const conv = {
+      id: 1,
+      subject: 'Hello',
+      last_message: 'hi',
+      last_message_at: '2026-05-20T00:00:00Z',
+      message_count: 1,
+      participants: [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+      ],
+    }
+    const out = await p.anonymizeConversation(conv)
+    expect(out.participants[0]?.name).toBe('Person 1')
+    expect(out.participants[1]?.name).toBe('Person 2')
+
+    // Same id → same name on a second call.
+    const out2 = await p.anonymizeConversation(conv)
+    expect(out2.participants[0]?.name).toBe('Person 1')
+  })
+})
+
+describe('anonymizeOutcomeResults', () => {
+  it('pseudonymizes linked.users while leaving everything else intact', async () => {
+    const p = make()
+    const response = {
+      outcome_results: [
+        {
+          id: 1,
+          score: 0.8,
+          submitted_or_assessed_at: null,
+          links: { user: 1, learning_outcome: 1, alignment: 1 },
+          percent: null,
+        },
+      ],
+      linked: {
+        users: [student(1, 'Alice'), student(2, 'Bob')],
+        outcomes: [],
+      },
+    } as unknown as Parameters<typeof p.anonymizeOutcomeResults>[1]
+
+    const out = await p.anonymizeOutcomeResults(COURSE_ID, response)
+    expect(out.linked?.users?.map((u) => u.name)).toEqual(['Student 1', 'Student 2'])
+    expect(out.outcome_results).toEqual(response.outcome_results)
+  })
+
+  it('passes responses without linked.users through unchanged', async () => {
+    const p = make()
+    const response = { outcome_results: [], linked: {} }
+    const out = await p.anonymizeOutcomeResults(COURSE_ID, response)
+    expect(out).toBe(response)
+  })
+})
+
+describe('reverseLookup', () => {
+  it('returns null when reverse lookup is disabled', async () => {
+    const p = make({ env: { CANVAS_PSEUDONYMIZE_STUDENTS: 'true' } })
+    await p.anonymizeUser(COURSE_ID, student(1, 'Alice'))
+    expect(await p.reverseLookup(COURSE_ID, 'Student 1')).toBeNull()
+  })
+
+  it('returns the original user_id when reverse lookup is enabled and pseudonym exists', async () => {
+    const p = make({
+      env: { CANVAS_PSEUDONYMIZE_STUDENTS: 'true', CANVAS_PSEUDONYMIZE_REVERSE_LOOKUP: 'true' },
+    })
+    await p.anonymizeUser(COURSE_ID, student(1, 'Alice'))
+    const result = await p.reverseLookup(COURSE_ID, 'Student 1')
+    expect(result).toEqual({ user_id: 1, pseudonym: 'Student 1', status: 'active' })
+  })
+
+  it('returns null for unknown pseudonyms and audit-logs the miss', async () => {
+    const lines: string[] = []
+    const p = new Pseudonymizer({
+      baseUrl: BASE_URL,
+      rootDir: tmpRoot,
+      env: { CANVAS_PSEUDONYMIZE_STUDENTS: 'true', CANVAS_PSEUDONYMIZE_REVERSE_LOOKUP: 'true' },
+      auditLog: (line) => lines.push(line),
+    })
+    await p.anonymizeUser(COURSE_ID, student(1, 'Alice'))
+    const result = await p.reverseLookup(COURSE_ID, 'Student 99')
+    expect(result).toBeNull()
+    expect(lines.some((l) => l.includes('Student 99'))).toBe(true)
+  })
+})
+
+describe('audit log file (opt-in)', () => {
+  it('appends successful reverse_lookup calls when CANVAS_PSEUDONYM_AUDIT_LOG is set', async () => {
+    const logFile = join(tmpRoot, 'audit.log')
+    const p = new Pseudonymizer({
+      baseUrl: BASE_URL,
+      rootDir: tmpRoot,
+      env: {
+        CANVAS_PSEUDONYMIZE_STUDENTS: 'true',
+        CANVAS_PSEUDONYMIZE_REVERSE_LOOKUP: 'true',
+        CANVAS_PSEUDONYM_AUDIT_LOG: logFile,
+      },
+      auditLog: () => undefined,
+    })
+    await p.anonymizeUser(COURSE_ID, student(1, 'Alice'))
+    await p.reverseLookup(COURSE_ID, 'Student 1')
+    // Allow the fire-and-forget append a tick.
+    await new Promise((r) => setTimeout(r, 20))
+    const contents = await readFile(logFile, 'utf8')
+    expect(contents).toContain('Student 1')
+    expect(contents).toContain('reverse_lookup hit')
+  })
+})

--- a/tests/pseudonym/roles.test.ts
+++ b/tests/pseudonym/roles.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { classifyRole, shouldPseudonymize } from '../../src/pseudonym/roles'
+import type { CanvasEnrollment, CanvasUser } from '../../src/canvas/types'
+
+function enrollment(type: string, extra: Partial<CanvasEnrollment> = {}): CanvasEnrollment {
+  return {
+    id: 1,
+    user_id: 1,
+    course_id: 1,
+    type,
+    enrollment_state: 'active',
+    role: type,
+    role_id: 1,
+    ...extra,
+  } as CanvasEnrollment
+}
+
+describe('classifyRole', () => {
+  it('returns student for StudentEnrollment', () => {
+    const user = { enrollments: [enrollment('StudentEnrollment')] } as Pick<
+      CanvasUser,
+      'enrollments'
+    >
+    expect(classifyRole(user)).toBe('student')
+  })
+
+  it('returns student for StudentViewEnrollment', () => {
+    const user = { enrollments: [enrollment('StudentViewEnrollment')] } as Pick<
+      CanvasUser,
+      'enrollments'
+    >
+    expect(classifyRole(user)).toBe('student')
+  })
+
+  it('returns staff for TeacherEnrollment', () => {
+    const user = { enrollments: [enrollment('TeacherEnrollment')] } as Pick<
+      CanvasUser,
+      'enrollments'
+    >
+    expect(classifyRole(user)).toBe('staff')
+  })
+
+  it('returns staff for TaEnrollment and DesignerEnrollment', () => {
+    expect(
+      classifyRole({ enrollments: [enrollment('TaEnrollment')] } as Pick<
+        CanvasUser,
+        'enrollments'
+      >),
+    ).toBe('staff')
+    expect(
+      classifyRole({
+        enrollments: [enrollment('DesignerEnrollment')],
+      } as Pick<CanvasUser, 'enrollments'>),
+    ).toBe('staff')
+  })
+
+  it('returns student when user has both student and staff enrollments (mixed → conservative)', () => {
+    const user = {
+      enrollments: [enrollment('TaEnrollment'), enrollment('StudentEnrollment')],
+    } as Pick<CanvasUser, 'enrollments'>
+    expect(classifyRole(user)).toBe('student')
+  })
+
+  it('returns unknown when user has no enrollments', () => {
+    expect(classifyRole({} as Pick<CanvasUser, 'enrollments'>)).toBe('unknown')
+    expect(classifyRole({ enrollments: [] } as Pick<CanvasUser, 'enrollments'>)).toBe('unknown')
+  })
+
+  it('returns unknown for ObserverEnrollment alone', () => {
+    const user = { enrollments: [enrollment('ObserverEnrollment')] } as Pick<
+      CanvasUser,
+      'enrollments'
+    >
+    expect(classifyRole(user)).toBe('unknown')
+  })
+
+  it('uses explicit enrollments parameter over user.enrollments', () => {
+    const user = { enrollments: [enrollment('TeacherEnrollment')] } as Pick<
+      CanvasUser,
+      'enrollments'
+    >
+    expect(classifyRole(user, [enrollment('StudentEnrollment')])).toBe('student')
+  })
+})
+
+describe('shouldPseudonymize', () => {
+  it('returns true for student and unknown, false for staff', () => {
+    expect(shouldPseudonymize('student')).toBe(true)
+    expect(shouldPseudonymize('unknown')).toBe(true)
+    expect(shouldPseudonymize('staff')).toBe(false)
+  })
+})

--- a/tests/pseudonym/store.test.ts
+++ b/tests/pseudonym/store.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  CURRENT_MAP_VERSION,
+  emptyConversationMap,
+  emptyCourseMap,
+  loadMap,
+  saveMap,
+  type CourseMap,
+} from '../../src/pseudonym/store'
+
+let tmpRoot: string
+
+beforeEach(async () => {
+  tmpRoot = await mkdtemp(join(tmpdir(), 'pseudonym-store-'))
+})
+
+afterEach(async () => {
+  await rm(tmpRoot, { recursive: true, force: true })
+})
+
+describe('emptyCourseMap / emptyConversationMap', () => {
+  it('stamps version, host, course_id, and a fresh student dict', () => {
+    const m = emptyCourseMap('school.instructure.com', 123)
+    expect(m.version).toBe(CURRENT_MAP_VERSION)
+    expect(m.host).toBe('school.instructure.com')
+    expect(m.course_id).toBe(123)
+    expect(m.next_pseudonym_index).toBe(1)
+    expect(m.students).toEqual({})
+    expect(typeof m.generated_at).toBe('string')
+  })
+
+  it('builds an empty conversation map without course_id', () => {
+    const m = emptyConversationMap('school.instructure.com')
+    expect(m.version).toBe(CURRENT_MAP_VERSION)
+    expect(m.host).toBe('school.instructure.com')
+    expect(m.next_pseudonym_index).toBe(1)
+    expect(m.participants).toEqual({})
+  })
+})
+
+describe('loadMap / saveMap', () => {
+  it('returns null when file does not exist', async () => {
+    const result = await loadMap<CourseMap>(join(tmpRoot, 'missing.json'))
+    expect(result).toBeNull()
+  })
+
+  it('round-trips data through write+read', async () => {
+    const file = join(tmpRoot, 'school.instructure.com', '123.json')
+    const map = emptyCourseMap('school.instructure.com', 123)
+    map.students['1'] = {
+      pseudonym: 'Student 1',
+      status: 'active',
+      first_seen: '2026-01-01T00:00:00Z',
+    }
+    map.next_pseudonym_index = 2
+
+    await saveMap(file, map)
+    const loaded = await loadMap<CourseMap>(file)
+    expect(loaded).toEqual(map)
+  })
+
+  it('creates parent directories', async () => {
+    const file = join(tmpRoot, 'a', 'b', 'c', '1.json')
+    await saveMap(file, emptyCourseMap('h', 1))
+    const s = await stat(file)
+    expect(s.isFile()).toBe(true)
+  })
+
+  it('observers never see a half-written file (sequential save+read)', async () => {
+    // The pseudonymizer serializes writes to the same target via in-memory
+    // locks; this test verifies that each individual save is atomic from a
+    // reader's perspective — the target either holds the previous version or
+    // the new one, never a torn JSON.
+    const file = join(tmpRoot, 'sequential.json')
+    for (let i = 1; i <= 8; i++) {
+      const m = emptyCourseMap('h', 0)
+      m.next_pseudonym_index = i
+      await saveMap(file, m)
+      const loaded = await loadMap<CourseMap>(file)
+      expect(loaded?.next_pseudonym_index).toBe(i)
+    }
+  })
+
+  it('does not leave .tmp- sidecar files after a successful save', async () => {
+    const file = join(tmpRoot, 'school.instructure.com', '7.json')
+    await saveMap(file, emptyCourseMap('school.instructure.com', 7))
+    const { readdir } = await import('node:fs/promises')
+    const entries = await readdir(join(tmpRoot, 'school.instructure.com'))
+    expect(entries.filter((e) => e.includes('.tmp-'))).toEqual([])
+  })
+
+  it('rethrows non-ENOENT read errors instead of silently returning null', async () => {
+    // Pointing loadMap at a directory triggers EISDIR — not ENOENT.
+    await expect(loadMap(tmpRoot)).rejects.toBeDefined()
+  })
+})
+
+describe('file modes (POSIX only)', () => {
+  // Windows ignores POSIX modes; the design accepts this and documents it.
+  const itPosix = process.platform === 'win32' ? it.skip : it
+
+  itPosix('writes the map file with mode 0o600', async () => {
+    const file = join(tmpRoot, 'mode-test.json')
+    await saveMap(file, emptyCourseMap('h', 1))
+    const s = await stat(file)
+    expect(s.mode & 0o777).toBe(0o600)
+  })
+})


### PR DESCRIPTION
## Summary

Implements Phase 1 of the FERPA / student-pseudonymization design from BRU-1264 — the Pseudonymizer core and the wiring needed for per-tool wraps in a follow-up Developer subtask.

- New `src/pseudonym/` module: `pseudonymizer.ts` (class with `isEnabled`, `anonymizeUser/Users/Enrollment/Submission/Conversation/OutcomeResults`, `reverseLookup`), `store.ts` (atomic temp+rename writes, `0o700` dir / `0o600` file), `roles.ts` (`classifyRole` with unknown → student), `paths.ts` (XDG / `%APPDATA%` / `~/Library/Application Support` + `CANVAS_PSEUDONYM_DIR` override), `coverage.ts` (hand-maintained allowlist consumed by CI).
- New conditional tool `resolve_pseudonym` in `src/tools/pseudonym.ts`. Registered only when `CANVAS_PSEUDONYMIZE_STUDENTS=true` AND `CANVAS_PSEUDONYMIZE_REVERSE_LOOKUP=true` — absent from `tools/list` otherwise. Every call audit-logged to stderr (plus optional `CANVAS_PSEUDONYM_AUDIT_LOG` file).
- `src/server.ts` constructs the Pseudonymizer and passes it into `getAllTools` / `registerAllTools`. `_meta.pseudonymized: true` is attached to every tool response when the flag is on. `src/http.ts` reuses a process-wide singleton across per-request MCP servers so pseudonyms stay stable.
- CI coverage lint (`tests/pseudonym/coverage.test.ts`): fails when a PII-bearing tool is added without also updating `PSEUDONYMIZER_WRAPPED_TOOLS`. Catches T3 regressions early.
- Folds two CTO-review follow-ups into the design doc: T5 mitigation (Canvas file tools cannot reach the local map directory) and the hot-file-deletion sharp edge.
- README gets a new "FERPA mode" section + env var table; CLAUDE.md gets the "wrap your PII-bearing tool" checklist item; the exported `CanvasClient` JSDoc warns library consumers that the bare client bypasses pseudonymization.

Phase 2 (out of scope here, separate Developer subtask): add the actual `pseudonymizer.anonymize*` wraps inside each tool handler in users/enrollments/submissions/conversations/outcomes/groups/gradebook-history/accounts and add per-tool runtime tests asserting names are pseudonyms when the flag is on.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 837 passed, 1 skipped (one POSIX-only file-mode test skipped on Windows by design)
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean
- [ ] CI green