### PR TITLE
chore: ignore .tmp scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 .DS_Store
 .mcpb-staging/
 *.mcpb
+.tmp/


### PR DESCRIPTION
## Summary

Adds `.tmp/` to `.gitignore`. Local agent sessions use the directory for API payload files and fetch scratch (it showed up as untracked noise in `git status`); it should never be committed.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)