### PR TITLE
feat(accounts): add list_account_notifications tool (#178)

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 119,
+  "toolCount": 120,
   "tools": [
     {
       "name": "health_check",
@@ -1139,6 +1139,18 @@
       "name": "get_account_reports",
       "domain": "accounts",
       "description": "List available report types for a Canvas account.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "admin",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_account_notifications",
+      "domain": "accounts",
+      "description": "List active global institution-wide announcements for the current user (maintenance windows, term deadlines, policy notices).",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true

--- a/src/canvas/accounts.ts
+++ b/src/canvas/accounts.ts
@@ -1,5 +1,11 @@
 import type { CanvasHttpClient } from './client'
-import type { CanvasAccount, CanvasAccountReport, CanvasCourse, CanvasUser } from './types'
+import type {
+  CanvasAccount,
+  CanvasAccountNotification,
+  CanvasAccountReport,
+  CanvasCourse,
+  CanvasUser,
+} from './types'
 
 export class AccountsModule {
   constructor(private client: CanvasHttpClient) {}
@@ -36,5 +42,11 @@ export class AccountsModule {
 
   async getReports(accountId: number): Promise<CanvasAccountReport[]> {
     return this.client.request<CanvasAccountReport[]>(`/api/v1/accounts/${accountId}/reports`)
+  }
+
+  async listNotifications(accountId: string): Promise<CanvasAccountNotification[]> {
+    return this.client.paginate<CanvasAccountNotification>(
+      `/api/v1/accounts/${accountId}/account_notifications`,
+    )
   }
 }

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -789,6 +789,15 @@ export interface CanvasOutcomeMasteryDistributionResponse {
 
 // --- Accounts ---
 
+export interface CanvasAccountNotification {
+  id: number
+  subject: string
+  message: string
+  start_at: string
+  end_at: string | null
+  icon: string
+}
+
 export interface CanvasAccount {
   id: number
   name: string

--- a/src/tools/accounts.ts
+++ b/src/tools/accounts.ts
@@ -115,7 +115,7 @@ export function accountTools(
         openWorldHint: true,
       },
       handler: async (params) => {
-        const accountId = (params.account_id as string | undefined) ?? 'self'
+        const accountId = (params.account_id as string) || 'self'
         return canvas.accounts.listNotifications(accountId)
       },
     },

--- a/src/tools/accounts.ts
+++ b/src/tools/accounts.ts
@@ -100,5 +100,24 @@ export function accountTools(
         return canvas.accounts.getReports(params.account_id as number)
       },
     },
+    {
+      name: 'list_account_notifications',
+      description:
+        'List active global institution-wide announcements for the current user (maintenance windows, term deadlines, policy notices).',
+      inputSchema: {
+        account_id: z
+          .string()
+          .optional()
+          .describe('Canvas account ID, or "self" for the root account (default: "self")'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const accountId = (params.account_id as string | undefined) ?? 'self'
+        return canvas.accounts.listNotifications(accountId)
+      },
+    },
   ]
 }

--- a/tests/canvas/accounts.test.ts
+++ b/tests/canvas/accounts.test.ts
@@ -65,4 +65,26 @@ describe('AccountsModule', () => {
     expect(result).toHaveLength(1)
     expect(client.request).toHaveBeenCalledWith('/api/v1/accounts/1/reports')
   })
+
+  it('lists account notifications for "self"', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([
+      {
+        id: 10,
+        subject: 'System Maintenance',
+        message: 'Canvas will be offline Sunday 2–4 AM.',
+        start_at: '2026-06-14T02:00:00Z',
+        end_at: '2026-06-14T04:00:00Z',
+        icon: 'warning',
+      },
+    ])
+    const result = await accounts.listNotifications('self')
+    expect(result).toHaveLength(1)
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/accounts/self/account_notifications')
+  })
+
+  it('lists account notifications for a numeric account id', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+    await accounts.listNotifications('1')
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/accounts/1/account_notifications')
+  })
 })

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(119)
+    expect(manifest.tools).toHaveLength(120)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/pseudonym/coverage.test.ts
+++ b/tests/pseudonym/coverage.test.ts
@@ -101,6 +101,7 @@ function buildMinimalCanvas(): CanvasClient {
       listCourses: list,
       listUsers: list,
       getReports: list,
+      listNotifications: list,
     },
     analytics: {
       searchContentType: list,

--- a/tests/tools/accounts.test.ts
+++ b/tests/tools/accounts.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import type { CanvasClient } from '../../src/canvas'
 import type {
   CanvasAccount,
+  CanvasAccountNotification,
   CanvasAccountReport,
   CanvasCourse,
   CanvasUser,
@@ -49,6 +50,15 @@ describe('accountTools', () => {
     last_run: null,
   }
 
+  const mockNotification: CanvasAccountNotification = {
+    id: 10,
+    subject: 'System Maintenance',
+    message: 'Canvas will be offline Sunday 2–4 AM.',
+    start_at: '2026-06-14T02:00:00Z',
+    end_at: '2026-06-14T04:00:00Z',
+    icon: 'warning',
+  }
+
   function buildMockCanvas(): CanvasClient {
     return {
       accounts: {
@@ -58,12 +68,13 @@ describe('accountTools', () => {
         listCourses: vi.fn().mockResolvedValue([mockCourse]),
         listUsers: vi.fn().mockResolvedValue([mockUser]),
         getReports: vi.fn().mockResolvedValue([mockReport]),
+        listNotifications: vi.fn().mockResolvedValue([mockNotification]),
       },
     } as unknown as CanvasClient
   }
 
-  it('returns 6 tool definitions', () => {
-    expect(accountTools(buildMockCanvas())).toHaveLength(6)
+  it('returns 7 tool definitions', () => {
+    expect(accountTools(buildMockCanvas())).toHaveLength(7)
   })
 
   it('exports tools with correct names', () => {
@@ -75,6 +86,7 @@ describe('accountTools', () => {
       'list_account_courses',
       'list_account_users',
       'get_account_reports',
+      'list_account_notifications',
     ])
   })
 
@@ -146,6 +158,47 @@ describe('accountTools', () => {
       const tool = accountTools(canvas).find((t) => t.name === 'get_account_reports')!
       await tool.handler({ account_id: 1 })
       expect(canvas.accounts.getReports).toHaveBeenCalledWith(1)
+    })
+  })
+
+  describe('list_account_notifications', () => {
+    it('has read-only annotations', () => {
+      const tool = accountTools(buildMockCanvas()).find(
+        (t) => t.name === 'list_account_notifications',
+      )!
+      expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+    })
+
+    it('defaults account_id to "self" when not provided', async () => {
+      const canvas = buildMockCanvas()
+      const tool = accountTools(canvas).find((t) => t.name === 'list_account_notifications')!
+      await tool.handler({})
+      expect(canvas.accounts.listNotifications).toHaveBeenCalledWith('self')
+    })
+
+    it('passes account_id to canvas.accounts.listNotifications when provided', async () => {
+      const canvas = buildMockCanvas()
+      const tool = accountTools(canvas).find((t) => t.name === 'list_account_notifications')!
+      await tool.handler({ account_id: '42' })
+      expect(canvas.accounts.listNotifications).toHaveBeenCalledWith('42')
+    })
+
+    it('returns the notification array from Canvas', async () => {
+      const canvas = buildMockCanvas()
+      const tool = accountTools(canvas).find((t) => t.name === 'list_account_notifications')!
+      const result = (await tool.handler({})) as CanvasAccountNotification[]
+      expect(result).toHaveLength(1)
+      expect(result[0].subject).toBe('System Maintenance')
+    })
+
+    it('propagates a 404 error from Canvas', async () => {
+      const { CanvasApiError } = await import('../../src/canvas/client')
+      const canvas = buildMockCanvas()
+      vi.mocked(canvas.accounts.listNotifications).mockRejectedValueOnce(
+        new CanvasApiError('Not Found', 404, '/api/v1/accounts/self/account_notifications'),
+      )
+      const tool = accountTools(canvas).find((t) => t.name === 'list_account_notifications')!
+      await expect(tool.handler({})).rejects.toBeInstanceOf(CanvasApiError)
     })
   })
 

--- a/tests/tools/accounts.test.ts
+++ b/tests/tools/accounts.test.ts
@@ -176,6 +176,13 @@ describe('accountTools', () => {
       expect(canvas.accounts.listNotifications).toHaveBeenCalledWith('self')
     })
 
+    it('defaults account_id to "self" when an empty string is passed', async () => {
+      const canvas = buildMockCanvas()
+      const tool = accountTools(canvas).find((t) => t.name === 'list_account_notifications')!
+      await tool.handler({ account_id: '' })
+      expect(canvas.accounts.listNotifications).toHaveBeenCalledWith('self')
+    })
+
     it('passes account_id to canvas.accounts.listNotifications when provided', async () => {
       const canvas = buildMockCanvas()
       const tool = accountTools(canvas).find((t) => t.name === 'list_account_notifications')!

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -125,6 +125,7 @@ function buildFullMockCanvas(): CanvasClient {
       listCourses: async () => [],
       listUsers: async () => [],
       getReports: async () => [],
+      listNotifications: async () => [],
     },
     analytics: {
       searchContentType: async () => [],
@@ -172,7 +173,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 118 tools across all domains', () => {
+  it('returns all 119 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 
@@ -272,13 +273,14 @@ describe('getAllTools', () => {
     expect(names).toContain('get_submission_peer_reviews')
     expect(names).toContain('create_peer_review')
     expect(names).toContain('delete_peer_review')
-    // Accounts (6)
+    // Accounts (7)
     expect(names).toContain('get_account')
     expect(names).toContain('list_accounts')
     expect(names).toContain('list_sub_accounts')
     expect(names).toContain('list_account_courses')
     expect(names).toContain('list_account_users')
     expect(names).toContain('get_account_reports')
+    expect(names).toContain('list_account_notifications')
     // Analytics & Search (4)
     expect(names).toContain('search_course_content')
     expect(names).toContain('get_course_analytics')
@@ -320,7 +322,7 @@ describe('getAllTools', () => {
     expect(names).toContain('list_submission_comments_needing_attention')
     expect(names).toContain('list_students_needing_attention')
 
-    expect(tools).toHaveLength(119)
+    expect(tools).toHaveLength(120)
   })
 
   it('all tools have openWorldHint: true', () => {


### PR DESCRIPTION
## Summary

- Adds `list_account_notifications` tool that surfaces institution-wide Canvas announcements (maintenance windows, term deadlines, policy notices) via `GET /api/v1/accounts/:account_id/account_notifications`
- New `CanvasAccountNotification` type (`id`, `subject`, `message`, `start_at`, `end_at`, `icon`)
- `account_id` is optional and defaults to `"self"` (the user's root account)
- Read-only tool (`readOnlyHint: true`, `openWorldHint: true`) slotted into the existing `accounts` domain

## Approach

Follows the standard Canvas client module pattern: new `listNotifications(accountId: string)` method on `AccountsModule` using `client.paginate`, composed into the `CanvasClient` facade via the existing `accounts` property. The tool layer adds the `list_account_notifications` definition to `src/tools/accounts.ts` and the committed tool manifest is regenerated (119 → 120 tools).

No pseudonymizer wrap is required — global account notifications contain no student PII.

## Test evidence

```
pnpm typecheck && pnpm lint && pnpm test && pnpm build

Test Files  75 passed (75)
     Tests  951 passed (951)
```

New tests cover:
- Canvas module: happy path with `"self"`, with a numeric string id
- Tool layer: read-only annotations, default `"self"` when no `account_id` provided, explicit `account_id` forwarded, return value shape, 404 propagation

Closes #178

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017c2iPZ8hHhVc49UP41c6dP)_