### PR TITLE
feat(ui): add view_course_structure interactive MCP Apps widget [BRU-1574]

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 MCP server for [Canvas LMS](https://www.instructure.com/canvas). Read courses, assignments, submissions, rubrics, quizzes; grade, comment, manage course content, and handle Canvas admin workflows from any AI agent.
 
-116 tools across Canvas courses, assignments, submissions, gradebook history, rubrics, quizzes, New Quizzes (LTI), files, users, groups, enrollments, discussions, modules, pages, calendar, conversations, peer reviews, accounts, analytics, outcomes, student workflows, dashboard, and health checks. Three deployment modes: stdio, HTTP, and library import.
+117 tools across Canvas courses, assignments, submissions, gradebook history, rubrics, quizzes, New Quizzes (LTI), files, users, groups, enrollments, discussions, modules, pages, calendar, conversations, peer reviews, accounts, analytics, outcomes, student workflows, dashboard, and health checks. Three deployment modes: stdio, HTTP, and library import.
 
 ## One-click install (Claude Desktop)
 
@@ -28,7 +28,7 @@ Prefer the terminal? Use the [Quick Start](#quick-start) below.
 | | canvas-lms-mcp | [vishalsachdev/canvas-mcp](https://github.com/vishalsachdev/canvas-mcp) | [DMontgomery40/mcp-canvas-lms](https://github.com/DMontgomery40/mcp-canvas-lms) |
 |---|---|---|---|
 | Language | TypeScript | Python | TypeScript |
-| Tools | 116 | 80+ | 54 |
+| Tools | 117 | 80+ | 54 |
 | License | [![License: MIT](https://img.shields.io/github/license/bruchris/canvas-lms-mcp)](https://github.com/bruchris/canvas-lms-mcp/blob/main/LICENSE) | [![License](https://img.shields.io/github/license/vishalsachdev/canvas-mcp)](https://github.com/vishalsachdev/canvas-mcp/blob/main/LICENSE) | [![License](https://img.shields.io/github/license/DMontgomery40/mcp-canvas-lms)](https://github.com/DMontgomery40/mcp-canvas-lms/blob/main/LICENSE) |
 | Last commit | [![Last commit](https://img.shields.io/github/last-commit/bruchris/canvas-lms-mcp)](https://github.com/bruchris/canvas-lms-mcp) | [![Last commit](https://img.shields.io/github/last-commit/vishalsachdev/canvas-mcp)](https://github.com/vishalsachdev/canvas-mcp) | [![Last commit](https://img.shields.io/github/last-commit/DMontgomery40/mcp-canvas-lms)](https://github.com/DMontgomery40/mcp-canvas-lms) |
 
@@ -85,7 +85,7 @@ Once configured, try these prompts with your AI client:
 
 ## Tool Inventory
 
-### All Registered Tools (116)
+### All Registered Tools (117)
 
 | Category | Tools |
 |----------|-------|
@@ -102,7 +102,7 @@ Once configured, try these prompts with your AI client:
 | Groups | `list_groups`, `list_group_members` |
 | Enrollments | `list_enrollments`, `enroll_user`, `remove_enrollment` |
 | Discussions | `list_discussions`, `get_discussion`, `list_announcements`, `post_discussion_entry`, `create_discussion`, `update_discussion`, `delete_discussion` |
-| Modules | `list_modules`, `get_module`, `list_module_items`, `get_course_structure`, `create_module`, `update_module`, `create_module_item` |
+| Modules | `list_modules`, `get_module`, `list_module_items`, `get_course_structure`, `view_course_structure`, `create_module`, `update_module`, `create_module_item` |
 | Pages | `list_pages`, `get_page`, `create_page`, `update_page`, `delete_page` |
 | Calendar | `list_calendar_events`, `create_calendar_event`, `update_calendar_event` |
 | Conversations | `list_conversations`, `get_conversation`, `get_conversation_unread_count`, `send_conversation` |
@@ -114,7 +114,7 @@ Once configured, try these prompts with your AI client:
 | Dashboard | `get_dashboard_cards`, `get_todo_items`, `get_upcoming_events`, `get_missing_submissions` |
 | FERPA (conditional) | `resolve_pseudonym` — registered only when `CANVAS_PSEUDONYMIZE_STUDENTS=true` |
 
-81 tools are read-only and 35 tools perform Canvas write operations. When FERPA mode is enabled, `resolve_pseudonym` adds a 117th read tool.
+82 tools are read-only and 35 tools perform Canvas write operations. When FERPA mode is enabled, `resolve_pseudonym` adds a 118th read tool.
 
 All write tools require appropriate Canvas permissions. Canvas enforces its own permission model -- the MCP server does not bypass it.
 
@@ -128,6 +128,16 @@ Canvas applies rate limits per-user. When creating many New Quizzes items (e.g.,
 |----------|-------------|------|
 | Course Syllabus | `canvas://course/{courseId}/syllabus` | text/html |
 | Assignment Description | `canvas://course/{courseId}/assignment/{assignmentId}/description` | text/html |
+
+### Interactive widgets
+
+`view_course_structure` is an [MCP Apps](https://github.com/modelcontextprotocol/ext-apps) tool: hosts that support the spec render an interactive tree explorer (collapsible modules, type-filter chips, title search, published/unpublished badges, links open in a new tab); hosts that don't fall back transparently to the same JSON payload that `get_course_structure` returns. The widget is self-contained — no external scripts, fonts, or network calls — and is shipped inline with the tool definition.
+
+| Tool | UI resource URI | Fallback |
+|------|----------------|----------|
+| `view_course_structure` | `ui://canvas-lms-mcp/course-structure.html` | Same JSON payload as `get_course_structure` |
+
+Host verification (Claude Desktop, ChatGPT, Codex fallback) is performed manually after each release, since it requires real Canvas credentials. A screenshot will be added once the first verified host pass lands.
 
 ## Deployment Modes
 

--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 116,
+  "toolCount": 117,
   "tools": [
     {
       "name": "health_check",
@@ -827,6 +827,18 @@
       "name": "get_course_structure",
       "domain": "modules",
       "description": "Return the full module → items tree for a course in a single call, with summary stats. Avoids N+1 round-trips when an agent needs to reason over the whole course shape.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "view_course_structure",
+      "domain": "modules",
+      "description": "Interactive tree view of a course's modules and items. Returns the same payload as `get_course_structure` and additionally links to an MCP Apps UI resource that renders an explorable tree with type filters and search. Hosts that do not support MCP Apps fall back to the JSON payload (same as `get_course_structure`).",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "canvas-lms-mcp",
   "version": "1.21.0",
   "mcpName": "io.github.bruchris/canvas-lms-mcp",
-  "description": "TypeScript MCP 1.x server for Canvas LMS — 116 tools across Canvas courses, assignments, grades, gradebook history, quizzes, New Quizzes (LTI), outcomes, discussions, admin workflows, and more.",
+  "description": "TypeScript MCP 1.x server for Canvas LMS — 117 tools across Canvas courses, assignments, grades, gradebook history, quizzes, New Quizzes (LTI), outcomes, discussions, admin workflows, and more.",
   "type": "module",
   "types": "./dist/server.d.ts",
   "exports": {
@@ -90,6 +90,7 @@
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",
+    "@modelcontextprotocol/ext-apps": "^1.7.4",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "prompts": "^2.4.2",
     "zod": "^4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
+      '@modelcontextprotocol/ext-apps':
+        specifier: ^1.7.4
+        version: 1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -498,6 +501,20 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@modelcontextprotocol/ext-apps@1.7.4':
+    resolution: {integrity: sha512-QQqysE549cf/Y0VabBmAACXhj92EhB3t8yVct2BHbkWiPTFA1S91EqTVjYXXcZEefXU0pmHcdObhsNMcomJIOQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.29.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -2185,6 +2202,12 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@modelcontextprotocol/ext-apps@1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@standard-schema/spec': 1.1.0
+      zod: 4.4.3
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -2,8 +2,10 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { CanvasClient } from '../canvas'
 import { registerSyllabusResource } from './syllabus'
 import { registerAssignmentDescriptionResource } from './assignment-description'
+import { registerCourseStructureUI } from './ui-course-structure'
 
 export function registerAllResources(server: McpServer, canvas: CanvasClient): void {
   registerSyllabusResource(server, canvas)
   registerAssignmentDescriptionResource(server, canvas)
+  registerCourseStructureUI(server)
 }

--- a/src/resources/ui-course-structure.ts
+++ b/src/resources/ui-course-structure.ts
@@ -1,0 +1,23 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { registerAppResource, RESOURCE_MIME_TYPE } from '@modelcontextprotocol/ext-apps/server'
+import { COURSE_STRUCTURE_HTML } from '../ui/course-structure.html'
+
+const RESOURCE_URI = 'ui://canvas-lms-mcp/course-structure.html'
+
+export function registerCourseStructureUI(server: McpServer): void {
+  registerAppResource(
+    server,
+    'Course Structure',
+    RESOURCE_URI,
+    { description: 'Interactive course structure tree' },
+    async () => ({
+      contents: [
+        {
+          uri: RESOURCE_URI,
+          mimeType: RESOURCE_MIME_TYPE,
+          text: COURSE_STRUCTURE_HTML,
+        },
+      ],
+    }),
+  )
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { registerAppTool } from '@modelcontextprotocol/ext-apps/server'
 import type { CanvasClient } from '../canvas'
 import { CanvasApiError } from '../canvas/client'
 import type { Pseudonymizer } from '../pseudonym/pseudonymizer'
@@ -18,6 +19,40 @@ export function getAllTools(canvas: CanvasClient, pseudonymizer?: Pseudonymizer)
   return [...domainTools, ...conditional]
 }
 
+type ToolResponse = {
+  content: { type: 'text'; text: string }[]
+  isError?: boolean
+  _meta?: Record<string, unknown>
+}
+
+function buildHandler(
+  tool: ToolDefinition,
+  pseudonymizer: Pseudonymizer | undefined,
+): (params: Record<string, unknown>, extra?: unknown) => Promise<ToolResponse> {
+  return async (params) => {
+    try {
+      const result = await tool.handler(params)
+      const text =
+        result === undefined ? 'Operation completed successfully.' : JSON.stringify(result, null, 2)
+      const response: ToolResponse = {
+        content: [{ type: 'text' as const, text }],
+      }
+      if (pseudonymizer?.isEnabled()) {
+        response._meta = { pseudonymized: true, note: PSEUDONYM_META_NOTE }
+      }
+      return response
+    } catch (error) {
+      if (!(error instanceof CanvasApiError)) {
+        console.error(`Unexpected error in tool "${tool.name}":`, error)
+      }
+      return {
+        content: [{ type: 'text' as const, text: formatError(error) }],
+        isError: true,
+      }
+    }
+  }
+}
+
 export function registerAllTools(
   server: McpServer,
   canvas: CanvasClient,
@@ -25,35 +60,22 @@ export function registerAllTools(
 ): void {
   const tools = getAllTools(canvas, pseudonymizer)
   for (const tool of tools) {
-    server.tool(tool.name, tool.description, tool.inputSchema, tool.annotations, async (params) => {
-      try {
-        const result = await tool.handler(params as Record<string, unknown>)
-        const text =
-          result === undefined
-            ? 'Operation completed successfully.'
-            : JSON.stringify(result, null, 2)
-        const response: {
-          content: { type: 'text'; text: string }[]
-          _meta?: Record<string, unknown>
-        } = {
-          content: [{ type: 'text' as const, text }],
-        }
-        if (pseudonymizer?.isEnabled()) {
-          response._meta = { pseudonymized: true, note: PSEUDONYM_META_NOTE }
-        }
-        return response
-      } catch (error) {
-        if (error instanceof CanvasApiError) {
-          // CanvasApiError — expected, no need to log
-        } else {
-          console.error(`Unexpected error in tool "${tool.name}":`, error)
-        }
-        return {
-          content: [{ type: 'text' as const, text: formatError(error) }],
-          isError: true,
-        }
-      }
-    })
+    const handler = buildHandler(tool, pseudonymizer)
+    if (tool.ui) {
+      registerAppTool(
+        server,
+        tool.name,
+        {
+          description: tool.description,
+          inputSchema: tool.inputSchema,
+          annotations: tool.annotations,
+          _meta: { ui: { resourceUri: tool.ui.resourceUri } },
+        },
+        handler,
+      )
+    } else {
+      server.tool(tool.name, tool.description, tool.inputSchema, tool.annotations, handler)
+    }
   }
 }
 export { formatError } from './errors'

--- a/src/tools/modules.ts
+++ b/src/tools/modules.ts
@@ -83,6 +83,45 @@ export function moduleTools(canvas: CanvasClient): ToolDefinition[] {
       },
     },
     {
+      // See docs/superpowers/specs/2026-06-11-mcp-apps-spike-course-structure.md.
+      // Payload is content metadata only — no student PII. If a future revision adds
+      // include_progress, instructors[], or per-student fields, this tool MUST be added
+      // to PSEUDONYMIZER_WRAPPED_TOOLS and wrapped at the handler.
+      name: 'view_course_structure',
+      description:
+        "Interactive tree view of a course's modules and items. Returns the same payload as `get_course_structure` and additionally links to an MCP Apps UI resource that renders an explorable tree with type filters and search. Hosts that do not support MCP Apps fall back to the JSON payload (same as `get_course_structure`).",
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        include_published_only: z
+          .boolean()
+          .optional()
+          .describe('When true, exclude unpublished items (default: false)'),
+        include_content_details: z
+          .boolean()
+          .optional()
+          .describe('When true, fetch content_details for each item (default: false)'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      ui: {
+        resourceUri: 'ui://canvas-lms-mcp/course-structure.html',
+        csp: {
+          connectDomains: [],
+          resourceDomains: [],
+          frameDomains: [],
+        },
+      },
+      handler: async (params) => {
+        const course_id = params.course_id as number
+        return canvas.modules.getCourseStructure(course_id, {
+          includePublishedOnly: params.include_published_only as boolean | undefined,
+          includeContentDetails: params.include_content_details as boolean | undefined,
+        })
+      },
+    },
+    {
       name: 'create_module',
       description: 'Create a new module in a course.',
       inputSchema: {

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -9,10 +9,22 @@ export interface ToolAnnotations {
   openWorldHint?: boolean
 }
 
+export interface ToolUiCsp {
+  connectDomains?: string[]
+  resourceDomains?: string[]
+  frameDomains?: string[]
+}
+
+export interface ToolUiBinding {
+  resourceUri: string
+  csp?: ToolUiCsp
+}
+
 export interface ToolDefinition {
   name: string
   description: string
   inputSchema: Record<string, z.ZodType>
   annotations: ToolAnnotations
   handler: (params: Record<string, unknown>) => Promise<unknown>
+  ui?: ToolUiBinding
 }

--- a/src/ui/course-structure.html.ts
+++ b/src/ui/course-structure.html.ts
@@ -1,0 +1,383 @@
+// Self-contained widget for `view_course_structure`. The host injects a CallToolResult
+// into a known sink (e.g., `window.openai.toolResult`); the widget renders an
+// interactive tree without making any network requests. CSP intentionally empty.
+export const COURSE_STRUCTURE_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Course Structure</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --fg: #1f2328;
+    --fg-muted: #6e7781;
+    --bg: #ffffff;
+    --bg-subtle: #f6f8fa;
+    --border: #d0d7de;
+    --accent: #0969da;
+    --warn: #9a6700;
+    --pill-bg: #eaeef2;
+    --pill-fg: #1f2328;
+    --pill-on-bg: #0969da;
+    --pill-on-fg: #ffffff;
+    --unpub-bg: #fff8c5;
+    --unpub-fg: #7d4e00;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --fg: #e6edf3;
+      --fg-muted: #8b949e;
+      --bg: #0d1117;
+      --bg-subtle: #161b22;
+      --border: #30363d;
+      --accent: #58a6ff;
+      --warn: #d29922;
+      --pill-bg: #21262d;
+      --pill-fg: #e6edf3;
+      --pill-on-bg: #1f6feb;
+      --pill-on-fg: #ffffff;
+      --unpub-bg: #3a2c00;
+      --unpub-fg: #f0c674;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    padding: 16px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-size: 14px;
+    color: var(--fg);
+    background: var(--bg);
+    line-height: 1.5;
+  }
+  .summary {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 8px 16px;
+    padding: 8px 12px;
+    background: var(--bg-subtle);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    margin-bottom: 12px;
+  }
+  .summary strong { font-size: 15px; }
+  .summary .by-type { color: var(--fg-muted); }
+  .controls { display: flex; flex-direction: column; gap: 8px; margin-bottom: 12px; }
+  .search {
+    width: 100%;
+    padding: 6px 10px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg);
+    color: var(--fg);
+    font: inherit;
+  }
+  .search:focus { outline: 2px solid var(--accent); outline-offset: -1px; }
+  .chips { display: flex; flex-wrap: wrap; gap: 6px; }
+  .chip {
+    border: 1px solid var(--border);
+    background: var(--pill-bg);
+    color: var(--pill-fg);
+    border-radius: 999px;
+    padding: 2px 10px;
+    font-size: 12px;
+    cursor: pointer;
+    user-select: none;
+  }
+  .chip.on { background: var(--pill-on-bg); color: var(--pill-on-fg); border-color: transparent; }
+  .modules { display: flex; flex-direction: column; gap: 8px; }
+  details.module {
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg);
+    overflow: hidden;
+  }
+  details.module > summary {
+    padding: 8px 12px;
+    background: var(--bg-subtle);
+    cursor: pointer;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  details.module > summary::-webkit-details-marker { display: none; }
+  details.module > summary::before {
+    content: "▶";
+    font-size: 10px;
+    color: var(--fg-muted);
+    transition: transform 0.15s ease;
+  }
+  details.module[open] > summary::before { transform: rotate(90deg); }
+  .module-title { font-weight: 600; }
+  .module-meta { color: var(--fg-muted); font-size: 12px; }
+  ul.items { list-style: none; margin: 0; padding: 4px 12px 8px 28px; }
+  ul.items li {
+    padding: 4px 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  ul.items li.hidden { display: none; }
+  .type-tag {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    color: var(--fg-muted);
+    min-width: 84px;
+  }
+  .item-title { color: var(--accent); text-decoration: none; }
+  .item-title:hover { text-decoration: underline; }
+  .item-title.no-link { color: var(--fg); }
+  .badge {
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+  }
+  .badge.unpublished { background: var(--unpub-bg); color: var(--unpub-fg); }
+  .empty {
+    padding: 24px;
+    text-align: center;
+    color: var(--fg-muted);
+    border: 1px dashed var(--border);
+    border-radius: 6px;
+  }
+  .empty code {
+    background: var(--bg-subtle);
+    padding: 1px 4px;
+    border-radius: 3px;
+  }
+</style>
+</head>
+<body>
+<div id="root" class="empty">Loading course structure…</div>
+<script>
+(function () {
+  'use strict';
+
+  var ITEM_TYPES = [
+    'Assignment',
+    'Page',
+    'Quiz',
+    'File',
+    'Discussion',
+    'ExternalUrl',
+    'ExternalTool',
+    'SubHeader',
+  ];
+
+  function readPayload() {
+    // Multi-sink probe: try documented hosts in order, fall back to a known shim variable.
+    try {
+      var openai = window.openai;
+      if (openai && openai.toolResult) return openai.toolResult;
+    } catch (_) {}
+    try {
+      if (window.__MCP_TOOL_RESULT__) return window.__MCP_TOOL_RESULT__;
+    } catch (_) {}
+    return null;
+  }
+
+  function extractStructure(result) {
+    if (!result || typeof result !== 'object') return null;
+    // Some hosts pass the CallToolResult envelope, others pass the parsed payload directly.
+    if (Array.isArray(result.modules) && result.summary) return result;
+    if (Array.isArray(result.content)) {
+      for (var i = 0; i < result.content.length; i++) {
+        var block = result.content[i];
+        if (block && block.type === 'text' && typeof block.text === 'string') {
+          try {
+            var parsed = JSON.parse(block.text);
+            if (parsed && Array.isArray(parsed.modules) && parsed.summary) return parsed;
+          } catch (_) {}
+        }
+      }
+    }
+    return null;
+  }
+
+  function renderEmpty(message) {
+    var root = document.getElementById('root');
+    root.className = 'empty';
+    root.textContent = '';
+    var p = document.createElement('div');
+    p.textContent = message;
+    root.appendChild(p);
+  }
+
+  function renderUnsupportedHost() {
+    renderEmpty('Open this tool in a host that supports MCP Apps to see the interactive course structure tree.');
+  }
+
+  function renderUnexpectedShape() {
+    renderEmpty('Unexpected payload shape — expected get_course_structure response.');
+  }
+
+  function el(tag, attrs, children) {
+    var node = document.createElement(tag);
+    if (attrs) {
+      for (var k in attrs) {
+        if (!Object.prototype.hasOwnProperty.call(attrs, k)) continue;
+        var v = attrs[k];
+        if (k === 'class') node.className = v;
+        else if (k === 'text') node.textContent = v;
+        else node.setAttribute(k, v);
+      }
+    }
+    if (children) {
+      for (var i = 0; i < children.length; i++) {
+        if (children[i] != null) node.appendChild(children[i]);
+      }
+    }
+    return node;
+  }
+
+  function renderStructure(data) {
+    var root = document.getElementById('root');
+    root.className = '';
+    root.textContent = '';
+
+    var summary = data.summary || {};
+    var itemsByType = summary.items_by_type || {};
+    var typeChips = ITEM_TYPES.filter(function (t) {
+      return Object.prototype.hasOwnProperty.call(itemsByType, t);
+    });
+
+    // Summary header.
+    var summaryEl = el('div', { class: 'summary' }, [
+      el('strong', { text: (summary.total_modules || 0) + ' modules' }),
+      el('span', { text: (summary.total_items || 0) + ' items' }),
+    ]);
+    if (typeChips.length) {
+      var byType = typeChips
+        .map(function (t) {
+          return t + ': ' + itemsByType[t];
+        })
+        .join(' • ');
+      summaryEl.appendChild(el('span', { class: 'by-type', text: byType }));
+    }
+    root.appendChild(summaryEl);
+
+    // Controls: search + filter chips.
+    var search = el('input', {
+      class: 'search',
+      type: 'search',
+      placeholder: 'Search items by title…',
+      'aria-label': 'Search items by title',
+    });
+
+    var activeTypes = {};
+    var chipEls = {};
+    var chipsContainer = el('div', { class: 'chips' });
+    typeChips.forEach(function (t) {
+      var chip = el('button', { class: 'chip', type: 'button', text: t });
+      chipEls[t] = chip;
+      chip.addEventListener('click', function () {
+        if (activeTypes[t]) {
+          delete activeTypes[t];
+          chip.classList.remove('on');
+        } else {
+          activeTypes[t] = true;
+          chip.classList.add('on');
+        }
+        applyFilter();
+      });
+      chipsContainer.appendChild(chip);
+    });
+    root.appendChild(el('div', { class: 'controls' }, [search, chipsContainer]));
+
+    // Module tree.
+    var modulesContainer = el('div', { class: 'modules' });
+    var itemNodes = [];
+
+    (data.modules || []).forEach(function (mod) {
+      var moduleDetails = el('details', { class: 'module' });
+      moduleDetails.open = true;
+      var headerLabel = mod.name || 'Module ' + (mod.id != null ? mod.id : '');
+      var moduleMeta = '';
+      var itemsCount = Array.isArray(mod.items) ? mod.items.length : 0;
+      moduleMeta = itemsCount + (itemsCount === 1 ? ' item' : ' items');
+      if (mod.state && mod.state !== 'active') moduleMeta += ' • ' + mod.state;
+      var moduleSummary = el('summary', null, [
+        el('span', { class: 'module-title', text: headerLabel }),
+        el('span', { class: 'module-meta', text: moduleMeta }),
+      ]);
+      moduleDetails.appendChild(moduleSummary);
+
+      var itemList = el('ul', { class: 'items' });
+      (mod.items || []).forEach(function (item) {
+        var titleNode;
+        if (item.html_url) {
+          titleNode = el('a', {
+            class: 'item-title',
+            href: item.html_url,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+            text: item.title || '(untitled)',
+          });
+        } else {
+          titleNode = el('span', { class: 'item-title no-link', text: item.title || '(untitled)' });
+        }
+        var children = [el('span', { class: 'type-tag', text: item.type || 'Unknown' }), titleNode];
+        if (item.published === false) {
+          children.push(el('span', { class: 'badge unpublished', text: 'unpublished' }));
+        }
+        var li = el('li', null, children);
+        li.dataset.type = item.type || '';
+        li.dataset.title = (item.title || '').toLowerCase();
+        itemList.appendChild(li);
+        itemNodes.push(li);
+      });
+      moduleDetails.appendChild(itemList);
+      modulesContainer.appendChild(moduleDetails);
+    });
+    root.appendChild(modulesContainer);
+
+    function applyFilter() {
+      var q = search.value.trim().toLowerCase();
+      var typeKeys = Object.keys(activeTypes);
+      var hasTypeFilter = typeKeys.length > 0;
+      for (var i = 0; i < itemNodes.length; i++) {
+        var node = itemNodes[i];
+        var typeOk = !hasTypeFilter || !!activeTypes[node.dataset.type];
+        var textOk = !q || node.dataset.title.indexOf(q) !== -1;
+        node.classList.toggle('hidden', !(typeOk && textOk));
+      }
+    }
+
+    search.addEventListener('input', applyFilter);
+  }
+
+  function init() {
+    var payload = readPayload();
+    if (payload == null) {
+      renderUnsupportedHost();
+      return;
+    }
+    var structure = extractStructure(payload);
+    if (!structure) {
+      renderUnexpectedShape();
+      return;
+    }
+    try {
+      renderStructure(structure);
+    } catch (err) {
+      console.error('view_course_structure render error', err);
+      renderUnexpectedShape();
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();
+</script>
+</body>
+</html>`

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(116)
+    expect(manifest.tools).toHaveLength(117)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/resources/ui-course-structure.test.ts
+++ b/tests/resources/ui-course-structure.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { RESOURCE_MIME_TYPE } from '@modelcontextprotocol/ext-apps/server'
+import { registerCourseStructureUI } from '../../src/resources/ui-course-structure'
+
+const RESOURCE_URI = 'ui://canvas-lms-mcp/course-structure.html'
+
+describe('registerCourseStructureUI', () => {
+  function captureHandler() {
+    const server = new McpServer({ name: 'test', version: '1.0.0' })
+    const spy = vi.spyOn(server, 'registerResource')
+    registerCourseStructureUI(server)
+    const call = spy.mock.calls[0]
+    // server.registerResource(name, uri, config, callback) — callback is last
+    return call[call.length - 1] as (
+      uri: URL,
+      extra: Record<string, unknown>,
+    ) => Promise<{ contents: Array<{ uri: string; mimeType?: string; text: string }> }>
+  }
+
+  it('registers without throwing', () => {
+    const server = new McpServer({ name: 'test', version: '1.0.0' })
+    expect(() => registerCourseStructureUI(server)).not.toThrow()
+  })
+
+  it('returns content with the MCP Apps mime type', async () => {
+    const handler = captureHandler()
+    const result = await handler(new URL(RESOURCE_URI), {})
+    expect(result.contents[0].mimeType).toBe(RESOURCE_MIME_TYPE)
+  })
+
+  it('returns HTML content at the expected URI', async () => {
+    const handler = captureHandler()
+    const result = await handler(new URL(RESOURCE_URI), {})
+    expect(result.contents[0].uri).toBe(RESOURCE_URI)
+    expect(result.contents[0].text).toMatch(/<!doctype html>/i)
+  })
+
+  it('preserves the multi-sink data injection probe', async () => {
+    const handler = captureHandler()
+    const result = await handler(new URL(RESOURCE_URI), {})
+    const html = result.contents[0].text
+    // The widget must probe window.openai.toolResult first, then a fallback sink.
+    expect(html).toContain('window.openai')
+    expect(html).toContain('window.__MCP_TOOL_RESULT__')
+  })
+
+  it('renders module and item chrome that the payload will populate', async () => {
+    const handler = captureHandler()
+    const result = await handler(new URL(RESOURCE_URI), {})
+    const html = result.contents[0].text
+    // Sanity check the widget surfaces the expected UI affordances.
+    expect(html).toContain('modules')
+    expect(html).toContain('items')
+  })
+})

--- a/tests/tools/modules.test.ts
+++ b/tests/tools/modules.test.ts
@@ -46,8 +46,8 @@ describe('moduleTools', () => {
     } as unknown as CanvasClient
   }
 
-  it('returns an array with 7 tool definitions', () => {
-    expect(moduleTools(buildMockCanvas())).toHaveLength(7)
+  it('returns an array with 8 tool definitions', () => {
+    expect(moduleTools(buildMockCanvas())).toHaveLength(8)
   })
 
   it('exports tools with correct names', () => {
@@ -57,6 +57,7 @@ describe('moduleTools', () => {
       'get_module',
       'list_module_items',
       'get_course_structure',
+      'view_course_structure',
       'create_module',
       'update_module',
       'create_module_item',
@@ -133,6 +134,61 @@ describe('moduleTools', () => {
         includePublishedOnly: true,
         includeContentDetails: true,
       })
+    })
+  })
+
+  describe('view_course_structure', () => {
+    it('has read-only annotations', () => {
+      const tool = moduleTools(buildMockCanvas()).find((t) => t.name === 'view_course_structure')!
+      expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+    })
+
+    it('declares the UI resource URI', () => {
+      const tool = moduleTools(buildMockCanvas()).find((t) => t.name === 'view_course_structure')!
+      expect(tool.ui?.resourceUri).toBe('ui://canvas-lms-mcp/course-structure.html')
+    })
+
+    it('keeps CSP empty (widget is self-contained)', () => {
+      const tool = moduleTools(buildMockCanvas()).find((t) => t.name === 'view_course_structure')!
+      expect(tool.ui?.csp).toEqual({
+        connectDomains: [],
+        resourceDomains: [],
+        frameDomains: [],
+      })
+    })
+
+    it('delegates to canvas.modules.getCourseStructure with defaults', async () => {
+      const canvas = buildMockCanvas()
+      const tool = moduleTools(canvas).find((t) => t.name === 'view_course_structure')!
+      await tool.handler({ course_id: 1 })
+      expect(canvas.modules.getCourseStructure).toHaveBeenCalledWith(1, {
+        includePublishedOnly: undefined,
+        includeContentDetails: undefined,
+      })
+    })
+
+    it('passes options through to getCourseStructure', async () => {
+      const canvas = buildMockCanvas()
+      const tool = moduleTools(canvas).find((t) => t.name === 'view_course_structure')!
+      await tool.handler({
+        course_id: 1,
+        include_published_only: true,
+        include_content_details: true,
+      })
+      expect(canvas.modules.getCourseStructure).toHaveBeenCalledWith(1, {
+        includePublishedOnly: true,
+        includeContentDetails: true,
+      })
+    })
+
+    it('returns the same payload shape as get_course_structure', async () => {
+      const canvas = buildMockCanvas()
+      const tools = moduleTools(canvas)
+      const get = tools.find((t) => t.name === 'get_course_structure')!
+      const view = tools.find((t) => t.name === 'view_course_structure')!
+      const getResult = await get.handler({ course_id: 1 })
+      const viewResult = await view.handler({ course_id: 1 })
+      expect(viewResult).toEqual(getResult)
     })
   })
 

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -170,7 +170,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 116 tools across all domains', () => {
+  it('returns all 117 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 
@@ -241,11 +241,12 @@ describe('getAllTools', () => {
     expect(names).toContain('create_discussion')
     expect(names).toContain('update_discussion')
     expect(names).toContain('delete_discussion')
-    // Modules (7)
+    // Modules (8)
     expect(names).toContain('list_modules')
     expect(names).toContain('get_module')
     expect(names).toContain('list_module_items')
     expect(names).toContain('get_course_structure')
+    expect(names).toContain('view_course_structure')
     expect(names).toContain('create_module')
     expect(names).toContain('update_module')
     expect(names).toContain('create_module_item')
@@ -314,7 +315,7 @@ describe('getAllTools', () => {
     expect(names).toContain('update_new_quiz_item')
     expect(names).toContain('delete_new_quiz_item')
 
-    expect(tools).toHaveLength(116)
+    expect(tools).toHaveLength(117)
   })
 
   it('all tools have openWorldHint: true', () => {


### PR DESCRIPTION
## Summary

Implements [BRU-1574](https://github.com/users/bruchris/projects/2). Adds the first MCP Apps widget — `view_course_structure` — per the design at `docs/superpowers/specs/2026-06-11-mcp-apps-spike-course-structure.md` (PR #168, commit b3c3f72).

- New tool `view_course_structure` returns the same payload as `get_course_structure` (delegates to `canvas.modules.getCourseStructure`) and additionally links to a UI resource at `ui://canvas-lms-mcp/course-structure.html`.
- New resource serves a self-contained vanilla JS/CSS tree explorer (collapsible per-module tree, item-type filter chips, type-ahead title search, published/unpublished badges, links open in a new tab, summary header with per-type counts).
- Hosts without MCP Apps support transparently fall back to the JSON payload — they ignore the unknown `_meta.ui.resourceUri` field per the MCP spec.
- `get_course_structure` is unchanged.

## Implementation notes

- Added `@modelcontextprotocol/ext-apps@^1.7.4` as a runtime dependency.
- Extended `ToolDefinition` with optional `ui?: { resourceUri; csp? }`. The tool registration loop in `src/tools/index.ts` branches on `tool.ui`: if present, it calls `registerAppTool` (which injects `_meta.ui.resourceUri`); otherwise it stays on the existing `server.tool` path. Pseudonymizer `_meta` continues to merge cleanly because `_meta.ui` and `_meta.pseudonymized` are independent keys.
- CSP is intentionally empty (`connectDomains: []`, `resourceDomains: []`, `frameDomains: []`) — the widget is self-contained, makes no outbound requests, uses the system font stack, and renders only what the server passes via the tool result. The SDK enforces secure-empty as the default, so the resource doesn't need to declare CSP explicitly; the empty CSP on the tool definition documents intent for future readers.
- Multi-sink data probe in the widget: tries `window.openai?.toolResult` first, falls back to `window.__MCP_TOOL_RESULT__`, finally renders a friendly "open in a host that supports MCP Apps" message. Also has a runtime guard that renders an "unexpected payload shape" message rather than crashing if the data doesn't match `CanvasCourseStructure`.
- Light/dark themes via `prefers-color-scheme`.
- Spec said to put `csp` on the tool definition; the actual ext-apps SDK v1.7.4 enforces CSP on the **resource**, not the tool (`McpUiToolMeta.csp: never`). Per the issue's "follow the SDK, don't force the spec" guidance, the type extension keeps `ui.csp` as a documented intent surface, but the registration branch only passes `_meta.ui.resourceUri` through to `registerAppTool`. The empty-CSP intent matches the SDK's secure-empty default for the resource, so the runtime behavior matches the spec.

## Size

Inlined widget HTML+CSS+JS:

- raw: **11 KB** (under the spec's ~15 KB cap)
- gzipped: **3.6 KB**

The `@modelcontextprotocol/ext-apps` SDK adds a one-time ~80 KB to the dependency closure.

## Pseudonymizer

Intentionally **not** added to `PSEUDONYMIZER_WRAPPED_TOOLS`. The payload is content metadata only — no `CanvasUser`, `participants`, `user_name`, or per-student field. See spec section 2 and the comment on the `view_course_structure` handler. If a future revision adds `include_progress`, `instructors[]`, or per-student data, the tool MUST be wrapped and listed in `PSEUDONYMIZER_WRAPPED_TOOLS`.

## Validation

\`\`\`
pnpm typecheck   # ✅
pnpm lint        # ✅
pnpm test        # ✅ 902 passed | 1 skipped (903 total)
pnpm build       # ✅
\`\`\`

`view_course_structure` appears in `docs/generated/tool-manifest.json` (regenerated). Tool count bumped to 117 in README, package.json description, and the registry/manifest tests.

## Test plan

- [x] TDD red-green-refactor cycle followed for the new tool + resource
- [x] Extended `tests/tools/modules.test.ts` to cover annotations, UI binding, CSP shape, handler delegation, and same-payload-as-`get_course_structure`
- [x] Added `tests/resources/ui-course-structure.test.ts` covering registration, mime type, URI, multi-sink probe sentinels, and module/items chrome in the HTML
- [x] Updated `tests/tools/registry.test.ts` (modules count 7→8, total 116→117) and `tests/discovery/manifests.test.ts` (116→117)
- [x] `tests/pseudonym/coverage.test.ts` untouched — payload has no PII
- [ ] Manual host verification (Claude Desktop, ChatGPT, Codex fallback) — not done in this PR; requires real Canvas credentials. The board will run host verification after merge.

## Out of scope (per the issue)

- Tool callbacks from the iframe (v2)
- Bulk publish/unpublish, drag-and-drop reorder (v2)
- Telemetry, localization, "Copy as Markdown" button, `--enable-ui-widgets` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)