### PR TITLE
feat(tools): add fields=slim projection to list_courses and list_assignments [BRU-1418]

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -18,7 +18,7 @@
     {
       "name": "list_courses",
       "domain": "courses",
-      "description": "List courses for the authenticated user. `include` adds optional fields (teachers, total_students, term, syllabus_body, etc.). `state[]` narrows by course workflow state; `enrollment_state` narrows by the caller’s enrollment state.",
+      "description": "List courses for the authenticated user. Use fields=\"slim\" when enumerating courses for selection; switch to \"full\" once you have identified the target. slim returns id, name, course_code, term name, and workflow_state only. \"full\" (default) includes all Canvas fields plus `include` extras (teachers, total_students, syllabus_body, etc.). `state[]` narrows by course workflow state; `enrollment_state` narrows by the caller's enrollment state.",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true
@@ -79,7 +79,7 @@
     {
       "name": "list_assignments",
       "domain": "assignments",
-      "description": "List all assignments in a course. Use `include` to request submission, all_dates, overrides, score_statistics, etc. Use `bucket` to filter by past/upcoming/overdue/etc. Other filters: `search_term`, `assignment_ids`, `order_by`.",
+      "description": "List all assignments in a course. Use fields=\"slim\" when enumerating assignments for selection; switch to \"full\" once you've identified the target. slim returns id, name, due_at, points_possible, published, and course_id only. \"full\" (default) includes all Canvas fields plus `include` extras (submission, all_dates, overrides, score_statistics, etc.). Use `bucket` to filter by past/upcoming/overdue/etc. Other filters: `search_term`, `assignment_ids`, `order_by`.",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true

--- a/src/tools/assignments.ts
+++ b/src/tools/assignments.ts
@@ -61,13 +61,21 @@ export function assignmentTools(canvas: CanvasClient): ToolDefinition[] {
     {
       name: 'list_assignments',
       description:
-        'List all assignments in a course. Use `include` to request submission, all_dates, overrides, score_statistics, etc. Use `bucket` to filter by past/upcoming/overdue/etc. Other filters: `search_term`, `assignment_ids`, `order_by`.',
+        'List all assignments in a course. Use fields="slim" when enumerating assignments for selection; switch to "full" once you\'ve identified the target. slim returns id, name, due_at, points_possible, published, and course_id only. "full" (default) includes all Canvas fields plus `include` extras (submission, all_dates, overrides, score_statistics, etc.). Use `bucket` to filter by past/upcoming/overdue/etc. Other filters: `search_term`, `assignment_ids`, `order_by`.',
       inputSchema: {
         course_id: z.number().describe('The Canvas course ID'),
+        fields: z
+          .enum(['slim', 'full'])
+          .optional()
+          .describe(
+            'Projection mode: "slim" returns id/name/due_at/points_possible/published/course_id only; "full" (default) returns all fields',
+          ),
         include: z
           .array(z.enum(ASSIGNMENT_LIST_INCLUDE))
           .optional()
-          .describe('Extra fields to include on each assignment (Canvas include[] param)'),
+          .describe(
+            'Extra fields to include on each assignment (Canvas include[] param); ignored when fields="slim"',
+          ),
         search_term: z
           .string()
           .optional()
@@ -101,8 +109,9 @@ export function assignmentTools(canvas: CanvasClient): ToolDefinition[] {
         openWorldHint: true,
       },
       handler: async (params) => {
+        const slim = params.fields === 'slim'
         const opts: ListAssignmentsOptions = {}
-        if (params.include !== undefined)
+        if (!slim && params.include !== undefined)
           opts.include = params.include as ReadonlyArray<AssignmentListInclude>
         if (params.search_term !== undefined) opts.search_term = params.search_term as string
         if (params.bucket !== undefined) opts.bucket = params.bucket as AssignmentBucket
@@ -114,7 +123,16 @@ export function assignmentTools(canvas: CanvasClient): ToolDefinition[] {
         if (params.needs_grading_count_by_section !== undefined)
           opts.needs_grading_count_by_section = params.needs_grading_count_by_section as boolean
         if (params.post_to_sis !== undefined) opts.post_to_sis = params.post_to_sis as boolean
-        return canvas.assignments.list(params.course_id as number, opts)
+        const assignments = await canvas.assignments.list(params.course_id as number, opts)
+        if (!slim) return assignments
+        return assignments.map((a) => ({
+          id: a.id,
+          name: a.name,
+          due_at: a.due_at,
+          points_possible: a.points_possible,
+          published: a.published,
+          course_id: a.course_id,
+        }))
       },
     },
     {

--- a/src/tools/courses.ts
+++ b/src/tools/courses.ts
@@ -46,12 +46,18 @@ export function courseTools(canvas: CanvasClient): ToolDefinition[] {
     {
       name: 'list_courses',
       description:
-        'List courses for the authenticated user. `include` adds optional fields (teachers, total_students, term, syllabus_body, etc.). `state[]` narrows by course workflow state; `enrollment_state` narrows by the caller’s enrollment state.',
+        'List courses for the authenticated user. Use fields="slim" when enumerating courses for selection; switch to "full" once you have identified the target. slim returns id, name, course_code, term name, and workflow_state only. "full" (default) includes all Canvas fields plus `include` extras (teachers, total_students, syllabus_body, etc.). `state[]` narrows by course workflow state; `enrollment_state` narrows by the caller\'s enrollment state.',
       inputSchema: {
+        fields: z
+          .enum(['slim', 'full'])
+          .optional()
+          .describe(
+            'Projection mode: "slim" returns id/name/course_code/term/workflow_state only; "full" (default) returns all fields',
+          ),
         enrollment_state: z
           .enum(COURSE_ENROLLMENT_STATE)
           .optional()
-          .describe('Filter courses by the caller’s enrollment state'),
+          .describe("Filter courses by the caller's enrollment state"),
         state: z
           .array(z.enum(COURSE_WORKFLOW_STATE))
           .optional()
@@ -59,7 +65,9 @@ export function courseTools(canvas: CanvasClient): ToolDefinition[] {
         include: z
           .array(z.enum(COURSE_LIST_INCLUDE))
           .optional()
-          .describe('Extra fields to include on each course (Canvas include[] param)'),
+          .describe(
+            'Extra fields to include on each course (Canvas include[] param); ignored when fields="slim"',
+          ),
         exclude_blueprint_courses: z
           .boolean()
           .optional()
@@ -70,16 +78,25 @@ export function courseTools(canvas: CanvasClient): ToolDefinition[] {
         openWorldHint: true,
       },
       handler: async (params) => {
+        const slim = params.fields === 'slim'
         const opts: ListCoursesOptions = {}
         if (params.enrollment_state !== undefined)
           opts.enrollment_state = params.enrollment_state as CourseEnrollmentState
         if (params.state !== undefined)
           opts.state = params.state as ReadonlyArray<CourseWorkflowState>
-        if (params.include !== undefined)
+        if (!slim && params.include !== undefined)
           opts.include = params.include as ReadonlyArray<CourseListInclude>
         if (params.exclude_blueprint_courses !== undefined)
           opts.exclude_blueprint_courses = params.exclude_blueprint_courses as boolean
-        return canvas.courses.list(opts)
+        const courses = await canvas.courses.list(opts)
+        if (!slim) return courses
+        return courses.map((c) => ({
+          id: c.id,
+          name: c.name,
+          course_code: c.course_code,
+          term: c.term?.name ?? null,
+          workflow_state: c.workflow_state,
+        }))
       },
     },
     {

--- a/tests/tools/assignments.test.ts
+++ b/tests/tools/assignments.test.ts
@@ -71,6 +71,12 @@ describe('assignmentTools', () => {
       expect(tool.inputSchema).toHaveProperty('course_id')
     })
 
+    it('has fields in input schema', () => {
+      const canvas = buildMockCanvas()
+      const tool = assignmentTools(canvas).find((t) => t.name === 'list_assignments')!
+      expect(tool.inputSchema).toHaveProperty('fields')
+    })
+
     it('calls canvas.assignments.list with the course_id and empty opts', async () => {
       const canvas = buildMockCanvas()
       const tool = assignmentTools(canvas).find((t) => t.name === 'list_assignments')!
@@ -94,11 +100,53 @@ describe('assignmentTools', () => {
       })
     })
 
-    it('returns the assignment list from Canvas', async () => {
+    it('returns the assignment list from Canvas when fields is omitted (full mode)', async () => {
       const canvas = buildMockCanvas()
       const tool = assignmentTools(canvas).find((t) => t.name === 'list_assignments')!
       const result = await tool.handler({ course_id: 1 })
       expect(result).toEqual([mockAssignment])
+    })
+
+    it('returns the full assignment list when fields="full"', async () => {
+      const canvas = buildMockCanvas()
+      const tool = assignmentTools(canvas).find((t) => t.name === 'list_assignments')!
+      const result = await tool.handler({ course_id: 1, fields: 'full' })
+      expect(result).toEqual([mockAssignment])
+    })
+
+    it('returns slim projection when fields="slim"', async () => {
+      const canvas = buildMockCanvas()
+      const tool = assignmentTools(canvas).find((t) => t.name === 'list_assignments')!
+      const result = await tool.handler({ course_id: 1, fields: 'slim' })
+      expect(result).toEqual([
+        {
+          id: 101,
+          name: 'Homework 1',
+          due_at: '2026-05-01T23:59:00Z',
+          points_possible: 100,
+          published: undefined,
+          course_id: 1,
+        },
+      ])
+    })
+
+    it('slim mode does not include extra fields', async () => {
+      const canvas = buildMockCanvas()
+      const tool = assignmentTools(canvas).find((t) => t.name === 'list_assignments')!
+      const result = (await tool.handler({ course_id: 1, fields: 'slim' })) as Array<
+        Record<string, unknown>
+      >
+      expect(result[0]).not.toHaveProperty('description')
+      expect(result[0]).not.toHaveProperty('grading_type')
+      expect(result[0]).not.toHaveProperty('submission_types')
+      expect(result[0]).not.toHaveProperty('allowed_attempts')
+    })
+
+    it('slim mode ignores the include param', async () => {
+      const canvas = buildMockCanvas()
+      const tool = assignmentTools(canvas).find((t) => t.name === 'list_assignments')!
+      await tool.handler({ course_id: 42, fields: 'slim', include: ['submission'] })
+      expect(canvas.assignments.list).toHaveBeenCalledWith(42, {})
     })
 
     it('has a description', () => {

--- a/tests/tools/courses.test.ts
+++ b/tests/tools/courses.test.ts
@@ -59,6 +59,12 @@ describe('courseTools', () => {
       expect(tool.inputSchema).toHaveProperty('enrollment_state')
     })
 
+    it('has fields in input schema', () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'list_courses')!
+      expect(tool.inputSchema).toHaveProperty('fields')
+    })
+
     it('calls canvas.courses.list with no params when none provided', async () => {
       const canvas = buildMockCanvas()
       const tool = courseTools(canvas).find((t) => t.name === 'list_courses')!
@@ -73,11 +79,68 @@ describe('courseTools', () => {
       expect(canvas.courses.list).toHaveBeenCalledWith({ enrollment_state: 'active' })
     })
 
-    it('returns the course list from Canvas', async () => {
+    it('returns the course list from Canvas when fields is omitted (full mode)', async () => {
       const canvas = buildMockCanvas()
       const tool = courseTools(canvas).find((t) => t.name === 'list_courses')!
       const result = await tool.handler({})
       expect(result).toEqual([mockCourse])
+    })
+
+    it('returns the full course list when fields="full"', async () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'list_courses')!
+      const result = await tool.handler({ fields: 'full' })
+      expect(result).toEqual([mockCourse])
+    })
+
+    it('returns slim projection when fields="slim"', async () => {
+      const courseWithTerm: CanvasCourse = {
+        ...mockCourse,
+        term: { id: 5, name: 'Fall 2026', start_at: null, end_at: null },
+      }
+      const canvas = buildMockCanvas()
+      ;(canvas.courses.list as ReturnType<typeof vi.fn>).mockResolvedValue([courseWithTerm])
+      const tool = courseTools(canvas).find((t) => t.name === 'list_courses')!
+      const result = await tool.handler({ fields: 'slim' })
+      expect(result).toEqual([
+        {
+          id: 1,
+          name: 'Intro to Testing',
+          course_code: 'TST101',
+          term: 'Fall 2026',
+          workflow_state: 'available',
+        },
+      ])
+    })
+
+    it('slim mode sets term to null when course has no term', async () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'list_courses')!
+      const result = await tool.handler({ fields: 'slim' })
+      expect((result as Array<{ term: unknown }>)[0].term).toBeNull()
+    })
+
+    it('slim mode does not include extra fields', async () => {
+      const courseWithExtras: CanvasCourse = {
+        ...mockCourse,
+        total_students: 30,
+        syllabus_body: 'lots of text',
+        term: { id: 1, name: 'Spring', start_at: null, end_at: null },
+      }
+      const canvas = buildMockCanvas()
+      ;(canvas.courses.list as ReturnType<typeof vi.fn>).mockResolvedValue([courseWithExtras])
+      const tool = courseTools(canvas).find((t) => t.name === 'list_courses')!
+      const result = (await tool.handler({ fields: 'slim' })) as Array<Record<string, unknown>>
+      expect(result[0]).not.toHaveProperty('total_students')
+      expect(result[0]).not.toHaveProperty('syllabus_body')
+      expect(result[0]).not.toHaveProperty('enrollment_term_id')
+    })
+
+    it('slim mode ignores the include param', async () => {
+      const canvas = buildMockCanvas()
+      const tool = courseTools(canvas).find((t) => t.name === 'list_courses')!
+      await tool.handler({ fields: 'slim', include: ['total_students'] })
+      expect(canvas.courses.list).toHaveBeenCalledWith({})
     })
 
     it('has a description', () => {


### PR DESCRIPTION
## Summary

- Adds `fields: "slim" | "full"` (default `"full"`) to `list_courses` and `list_assignments`
- Slim mode returns a minimal subset at the tool layer, preserving existing full-fidelity behavior by default
- `get_course` and `get_assignment` are unchanged

## list_courses slim subset
`id`, `name`, `course_code`, `term` (name string, not full term object), `workflow_state`

## list_assignments slim subset
`id`, `name`, `due_at`, `points_possible`, `published`, `course_id`

## Decision: list_assignments scope
Included in this PR. The assignment payload has ~25 fields (description, grading_type, submission_types, rubric_settings, allowed_attempts, etc.) and agents routinely enumerate assignments before drilling in with get_assignment — the same token-saving pattern applies equally.

## Implementation notes
- Filtering is done at the tool layer (not the canvas client). The canvas client returns full objects; the tool maps down to the slim shape.
- In slim mode, `include[]` is ignored. The canvas client's default `include=term` ensures `c.term` is populated for the course projection.
- No pseudonymizer changes needed — neither tool returns PII fields (verified: `tests/pseudonym/coverage.test.ts` still passes with no changes to `PSEUDONYMIZER_WRAPPED_TOOLS`).

## Test plan
- [x] `list_courses` slim mode returns exactly the 5 slim fields
- [x] `list_courses` slim mode sets `term: null` when course has no term
- [x] `list_courses` slim mode ignores `include` param
- [x] `list_courses` full mode returns unchanged course objects
- [x] `list_assignments` slim mode returns exactly the 6 slim fields
- [x] `list_assignments` slim mode ignores `include` param
- [x] `list_assignments` full mode returns unchanged assignment objects
- [x] All 888 existing tests pass
- [x] `pnpm typecheck && pnpm test && pnpm lint && pnpm build` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)