### PR TITLE
feat: add list_students_needing_attention tool (Signal B) [BRU-1593]

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 MCP server for [Canvas LMS](https://www.instructure.com/canvas). Read courses, assignments, submissions, rubrics, quizzes; grade, comment, manage course content, and handle Canvas admin workflows from any AI agent.
 
-118 tools across Canvas courses, assignments, submissions, gradebook history, rubrics, quizzes, New Quizzes (LTI), files, users, groups, enrollments, discussions, modules, pages, calendar, conversations, peer reviews, accounts, analytics, outcomes, student workflows, dashboard, instructor attention workflows, and health checks. Three deployment modes: stdio, HTTP, and library import.
+119 tools across Canvas courses, assignments, submissions, gradebook history, rubrics, quizzes, New Quizzes (LTI), files, users, groups, enrollments, discussions, modules, pages, calendar, conversations, peer reviews, accounts, analytics, outcomes, student workflows, dashboard, instructor attention workflows, and health checks. Three deployment modes: stdio, HTTP, and library import.
 
 ## One-click install (Claude Desktop)
 
@@ -28,7 +28,7 @@ Prefer the terminal? Use the [Quick Start](#quick-start) below.
 | | canvas-lms-mcp | [vishalsachdev/canvas-mcp](https://github.com/vishalsachdev/canvas-mcp) | [DMontgomery40/mcp-canvas-lms](https://github.com/DMontgomery40/mcp-canvas-lms) |
 |---|---|---|---|
 | Language | TypeScript | Python | TypeScript |
-| Tools | 118 | 80+ | 54 |
+| Tools | 119 | 80+ | 54 |
 | License | [![License: MIT](https://img.shields.io/github/license/bruchris/canvas-lms-mcp)](https://github.com/bruchris/canvas-lms-mcp/blob/main/LICENSE) | [![License](https://img.shields.io/github/license/vishalsachdev/canvas-mcp)](https://github.com/vishalsachdev/canvas-mcp/blob/main/LICENSE) | [![License](https://img.shields.io/github/license/DMontgomery40/mcp-canvas-lms)](https://github.com/DMontgomery40/mcp-canvas-lms/blob/main/LICENSE) |
 | Last commit | [![Last commit](https://img.shields.io/github/last-commit/bruchris/canvas-lms-mcp)](https://github.com/bruchris/canvas-lms-mcp) | [![Last commit](https://img.shields.io/github/last-commit/vishalsachdev/canvas-mcp)](https://github.com/vishalsachdev/canvas-mcp) | [![Last commit](https://img.shields.io/github/last-commit/DMontgomery40/mcp-canvas-lms)](https://github.com/DMontgomery40/mcp-canvas-lms) |
 
@@ -85,7 +85,7 @@ Once configured, try these prompts with your AI client:
 
 ## Tool Inventory
 
-### All Registered Tools (118)
+### All Registered Tools (119)
 
 | Category | Tools |
 |----------|-------|
@@ -112,10 +112,10 @@ Once configured, try these prompts with your AI client:
 | Outcomes | `get_root_outcome_group`, `list_outcome_groups`, `list_outcome_group_links`, `get_outcome_group`, `list_outcome_group_outcomes`, `list_outcome_group_subgroups`, `get_outcome`, `get_outcome_alignments`, `get_outcome_results`, `get_outcome_rollups`, `get_outcome_contributing_scores`, `get_outcome_mastery_distribution` |
 | Student | `get_my_courses`, `get_my_grades`, `get_my_submissions`, `get_my_upcoming_assignments` |
 | Dashboard | `get_dashboard_cards`, `get_todo_items`, `get_upcoming_events`, `get_missing_submissions` |
-| Attention | `list_submission_comments_needing_attention` |
+| Attention | `list_submission_comments_needing_attention`, `list_students_needing_attention` |
 | FERPA (conditional) | `resolve_pseudonym` — registered only when `CANVAS_PSEUDONYMIZE_STUDENTS=true` |
 
-83 tools are read-only and 35 tools perform Canvas write operations. When FERPA mode is enabled, `resolve_pseudonym` adds a 119th read tool.
+84 tools are read-only and 35 tools perform Canvas write operations. When FERPA mode is enabled, `resolve_pseudonym` adds a 120th read tool.
 
 All write tools require appropriate Canvas permissions. Canvas enforces its own permission model -- the MCP server does not bypass it.
 

--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 118,
+  "toolCount": 119,
   "tools": [
     {
       "name": "health_check",
@@ -1451,6 +1451,18 @@
       "name": "list_submission_comments_needing_attention",
       "domain": "attention",
       "description": "List submissions where the most recent comment is from the student and has not been addressed by grading or a reply — i.e. comments the instructor has likely not seen. Returns a triage list, oldest-unaddressed first. Requires instructor/TA permissions in the course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_students_needing_attention",
+      "domain": "attention",
+      "description": "Report students who may need instructor attention based on inactivity, missing or late submissions, and low current score. Each finding lists the exact signals that fired and the thresholds used — this is a factual report, not a prediction. Requires instructor/TA permissions in the course.",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true

--- a/src/canvas/analytics.ts
+++ b/src/canvas/analytics.ts
@@ -3,6 +3,7 @@ import type {
   CanvasCourseActivitySummary,
   CanvasStudentActivitySummary,
   CanvasActivityStreamItem,
+  CanvasStudentSummary,
   CourseSearchResult,
 } from './types'
 
@@ -97,6 +98,12 @@ export class AnalyticsModule {
   async getCourseActivityStream(courseId: number): Promise<CanvasActivityStreamItem[]> {
     return this.client.request<CanvasActivityStreamItem[]>(
       `/api/v1/courses/${courseId}/activity_stream/summary`,
+    )
+  }
+
+  async getStudentSummaries(courseId: number): Promise<CanvasStudentSummary[]> {
+    return this.client.paginate<CanvasStudentSummary>(
+      `/api/v1/courses/${courseId}/analytics/student_summaries`,
     )
   }
 }

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -857,6 +857,23 @@ export interface CanvasActivityStreamItem {
   unread_count: number
 }
 
+export interface CanvasStudentSummary {
+  id: number
+  page_views: number
+  max_page_views?: number
+  page_views_level?: number
+  participations: number
+  max_participations?: number
+  participations_level?: number
+  tardiness_breakdown: {
+    total: number
+    on_time: number
+    late: number
+    missing: number
+    floating: number
+  }
+}
+
 export interface CourseSearchResult {
   id: number
   title: string

--- a/src/pseudonym/coverage.ts
+++ b/src/pseudonym/coverage.ts
@@ -49,4 +49,5 @@ export const PSEUDONYMIZER_WRAPPED_TOOLS: readonly string[] = [
 
   // src/tools/attention.ts
   'list_submission_comments_needing_attention',
+  'list_students_needing_attention',
 ] as const

--- a/src/tools/attention.ts
+++ b/src/tools/attention.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod'
+import { CanvasApiError } from '../canvas/client'
 import type { CanvasClient } from '../canvas'
-import type { CanvasSubmission, CanvasSubmissionComment } from '../canvas/types'
+import type {
+  CanvasSubmission,
+  CanvasSubmissionComment,
+  CanvasStudentSummary,
+} from '../canvas/types'
 import type { Pseudonymizer } from '../pseudonym/pseudonymizer'
 import type { ToolDefinition } from './types'
 
@@ -139,6 +144,174 @@ export function attentionTools(
           findings_count: findings.length,
           findings,
         }
+      },
+    },
+    {
+      name: 'list_students_needing_attention',
+      description:
+        'Report students who may need instructor attention based on inactivity, missing or late submissions, and low current score. Each finding lists the exact signals that fired and the thresholds used — this is a factual report, not a prediction. Requires instructor/TA permissions in the course.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        inactive_days: z
+          .number()
+          .optional()
+          .describe('Flag students with no activity in the last N days (default 7)'),
+        min_missing: z
+          .number()
+          .optional()
+          .describe('Flag students with at least N missing submissions (default 1)'),
+        min_late: z
+          .number()
+          .optional()
+          .describe('Flag students with at least N late submissions (default 3)'),
+        score_threshold: z
+          .number()
+          .optional()
+          .describe('Flag students with a current score below this value (default 70)'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+        const inactiveDays = (params.inactive_days as number | undefined) ?? 7
+        const minMissing = (params.min_missing as number | undefined) ?? 1
+        const minLate = (params.min_late as number | undefined) ?? 3
+        const scoreThreshold = (params.score_threshold as number | undefined) ?? 70
+
+        const thresholds = {
+          inactive_days: inactiveDays,
+          min_missing: minMissing,
+          min_late: minLate,
+          score_threshold: scoreThreshold,
+        }
+
+        const rawEnrollments = await canvas.enrollments.listForCourse(courseId, {
+          type: ['StudentEnrollment'],
+          state: ['active'],
+          include: ['grades'],
+        })
+
+        const enrollments = pseudonymizer?.isEnabled()
+          ? await Promise.all(
+              rawEnrollments.map((e) => pseudonymizer.anonymizeEnrollment(courseId, e)),
+            )
+          : rawEnrollments
+
+        const summaryMap = new Map<number, CanvasStudentSummary>()
+        let analyticsAvailable = true
+        try {
+          const summaries = await canvas.analytics.getStudentSummaries(courseId)
+          for (const s of summaries) {
+            summaryMap.set(s.id, s)
+          }
+        } catch (err) {
+          if (err instanceof CanvasApiError && err.status === 404) {
+            analyticsAvailable = false
+          } else {
+            throw err
+          }
+        }
+
+        const now = Date.now()
+        const inactiveCutoffMs = inactiveDays * 24 * 60 * 60 * 1000
+        const riskOrder: Record<string, number> = { high: 0, medium: 1, low: 2 }
+
+        const findings: object[] = []
+
+        for (const e of enrollments) {
+          const signals: object[] = []
+          const summary = summaryMap.get(e.user_id)
+
+          const lastActivityMs = e.last_activity_at ? new Date(e.last_activity_at).getTime() : null
+          if (lastActivityMs === null || now - lastActivityMs > inactiveCutoffMs) {
+            const daysSince =
+              lastActivityMs !== null
+                ? Math.floor((now - lastActivityMs) / (24 * 60 * 60 * 1000))
+                : null
+            signals.push({
+              type: 'inactive',
+              value: e.last_activity_at ?? null,
+              threshold: `${inactiveDays} days`,
+              detail:
+                daysSince !== null
+                  ? `No course activity for ${daysSince} days`
+                  : 'No course activity recorded',
+            })
+          }
+
+          const score = e.grades?.current_score ?? null
+          if (score !== null && score < scoreThreshold) {
+            signals.push({
+              type: 'low_score',
+              value: score,
+              threshold: scoreThreshold,
+              detail: `Current score ${score}%`,
+            })
+          }
+
+          if (analyticsAvailable && summary) {
+            const tb = summary.tardiness_breakdown
+            if (tb.missing >= minMissing) {
+              signals.push({
+                type: 'missing_submissions',
+                value: tb.missing,
+                threshold: minMissing,
+                detail: `${tb.missing} assignment${tb.missing === 1 ? '' : 's'} missing`,
+              })
+            }
+            if (tb.late >= minLate) {
+              signals.push({
+                type: 'late_pattern',
+                value: tb.late,
+                threshold: minLate,
+                detail: `${tb.late} assignment${tb.late === 1 ? '' : 's'} late`,
+              })
+            }
+          }
+
+          if (signals.length === 0) continue
+
+          const count = signals.length
+          const riskLevel = count >= 3 ? 'high' : count === 2 ? 'medium' : 'low'
+
+          findings.push({
+            user_id: e.user_id,
+            user_name: e.user?.name ?? null,
+            risk_level: riskLevel,
+            signals,
+            last_activity_at: e.last_activity_at ?? null,
+            current_score: score,
+            missing_count: summary?.tardiness_breakdown.missing ?? null,
+            late_count: summary?.tardiness_breakdown.late ?? null,
+          })
+        }
+
+        findings.sort((a, b) => {
+          const aRisk = (a as { risk_level: string }).risk_level
+          const bRisk = (b as { risk_level: string }).risk_level
+          const rDiff = (riskOrder[aRisk] ?? 3) - (riskOrder[bRisk] ?? 3)
+          if (rDiff !== 0) return rDiff
+          const aCount = (a as { signals: object[] }).signals.length
+          const bCount = (b as { signals: object[] }).signals.length
+          return bCount - aCount
+        })
+
+        const response: Record<string, unknown> = {
+          course_id: courseId,
+          students_scanned: enrollments.length,
+          analytics_available: analyticsAvailable,
+          thresholds_used: thresholds,
+          findings,
+        }
+
+        if (!analyticsAvailable) {
+          response.note =
+            'Analytics not available for this course. Reporting on inactivity and low score only (missing_submissions and late_pattern signals skipped).'
+        }
+
+        return response
       },
     },
   ]

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(118)
+    expect(manifest.tools).toHaveLength(119)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/pseudonym/coverage.test.ts
+++ b/tests/pseudonym/coverage.test.ts
@@ -26,6 +26,7 @@ const EXPECTED_PII_BEARING_TOOLS = new Set([
   'get_outcome_rollups',
   'list_group_members',
   'list_submission_comments_needing_attention',
+  'list_students_needing_attention',
 ])
 
 function buildMinimalCanvas(): CanvasClient {
@@ -106,6 +107,7 @@ function buildMinimalCanvas(): CanvasClient {
       getCourseActivity: list,
       getStudentActivity: noop,
       getCourseActivityStream: list,
+      getStudentSummaries: list,
     },
     outcomes: {
       getRootOutcomeGroup: noop,

--- a/tests/tools/attention.test.ts
+++ b/tests/tools/attention.test.ts
@@ -2,8 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { CanvasApiError } from '../../src/canvas/client'
 import type { CanvasClient } from '../../src/canvas'
-import type { CanvasSubmission } from '../../src/canvas/types'
+import type {
+  CanvasEnrollment,
+  CanvasStudentSummary,
+  CanvasSubmission,
+} from '../../src/canvas/types'
 import { Pseudonymizer } from '../../src/pseudonym/pseudonymizer'
 import { attentionTools } from '../../src/tools/attention'
 
@@ -41,18 +46,80 @@ function buildMockCanvas(submissions: CanvasSubmission[] = []): CanvasClient {
     submissions: {
       listForStudents: vi.fn().mockResolvedValue(submissions),
     },
+    enrollments: {
+      listForCourse: vi.fn().mockResolvedValue([]),
+    },
+    analytics: {
+      getStudentSummaries: vi.fn().mockResolvedValue([]),
+    },
+  } as unknown as CanvasClient
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures for Signal B (list_students_needing_attention)
+// ---------------------------------------------------------------------------
+
+const atRiskEnrollment: CanvasEnrollment = {
+  id: 10,
+  course_id: 101,
+  user_id: 42,
+  type: 'StudentEnrollment',
+  enrollment_state: 'active',
+  role: 'StudentEnrollment',
+  last_activity_at: new Date(Date.now() - 15 * 24 * 60 * 60 * 1000).toISOString(),
+  grades: { current_score: 58, current_grade: 'F', final_score: 58, final_grade: 'F' },
+  user: { id: 42, name: 'Alice', sortable_name: 'Alice', short_name: 'Alice' },
+}
+
+const healthyEnrollment: CanvasEnrollment = {
+  id: 11,
+  course_id: 101,
+  user_id: 99,
+  type: 'StudentEnrollment',
+  enrollment_state: 'active',
+  role: 'StudentEnrollment',
+  last_activity_at: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+  grades: { current_score: 92, current_grade: 'A', final_score: 92, final_grade: 'A' },
+  user: { id: 99, name: 'Bob', sortable_name: 'Bob', short_name: 'Bob' },
+}
+
+const atRiskSummary: CanvasStudentSummary = {
+  id: 42,
+  page_views: 5,
+  participations: 1,
+  tardiness_breakdown: { total: 10, on_time: 4, late: 3, missing: 2, floating: 1 },
+}
+
+const healthySummary: CanvasStudentSummary = {
+  id: 99,
+  page_views: 40,
+  participations: 10,
+  tardiness_breakdown: { total: 10, on_time: 10, late: 0, missing: 0, floating: 0 },
+}
+
+function buildAtRiskCanvas(
+  enrollments: CanvasEnrollment[] = [atRiskEnrollment],
+  summaries: CanvasStudentSummary[] = [atRiskSummary],
+): CanvasClient {
+  return {
+    submissions: { listForStudents: vi.fn().mockResolvedValue([]) },
+    enrollments: { listForCourse: vi.fn().mockResolvedValue(enrollments) },
+    analytics: { getStudentSummaries: vi.fn().mockResolvedValue(summaries) },
   } as unknown as CanvasClient
 }
 
 describe('attentionTools', () => {
-  it('returns an array with 1 tool definition', () => {
+  it('returns an array with 2 tool definitions', () => {
     const tools = attentionTools(buildMockCanvas())
-    expect(tools).toHaveLength(1)
+    expect(tools).toHaveLength(2)
   })
 
-  it('exports the tool with the correct name', () => {
+  it('exports tools with the correct names', () => {
     const tools = attentionTools(buildMockCanvas())
-    expect(tools[0].name).toBe('list_submission_comments_needing_attention')
+    expect(tools.map((t) => t.name)).toEqual([
+      'list_submission_comments_needing_attention',
+      'list_students_needing_attention',
+    ])
   })
 
   it('has readOnlyHint and openWorldHint annotations', () => {
@@ -425,6 +492,288 @@ describe('attentionTools', () => {
       expect(result1.findings[0].user_id).toBe(42)
       // Pseudonym is stable across calls
       expect(result1.findings[0].user_name).toBe(result2.findings[0].user_name)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Signal B: list_students_needing_attention
+  // -------------------------------------------------------------------------
+
+  describe('list_students_needing_attention', () => {
+    function getTool(canvas: CanvasClient, pseudonymizer?: Pseudonymizer) {
+      return attentionTools(canvas, pseudonymizer).find(
+        (t) => t.name === 'list_students_needing_attention',
+      )!
+    }
+
+    it('has readOnlyHint and openWorldHint annotations', () => {
+      expect(getTool(buildAtRiskCanvas()).annotations).toEqual({
+        readOnlyHint: true,
+        openWorldHint: true,
+      })
+    })
+
+    it('returns correct students_scanned count and analytics_available true', async () => {
+      const canvas = buildAtRiskCanvas(
+        [atRiskEnrollment, healthyEnrollment],
+        [atRiskSummary, healthySummary],
+      )
+      const result = (await getTool(canvas).handler({ course_id: 101 })) as Record<string, unknown>
+      expect(result.students_scanned).toBe(2)
+      expect(result.analytics_available).toBe(true)
+    })
+
+    it('echoes default thresholds_used', async () => {
+      const result = (await getTool(buildAtRiskCanvas()).handler({
+        course_id: 101,
+      })) as Record<string, unknown>
+      expect(result.thresholds_used).toEqual({
+        inactive_days: 7,
+        min_missing: 1,
+        min_late: 3,
+        score_threshold: 70,
+      })
+    })
+
+    it('echoes overridden thresholds_used', async () => {
+      const result = (await getTool(buildAtRiskCanvas()).handler({
+        course_id: 101,
+        inactive_days: 14,
+        min_missing: 2,
+        min_late: 5,
+        score_threshold: 80,
+      })) as Record<string, unknown>
+      expect(result.thresholds_used).toEqual({
+        inactive_days: 14,
+        min_missing: 2,
+        min_late: 5,
+        score_threshold: 80,
+      })
+    })
+
+    it('omits zero-signal students', async () => {
+      const canvas = buildAtRiskCanvas([healthyEnrollment], [healthySummary])
+      const result = (await getTool(canvas).handler({ course_id: 101 })) as Record<string, unknown>
+      expect((result.findings as unknown[]).length).toBe(0)
+    })
+
+    it('flags inactive signal for student with old last_activity_at', async () => {
+      const result = (await getTool(buildAtRiskCanvas()).handler({
+        course_id: 101,
+      })) as Record<string, unknown>
+      const findings = result.findings as Array<Record<string, unknown>>
+      const signals = findings[0].signals as Array<{ type: string }>
+      expect(signals.some((s) => s.type === 'inactive')).toBe(true)
+    })
+
+    it('flags low_score signal for student below threshold', async () => {
+      const result = (await getTool(buildAtRiskCanvas()).handler({
+        course_id: 101,
+      })) as Record<string, unknown>
+      const findings = result.findings as Array<Record<string, unknown>>
+      const signals = findings[0].signals as Array<{ type: string }>
+      expect(signals.some((s) => s.type === 'low_score')).toBe(true)
+    })
+
+    it('flags missing_submissions and late_pattern from analytics', async () => {
+      const result = (await getTool(buildAtRiskCanvas()).handler({
+        course_id: 101,
+      })) as Record<string, unknown>
+      const findings = result.findings as Array<Record<string, unknown>>
+      const types = (findings[0].signals as Array<{ type: string }>).map((s) => s.type)
+      expect(types).toContain('missing_submissions')
+      expect(types).toContain('late_pattern')
+    })
+
+    it('assigns risk_level high when 4 signals fire', async () => {
+      const result = (await getTool(buildAtRiskCanvas()).handler({
+        course_id: 101,
+      })) as Record<string, unknown>
+      const findings = result.findings as Array<Record<string, unknown>>
+      // inactive + low_score + missing_submissions + late_pattern = 4
+      expect(findings[0].risk_level).toBe('high')
+    })
+
+    it('assigns risk_level medium when exactly 2 signals fire', async () => {
+      // Only inactive + low_score (missing=0, late=0)
+      const summary: CanvasStudentSummary = {
+        ...atRiskSummary,
+        tardiness_breakdown: { total: 5, on_time: 5, late: 0, missing: 0, floating: 0 },
+      }
+      const result = (await getTool(buildAtRiskCanvas([atRiskEnrollment], [summary])).handler({
+        course_id: 101,
+      })) as Record<string, unknown>
+      const findings = result.findings as Array<Record<string, unknown>>
+      expect(findings[0].risk_level).toBe('medium')
+    })
+
+    it('assigns risk_level low when exactly 1 signal fires', async () => {
+      const enrollment: CanvasEnrollment = {
+        ...atRiskEnrollment,
+        grades: { current_score: 90, current_grade: 'A', final_score: 90, final_grade: 'A' },
+      }
+      const summary: CanvasStudentSummary = {
+        ...atRiskSummary,
+        tardiness_breakdown: { total: 5, on_time: 5, late: 0, missing: 0, floating: 0 },
+      }
+      const result = (await getTool(buildAtRiskCanvas([enrollment], [summary])).handler({
+        course_id: 101,
+      })) as Record<string, unknown>
+      const findings = result.findings as Array<Record<string, unknown>>
+      expect(findings[0].risk_level).toBe('low')
+    })
+
+    it('respects score_threshold override — skips low_score when score is above new threshold', async () => {
+      // atRiskEnrollment has score=58; raising threshold to 50 means 58>=50, so low_score should NOT fire
+      const result = (await getTool(buildAtRiskCanvas()).handler({
+        course_id: 101,
+        score_threshold: 50,
+      })) as Record<string, unknown>
+      const findings = result.findings as Array<Record<string, unknown>>
+      const types = (findings[0].signals as Array<{ type: string }>).map((s) => s.type)
+      expect(types).not.toContain('low_score')
+    })
+
+    it('respects min_late override — skips late_pattern when below raised threshold', async () => {
+      // atRiskSummary has late=3; raising to 5 means 3<5, so late_pattern should NOT fire
+      const result = (await getTool(buildAtRiskCanvas()).handler({
+        course_id: 101,
+        min_late: 5,
+      })) as Record<string, unknown>
+      const findings = result.findings as Array<Record<string, unknown>>
+      const types = (findings[0].signals as Array<{ type: string }>).map((s) => s.type)
+      expect(types).not.toContain('late_pattern')
+    })
+
+    it('sorts high-risk before low-risk findings', async () => {
+      const lowRisk: CanvasEnrollment = {
+        ...atRiskEnrollment,
+        user_id: 1,
+        user: { id: 1, name: 'LowRisk', sortable_name: 'LowRisk', short_name: 'LowRisk' },
+        grades: { current_score: 90, current_grade: 'A', final_score: 90, final_grade: 'A' },
+      }
+      const lowSummary: CanvasStudentSummary = {
+        id: 1,
+        page_views: 1,
+        participations: 0,
+        tardiness_breakdown: { total: 5, on_time: 5, late: 0, missing: 0, floating: 0 },
+      }
+      const highRisk: CanvasEnrollment = {
+        ...atRiskEnrollment,
+        user_id: 2,
+        user: { id: 2, name: 'HighRisk', sortable_name: 'HighRisk', short_name: 'HighRisk' },
+        grades: { current_score: 55, current_grade: 'F', final_score: 55, final_grade: 'F' },
+      }
+      const highSummary: CanvasStudentSummary = {
+        id: 2,
+        page_views: 1,
+        participations: 0,
+        tardiness_breakdown: { total: 10, on_time: 3, late: 4, missing: 3, floating: 0 },
+      }
+      const canvas = buildAtRiskCanvas([lowRisk, highRisk], [lowSummary, highSummary])
+      const result = (await getTool(canvas).handler({ course_id: 101 })) as Record<string, unknown>
+      const findings = result.findings as Array<Record<string, unknown>>
+      expect(findings[0].user_id).toBe(2) // HighRisk first
+      expect(findings[1].user_id).toBe(1) // LowRisk second
+    })
+
+    describe('analytics 404 degradation', () => {
+      it('sets analytics_available false and appends a note', async () => {
+        const canvas = buildAtRiskCanvas()
+        vi.mocked(canvas.analytics.getStudentSummaries).mockRejectedValueOnce(
+          new CanvasApiError('Not Found', 404, '/api/v1/courses/101/analytics/student_summaries'),
+        )
+        const result = (await getTool(canvas).handler({ course_id: 101 })) as Record<
+          string,
+          unknown
+        >
+        expect(result.analytics_available).toBe(false)
+        expect(typeof result.note).toBe('string')
+      })
+
+      it('still reports inactive and low_score signals on analytics 404', async () => {
+        const canvas = buildAtRiskCanvas()
+        vi.mocked(canvas.analytics.getStudentSummaries).mockRejectedValueOnce(
+          new CanvasApiError('Not Found', 404, '/api/v1/courses/101/analytics/student_summaries'),
+        )
+        const result = (await getTool(canvas).handler({ course_id: 101 })) as Record<
+          string,
+          unknown
+        >
+        const findings = result.findings as Array<Record<string, unknown>>
+        const types = (findings[0].signals as Array<{ type: string }>).map((s) => s.type)
+        expect(types).toContain('inactive')
+        expect(types).toContain('low_score')
+        expect(types).not.toContain('missing_submissions')
+        expect(types).not.toContain('late_pattern')
+      })
+
+      it('rethrows non-404 analytics errors', async () => {
+        const canvas = buildAtRiskCanvas()
+        vi.mocked(canvas.analytics.getStudentSummaries).mockRejectedValueOnce(
+          new CanvasApiError('Forbidden', 403, '/api/v1/courses/101/analytics/student_summaries'),
+        )
+        await expect(getTool(canvas).handler({ course_id: 101 })).rejects.toBeInstanceOf(
+          CanvasApiError,
+        )
+      })
+    })
+
+    describe('pseudonymization', () => {
+      const enrollmentWithPii: CanvasEnrollment = {
+        ...atRiskEnrollment,
+        sis_user_id: 'SIS-9999',
+        user: {
+          id: 42,
+          name: 'Alice Smith',
+          sortable_name: 'Smith, Alice',
+          short_name: 'Alice',
+          email: 'alice@example.edu',
+        },
+      }
+
+      let tmpDir: string
+      beforeEach(async () => {
+        tmpDir = await mkdtemp(join(tmpdir(), 'attention-b-'))
+      })
+      afterEach(async () => {
+        await rm(tmpDir, { recursive: true, force: true })
+      })
+
+      function makePseudonymizer(enabled = true) {
+        return new Pseudonymizer({
+          baseUrl: 'https://school.instructure.com/api/v1',
+          rootDir: tmpDir,
+          env: enabled ? { CANVAS_PSEUDONYMIZE_STUDENTS: 'true' } : {},
+        })
+      }
+
+      it('replaces user_name with pseudonym when enabled', async () => {
+        const canvas = buildAtRiskCanvas([enrollmentWithPii], [atRiskSummary])
+        const result = (await getTool(canvas, makePseudonymizer()).handler({
+          course_id: 101,
+        })) as Record<string, unknown>
+        const findings = result.findings as Array<Record<string, unknown>>
+        expect(findings[0].user_name).toMatch(/^Student \d+$/)
+      })
+
+      it('preserves real user_name when pseudonymizer disabled', async () => {
+        const canvas = buildAtRiskCanvas([enrollmentWithPii], [atRiskSummary])
+        const result = (await getTool(canvas, makePseudonymizer(false)).handler({
+          course_id: 101,
+        })) as Record<string, unknown>
+        const findings = result.findings as Array<Record<string, unknown>>
+        expect(findings[0].user_name).toBe('Alice Smith')
+      })
+
+      it('preserves numeric user_id under pseudonymization', async () => {
+        const canvas = buildAtRiskCanvas([enrollmentWithPii], [atRiskSummary])
+        const result = (await getTool(canvas, makePseudonymizer()).handler({
+          course_id: 101,
+        })) as Record<string, unknown>
+        const findings = result.findings as Array<Record<string, unknown>>
+        expect(findings[0].user_id).toBe(42)
+      })
     })
   })
 })

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -131,6 +131,7 @@ function buildFullMockCanvas(): CanvasClient {
       getCourseActivity: async () => [],
       getStudentActivity: async () => ({}),
       getCourseActivityStream: async () => [],
+      getStudentSummaries: async () => [],
     },
     outcomes: {
       getRootOutcomeGroup: async () => ({}),
@@ -315,10 +316,11 @@ describe('getAllTools', () => {
     expect(names).toContain('create_new_quiz_item')
     expect(names).toContain('update_new_quiz_item')
     expect(names).toContain('delete_new_quiz_item')
-    // Attention (1)
+    // Attention (2)
     expect(names).toContain('list_submission_comments_needing_attention')
+    expect(names).toContain('list_students_needing_attention')
 
-    expect(tools).toHaveLength(118)
+    expect(tools).toHaveLength(119)
   })
 
   it('all tools have openWorldHint: true', () => {


### PR DESCRIPTION
## Summary

- Implements `list_students_needing_attention` (Signal B) from the approved design spec `docs/superpowers/specs/2026-06-12-instructor-needs-attention.md`
- Adds `AnalyticsModule.getStudentSummaries()` + `CanvasStudentSummary` type to the Canvas client
- Four at-risk signals with caller-overridable thresholds: `inactive`, `missing_submissions`, `late_pattern`, `low_score`
- Graceful 404 degradation: falls back to enrollment-only signals when analytics is disabled per-institution
- Full pseudonymization via `anonymizeEnrollment`; tool registered in `PSEUDONYMIZER_WRAPPED_TOOLS`
- Tool count: 118 → 119 (83 → 84 read tools)

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] 47/47 targeted tests pass (attention, registry, pseudonym coverage)
- [x] Threshold override cases (`score_threshold`, `min_late`)
- [x] Analytics 404 degradation path (skips missing/late signals, sets `analytics_available: false`)
- [x] 403 analytics errors are re-thrown
- [x] Risk level: high (3+), medium (2), low (1); zero-signal students omitted
- [x] Sort: high → medium → low, signal count descending
- [x] Pseudonymization: name replaced, user_id preserved

Parent design: BRU-1591 | Blocked-by (resolved): BRU-1592 (Signal A, PR #174)

🤖 Generated with [Claude Code](https://claude.com/claude-code)