### PR TITLE
feat(install): ship .mcpb bundle for one-click install [BRU-1348]

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -51,6 +51,37 @@ jobs:
       - name: Publish to npm with Trusted Publisher OIDC
         run: npm publish --access public --no-git-checks --provenance --registry https://registry.npmjs.org/
 
+  mcpb-bundle:
+    name: Pack and Upload .mcpb Bundle
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - name: Pack .mcpb bundle
+        run: pnpm mcpb:pack
+      - name: Verify bundle exists and is non-empty
+        run: |
+          if [ ! -s canvas-lms-mcp.mcpb ]; then
+            echo "ERROR: canvas-lms-mcp.mcpb is missing or empty"
+            exit 1
+          fi
+          ls -lh canvas-lms-mcp.mcpb
+      - name: Upload .mcpb to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: gh release upload "$TAG" canvas-lms-mcp.mcpb --clobber
+
   registry-publish:
     name: Publish to MCP Registry
     needs: [release-please, npm-publish]

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 *.tsbuildinfo
 coverage/
 .DS_Store
+.mcpb-staging/
+*.mcpb

--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ MCP server for [Canvas LMS](https://www.instructure.com/canvas). Read courses, a
 
 116 tools across Canvas courses, assignments, submissions, gradebook history, rubrics, quizzes, New Quizzes (LTI), files, users, groups, enrollments, discussions, modules, pages, calendar, conversations, peer reviews, accounts, analytics, outcomes, student workflows, dashboard, and health checks. Three deployment modes: stdio, HTTP, and library import.
 
+## One-click install (Claude Desktop)
+
+1. **[Download `canvas-lms-mcp.mcpb`](https://github.com/bruchris/canvas-lms-mcp/releases/latest/download/canvas-lms-mcp.mcpb)** from the latest release.
+2. Double-click the file (or drag it into Claude Desktop's Extensions settings).
+3. When prompted, paste your Canvas API token and Canvas API base URL (e.g. `https://school.instructure.com/api/v1`).
+
+No terminal, no Node.js install, no config-file editing — Claude Desktop bundles the runtime and handles config for you. The same `.mcpb` works in Claude Code and MCP for Windows.
+
+Prefer the terminal? Use the [Quick Start](#quick-start) below.
+
 ## Comparison
 
 | | canvas-lms-mcp | [vishalsachdev/canvas-mcp](https://github.com/vishalsachdev/canvas-mcp) | [DMontgomery40/mcp-canvas-lms](https://github.com/DMontgomery40/mcp-canvas-lms) |

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://raw.githubusercontent.com/modelcontextprotocol/mcpb/main/schemas/manifest.schema.json",
+  "manifest_version": "0.3",
+  "name": "canvas-lms-mcp",
+  "display_name": "Canvas LMS",
+  "version": "1.18.0",
+  "description": "TypeScript MCP server for Canvas LMS — 115 read+write tools across 17 domains.",
+  "long_description": "MCP server for Canvas LMS. Read courses, assignments, submissions, rubrics, quizzes; grade, comment, manage course content, and handle Canvas admin workflows from any AI agent.",
+  "author": {
+    "name": "Christian Bru",
+    "url": "https://github.com/bruchris"
+  },
+  "homepage": "https://github.com/bruchris/canvas-lms-mcp",
+  "documentation": "https://github.com/bruchris/canvas-lms-mcp#readme",
+  "support": "https://github.com/bruchris/canvas-lms-mcp/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bruchris/canvas-lms-mcp"
+  },
+  "license": "MIT",
+  "keywords": [
+    "canvas",
+    "canvas-lms",
+    "lms",
+    "education",
+    "grading",
+    "instructure"
+  ],
+  "server": {
+    "type": "node",
+    "entry_point": "dist/stdio.js",
+    "mcp_config": {
+      "command": "node",
+      "args": [
+        "${__dirname}/dist/stdio.js"
+      ],
+      "env": {
+        "CANVAS_API_TOKEN": "${user_config.canvas_api_token}",
+        "CANVAS_BASE_URL": "${user_config.canvas_base_url}"
+      }
+    }
+  },
+  "user_config": {
+    "canvas_api_token": {
+      "type": "string",
+      "title": "Canvas API Token",
+      "description": "Personal access token from Account → Settings → Approved Integrations → New Access Token.",
+      "required": true,
+      "sensitive": true
+    },
+    "canvas_base_url": {
+      "type": "string",
+      "title": "Canvas API Base URL",
+      "description": "Your Canvas instance API URL, e.g. https://school.instructure.com/api/v1",
+      "required": true
+    }
+  },
+  "compatibility": {
+    "claude_desktop": ">=0.10.0",
+    "platforms": [
+      "darwin",
+      "win32",
+      "linux"
+    ],
+    "runtimes": {
+      "node": ">=22.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "dev": "tsup --watch",
     "build": "tsup && tsc -p tsconfig.build.json",
     "generate:manifests": "tsx scripts/generate-manifests.ts",
+    "mcpb:pack": "node scripts/pack-mcpb.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint src/ tests/ && prettier --check src/ tests/",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,13 @@
     ".": {
       "release-type": "node",
       "bump-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "manifest.json",
+          "jsonpath": "$.version"
+        }
+      ],
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },

--- a/scripts/pack-mcpb.mjs
+++ b/scripts/pack-mcpb.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Packs an .mcpb bundle for one-click install in Claude Desktop / Claude Code / MCP for Windows.
+//
+// Steps:
+//   1. Sync manifest.json `version` from package.json.
+//   2. Stage manifest.json, dist/, a slimmed package.json, and LICENSE into a temp dir.
+//   3. Install production-only dependencies into the staging dir (flat node_modules).
+//   4. Invoke `mcpb pack` against the staging dir; output canvas-lms-mcp.mcpb at repo root.
+//   5. Fail loudly if the output is missing or empty.
+//
+// Local usage:   pnpm build && pnpm mcpb:pack
+// CI usage:      release workflow runs this on tagged releases.
+
+import { spawnSync } from 'node:child_process'
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = resolve(fileURLToPath(import.meta.url), '..', '..')
+const STAGING_DIR = resolve(REPO_ROOT, '.mcpb-staging')
+const OUTPUT_FILE = resolve(REPO_ROOT, 'canvas-lms-mcp.mcpb')
+const MANIFEST_PATH = resolve(REPO_ROOT, 'manifest.json')
+const PACKAGE_JSON_PATH = resolve(REPO_ROOT, 'package.json')
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { stdio: 'inherit', shell: process.platform === 'win32', ...options })
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} exited with status ${result.status}`)
+  }
+}
+
+function syncManifestVersion(version) {
+  const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'))
+  if (manifest.version !== version) {
+    manifest.version = version
+    writeFileSync(MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
+    console.log(`manifest.json version synced to ${version}`)
+  }
+  return manifest
+}
+
+function buildStaging(pkg, manifest) {
+  if (existsSync(STAGING_DIR)) rmSync(STAGING_DIR, { recursive: true, force: true })
+  mkdirSync(STAGING_DIR, { recursive: true })
+
+  writeFileSync(resolve(STAGING_DIR, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
+
+  const distSrc = resolve(REPO_ROOT, 'dist')
+  if (!existsSync(distSrc)) {
+    throw new Error('dist/ not found — run `pnpm build` before packing.')
+  }
+  cpSync(distSrc, resolve(STAGING_DIR, 'dist'), { recursive: true })
+
+  const licenseSrc = resolve(REPO_ROOT, 'LICENSE')
+  if (existsSync(licenseSrc)) cpSync(licenseSrc, resolve(STAGING_DIR, 'LICENSE'))
+
+  const stagedPkg = {
+    name: pkg.name,
+    version: pkg.version,
+    description: pkg.description,
+    type: pkg.type,
+    main: 'dist/stdio.js',
+    license: pkg.license,
+    dependencies: pkg.dependencies ?? {},
+  }
+  writeFileSync(resolve(STAGING_DIR, 'package.json'), `${JSON.stringify(stagedPkg, null, 2)}\n`, 'utf8')
+}
+
+function installProductionDeps() {
+  run('npm', ['install', '--omit=dev', '--ignore-scripts', '--no-fund', '--no-audit', '--no-package-lock'], {
+    cwd: STAGING_DIR,
+  })
+}
+
+function packBundle() {
+  run('npx', ['--yes', '@anthropic-ai/mcpb@latest', 'pack', STAGING_DIR, OUTPUT_FILE])
+
+  if (!existsSync(OUTPUT_FILE)) {
+    throw new Error(`mcpb pack did not produce ${OUTPUT_FILE}`)
+  }
+  const { size } = statSync(OUTPUT_FILE)
+  if (size <= 0) {
+    throw new Error(`${OUTPUT_FILE} is empty (0 bytes)`)
+  }
+  const sizeMb = (size / (1024 * 1024)).toFixed(2)
+  console.log(`Packed ${OUTPUT_FILE} (${sizeMb} MB)`)
+}
+
+function main() {
+  const pkg = JSON.parse(readFileSync(PACKAGE_JSON_PATH, 'utf8'))
+  const manifest = syncManifestVersion(pkg.version)
+  buildStaging(pkg, manifest)
+  installProductionDeps()
+  packBundle()
+  rmSync(STAGING_DIR, { recursive: true, force: true })
+}
+
+main()

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const manifest = JSON.parse(readFileSync(resolve(__dirname, '..', 'manifest.json'), 'utf8'))
+const pkg = JSON.parse(readFileSync(resolve(__dirname, '..', 'package.json'), 'utf8'))
+
+describe('manifest.json (.mcpb bundle)', () => {
+  it('has required top-level fields', () => {
+    expect(manifest.manifest_version).toBeTypeOf('string')
+    expect(manifest.name).toBe('canvas-lms-mcp')
+    expect(manifest.version).toBe(pkg.version)
+    expect(manifest.description).toBeTypeOf('string')
+    expect(manifest.author?.name).toBeTypeOf('string')
+  })
+
+  it('keeps description within the 100-char MCP Registry limit', () => {
+    expect(manifest.description.length).toBeLessThanOrEqual(100)
+  })
+
+  it('declares CANVAS_API_TOKEN and CANVAS_BASE_URL as required user_config', () => {
+    expect(manifest.user_config.canvas_api_token).toMatchObject({ required: true, sensitive: true })
+    expect(manifest.user_config.canvas_base_url).toMatchObject({ required: true })
+  })
+
+  it('forwards user_config into mcp_config env vars', () => {
+    expect(manifest.server.mcp_config.env.CANVAS_API_TOKEN).toBe('${user_config.canvas_api_token}')
+    expect(manifest.server.mcp_config.env.CANVAS_BASE_URL).toBe('${user_config.canvas_base_url}')
+  })
+
+  it('targets dist/stdio.js as the node entry point', () => {
+    expect(manifest.server.type).toBe('node')
+    expect(manifest.server.entry_point).toBe('dist/stdio.js')
+    expect(manifest.server.mcp_config.command).toBe('node')
+    expect(manifest.server.mcp_config.args).toContain('${__dirname}/dist/stdio.js')
+  })
+
+  it('supports darwin, win32, and linux', () => {
+    expect(manifest.compatibility.platforms).toEqual(
+      expect.arrayContaining(['darwin', 'win32', 'linux']),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Adopt the official MCP Bundle format (`.mcpb`) so users can install `canvas-lms-mcp` with a single click in Claude Desktop, Claude Code, and MCP for Windows — no terminal, no manual config edits.

Closes BRU-1348. Spun out of product research BRU-1346 — adoption friction is our biggest growth blocker, and the newest Canvas MCP entrant already ships `.mcpb`.

## What's in the bundle

- **`manifest.json`** — `manifest_version: 0.3`, `name: canvas-lms-mcp`, `server.type: node`, `entry_point: dist/stdio.js`. `CANVAS_API_TOKEN` (sensitive) and `CANVAS_BASE_URL` declared as required `user_config` so Claude Desktop prompts the user on install. Description is 78/100 chars to satisfy the MCP Registry constraint.
- **`scripts/pack-mcpb.mjs`** — stages `dist/` + production `node_modules` (via `npm install --omit=dev`) + slimmed `package.json` + `LICENSE` into `.mcpb-staging/`, runs `mcpb pack`, fails loudly if the output is missing or empty. Wired as `pnpm mcpb:pack`. Local run produces a 3.4 MB `canvas-lms-mcp.mcpb` containing 2,365 files.
- **Release workflow** — new `mcpb-bundle` job (runs after `release-please` creates a release) builds, packs, verifies non-empty, and uploads `canvas-lms-mcp.mcpb` to the GitHub release via `gh release upload --clobber`.
- **`release-please-config.json`** — added `extra-files` so manifest.json's `$.version` gets bumped on every release, keeping it in sync with `package.json`.
- **README** — new "One-click install (Claude Desktop)" section at the top with a direct link to `/releases/latest/download/canvas-lms-mcp.mcpb`. Existing `npx canvas-lms-mcp init` Quick Start kept for power users.
- **`tests/manifest.test.ts`** — pins the 100-char description limit, required `user_config` flags, entry-point path, and `darwin`/`win32`/`linux` platform support so regressions fail CI.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm build` all green
- [x] `pnpm mcpb:pack` produces `canvas-lms-mcp.mcpb` (3.4 MB, 2,365 files) — verified locally on Windows
- [x] New `tests/manifest.test.ts` (6 cases) passes
- [ ] **Manual verification post-merge**: download the `.mcpb` from the release, double-click into Claude Desktop, confirm it boots and `list_courses` works against a real Canvas instance — will note in the v1.19.0 release issue.

## Notes for reviewer

- `mcpb-bundle` is independent of `npm-publish` and `registry-publish` so a bundle failure does not block npm/registry publishing (and vice versa). If you'd rather have it block the npm publish on a missing bundle, easy to switch `needs:` to `[release-please, mcpb-bundle]`.
- I used `npm install --omit=dev` (not pnpm) inside the staging dir on purpose: it gives us a flat `node_modules` without pnpm's symlink/store layout, which keeps the bundle portable. Production deps are only `@iarna/toml`, `@modelcontextprotocol/sdk`, `prompts`, `zod` — npm resolves these identically to pnpm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)