### PR TITLE
feat(accounts): add view_account_notifications interactive MCP Apps widget (#179)

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 120,
+  "toolCount": 121,
   "tools": [
     {
       "name": "health_check",
@@ -1151,6 +1151,18 @@
       "name": "list_account_notifications",
       "domain": "accounts",
       "description": "List active global institution-wide announcements for the current user (maintenance windows, term deadlines, policy notices).",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "admin",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "view_account_notifications",
+      "domain": "accounts",
+      "description": "Interactive panel of active institution-wide announcements. Returns the same payload as `list_account_notifications` and additionally links to an MCP Apps UI resource that renders scannable announcement cards with type filters and search. Hosts that do not support MCP Apps fall back to the JSON payload (same as `list_account_notifications`).",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -3,9 +3,11 @@ import type { CanvasClient } from '../canvas'
 import { registerSyllabusResource } from './syllabus'
 import { registerAssignmentDescriptionResource } from './assignment-description'
 import { registerCourseStructureUI } from './ui-course-structure'
+import { registerAccountNotificationsUI } from './ui-account-notifications'
 
 export function registerAllResources(server: McpServer, canvas: CanvasClient): void {
   registerSyllabusResource(server, canvas)
   registerAssignmentDescriptionResource(server, canvas)
   registerCourseStructureUI(server)
+  registerAccountNotificationsUI(server)
 }

--- a/src/resources/ui-account-notifications.ts
+++ b/src/resources/ui-account-notifications.ts
@@ -1,0 +1,23 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { registerAppResource, RESOURCE_MIME_TYPE } from '@modelcontextprotocol/ext-apps/server'
+import { ACCOUNT_NOTIFICATIONS_HTML } from '../ui/account-notifications.html'
+
+const RESOURCE_URI = 'ui://canvas-lms-mcp/account-notifications.html'
+
+export function registerAccountNotificationsUI(server: McpServer): void {
+  registerAppResource(
+    server,
+    'Institution Announcements',
+    RESOURCE_URI,
+    { description: 'Interactive institution announcements panel' },
+    async () => ({
+      contents: [
+        {
+          uri: RESOURCE_URI,
+          mimeType: RESOURCE_MIME_TYPE,
+          text: ACCOUNT_NOTIFICATIONS_HTML,
+        },
+      ],
+    }),
+  )
+}

--- a/src/tools/accounts.ts
+++ b/src/tools/accounts.ts
@@ -119,5 +119,35 @@ export function accountTools(
         return canvas.accounts.listNotifications(accountId)
       },
     },
+    {
+      // Payload is institution-authored announcement metadata only — no student PII,
+      // so no pseudonymizer wrap is required. If a future revision adds per-user
+      // fields, this tool MUST be added to PSEUDONYMIZER_WRAPPED_TOOLS and wrapped.
+      name: 'view_account_notifications',
+      description:
+        'Interactive panel of active institution-wide announcements. Returns the same payload as `list_account_notifications` and additionally links to an MCP Apps UI resource that renders scannable announcement cards with type filters and search. Hosts that do not support MCP Apps fall back to the JSON payload (same as `list_account_notifications`).',
+      inputSchema: {
+        account_id: z
+          .string()
+          .optional()
+          .describe('Canvas account ID, or "self" for the root account (default: "self")'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      ui: {
+        resourceUri: 'ui://canvas-lms-mcp/account-notifications.html',
+        csp: {
+          connectDomains: [],
+          resourceDomains: [],
+          frameDomains: [],
+        },
+      },
+      handler: async (params) => {
+        const accountId = (params.account_id as string) || 'self'
+        return canvas.accounts.listNotifications(accountId)
+      },
+    },
   ]
 }

--- a/src/ui/account-notifications-sanitizer.ts
+++ b/src/ui/account-notifications-sanitizer.ts
@@ -1,0 +1,94 @@
+// Pure, DOM-free definition of the announcement-HTML sanitizer trust boundary.
+//
+// Announcement `message` bodies are institution-authored HTML. The widget
+// (`account-notifications.html.ts`) renders them through an allowlist DOM rebuild.
+// The *security-critical decisions* — which tags survive and which URL schemes are
+// permitted — are defined HERE and interpolated into the widget, so there is a
+// single source of truth that is unit-tested directly (the widget's runtime JS
+// cannot execute under the node test environment, but these decisions can).
+
+// Inline/structural tags that are cloned into the output as-is.
+export const ALLOWED_TAGS: readonly string[] = [
+  'A',
+  'ABBR',
+  'B',
+  'BLOCKQUOTE',
+  'BR',
+  'CODE',
+  'DD',
+  'DIV',
+  'DL',
+  'DT',
+  'EM',
+  'H1',
+  'H2',
+  'H3',
+  'H4',
+  'H5',
+  'H6',
+  'HR',
+  'I',
+  'LI',
+  'OL',
+  'P',
+  'PRE',
+  'SMALL',
+  'SPAN',
+  'STRONG',
+  'SUB',
+  'SUP',
+  'U',
+  'UL',
+]
+
+// Tags whose entire subtree is discarded — scripts, styles, embeds, form controls,
+// and anything that can load a remote resource or execute code.
+export const DROP_TAGS: readonly string[] = [
+  'SCRIPT',
+  'STYLE',
+  'IFRAME',
+  'OBJECT',
+  'EMBED',
+  'LINK',
+  'META',
+  'TEMPLATE',
+  'NOSCRIPT',
+  'FORM',
+  'INPUT',
+  'BUTTON',
+  'IMG',
+  'SVG',
+]
+
+// Anchor `href` values are kept only if they match one of these (case-insensitive)
+// schemes. Everything else (javascript:, data:, vbscript:, relative, protocol-
+// relative, …) is dropped. Stored as pattern source strings so the same definition
+// drives both the runtime guard below and the interpolated widget copy.
+export const SAFE_URL_PATTERNS: readonly string[] = ['^https?://', '^mailto:']
+
+export type TagDisposition = 'allow' | 'drop' | 'unwrap'
+
+/**
+ * Decide what the sanitizer does with an element: clone it (`allow`), discard it
+ * and its contents (`drop`), or remove the wrapper but keep its children (`unwrap`).
+ */
+export function classifyTag(tagName: unknown): TagDisposition {
+  const tag = (tagName == null ? '' : String(tagName)).toUpperCase()
+  if (ALLOWED_TAGS.includes(tag)) return 'allow'
+  if (DROP_TAGS.includes(tag)) return 'drop'
+  return 'unwrap'
+}
+
+const SAFE_URL_RES = SAFE_URL_PATTERNS.map((p) => new RegExp(p, 'i'))
+
+/**
+ * Return the trimmed URL if it uses an allowed scheme, else null.
+ * This is the only guard that blocks javascript:/data:/vbscript: hrefs.
+ */
+export function sanitizeUrl(value: unknown): string | null {
+  const v = (value == null ? '' : String(value)).trim()
+  for (const re of SAFE_URL_RES) {
+    if (re.test(v)) return v
+  }
+  return null
+}

--- a/src/ui/account-notifications.html.ts
+++ b/src/ui/account-notifications.html.ts
@@ -3,11 +3,20 @@
 // renders an interactive panel of institution announcements without making any
 // network requests. Announcement `message` bodies are institution-authored HTML
 // and are rendered through an allowlist sanitizer (no script execution, no remote
-// resource loads). CSP intentionally empty.
+// resource loads). The tool's `ui.csp` binding is intentionally empty; the widget
+// additionally ships a restrictive <meta> CSP as defense-in-depth.
+//
+// The sanitizer's security-critical decisions (ALLOWED_TAGS / DROP_TAGS / the URL
+// scheme allowlist) are defined once in `account-notifications-sanitizer.ts` and
+// interpolated below, so a unit test of that module guards the exact policy the
+// widget runs.
+import { ALLOWED_TAGS, DROP_TAGS, SAFE_URL_PATTERNS } from './account-notifications-sanitizer'
+
 export const ACCOUNT_NOTIFICATIONS_HTML = `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Institution Announcements</title>
 <style>
@@ -173,15 +182,18 @@ export const ACCOUNT_NOTIFICATIONS_HTML = `<!doctype html>
 
   // Allowlist sanitizer: only these inline/structural tags survive; everything else
   // is either dropped entirely (scripts, styles, embeds) or unwrapped to its text.
-  var ALLOWED_TAGS = {
-    A: 1, ABBR: 1, B: 1, BLOCKQUOTE: 1, BR: 1, CODE: 1, DD: 1, DIV: 1, DL: 1,
-    DT: 1, EM: 1, H1: 1, H2: 1, H3: 1, H4: 1, H5: 1, H6: 1, HR: 1, I: 1, LI: 1,
-    OL: 1, P: 1, PRE: 1, SMALL: 1, SPAN: 1, STRONG: 1, SUB: 1, SUP: 1, U: 1, UL: 1
-  };
-  var DROP_TAGS = {
-    SCRIPT: 1, STYLE: 1, IFRAME: 1, OBJECT: 1, EMBED: 1, LINK: 1, META: 1,
-    TEMPLATE: 1, NOSCRIPT: 1, FORM: 1, INPUT: 1, BUTTON: 1, IMG: 1, SVG: 1
-  };
+  // The tag lists and URL allowlist are interpolated from
+  // account-notifications-sanitizer.ts so the unit-tested policy is the one that ships.
+  function toSet(list) {
+    var set = {};
+    for (var i = 0; i < list.length; i++) set[list[i]] = 1;
+    return set;
+  }
+  var ALLOWED_TAGS = toSet(${JSON.stringify(ALLOWED_TAGS)});
+  var DROP_TAGS = toSet(${JSON.stringify(DROP_TAGS)});
+  var SAFE_URL_RES = ${JSON.stringify(SAFE_URL_PATTERNS)}.map(function (p) {
+    return new RegExp(p, 'i');
+  });
 
   function readPayload() {
     // Multi-sink probe: try documented hosts in order, fall back to a known shim variable.
@@ -257,8 +269,9 @@ export const ACCOUNT_NOTIFICATIONS_HTML = `<!doctype html>
 
   function safeUrl(value) {
     var v = (value == null ? '' : String(value)).trim();
-    if (/^https?:\\/\\//i.test(v)) return v;
-    if (/^mailto:/i.test(v)) return v;
+    for (var i = 0; i < SAFE_URL_RES.length; i++) {
+      if (SAFE_URL_RES[i].test(v)) return v;
+    }
     return null;
   }
 
@@ -305,7 +318,9 @@ export const ACCOUNT_NOTIFICATIONS_HTML = `<!doctype html>
   }
 
   function formatDate(iso) {
-    if (!iso) return null;
+    // Fields are institution JSON of unknown runtime type; only coerce real
+    // strings/numbers so a malformed value is omitted rather than rendered as junk.
+    if (!iso || (typeof iso !== 'string' && typeof iso !== 'number')) return null;
     var d = new Date(iso);
     if (isNaN(d.getTime())) return String(iso);
     try {
@@ -391,9 +406,10 @@ export const ACCOUNT_NOTIFICATIONS_HTML = `<!doctype html>
       var badgeCls = typeInfo ? typeInfo.cls : 'neutral';
       var badgeLabel = typeInfo ? typeInfo.label : (icon || 'announcement');
 
+      var subjectText = note && typeof note.subject === 'string' ? note.subject : '';
       var head = el('div', { class: 'card-head' }, [
         el('span', { class: 'type-badge ' + badgeCls, text: badgeLabel }),
-        el('span', { class: 'subject', text: (note && note.subject) || '(no subject)' })
+        el('span', { class: 'subject', text: subjectText || '(no subject)' })
       ]);
 
       var children = [head];
@@ -403,7 +419,7 @@ export const ACCOUNT_NOTIFICATIONS_HTML = `<!doctype html>
 
       var card = el('div', { class: 'card' }, children);
       card.dataset.type = (icon || '');
-      card.dataset.subject = ((note && note.subject) || '').toLowerCase();
+      card.dataset.subject = subjectText.toLowerCase();
       cardsContainer.appendChild(card);
       cardNodes.push(card);
     });

--- a/src/ui/account-notifications.html.ts
+++ b/src/ui/account-notifications.html.ts
@@ -1,0 +1,458 @@
+// Self-contained widget for `view_account_notifications`. The host injects a
+// CallToolResult into a known sink (e.g., `window.openai.toolResult`); the widget
+// renders an interactive panel of institution announcements without making any
+// network requests. Announcement `message` bodies are institution-authored HTML
+// and are rendered through an allowlist sanitizer (no script execution, no remote
+// resource loads). CSP intentionally empty.
+export const ACCOUNT_NOTIFICATIONS_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Institution Announcements</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --fg: #1f2328;
+    --fg-muted: #6e7781;
+    --bg: #ffffff;
+    --bg-subtle: #f6f8fa;
+    --border: #d0d7de;
+    --accent: #0969da;
+    --pill-bg: #eaeef2;
+    --pill-fg: #1f2328;
+    --pill-on-bg: #0969da;
+    --pill-on-fg: #ffffff;
+    --info-bg: #ddf4ff;
+    --info-fg: #0550ae;
+    --warn-bg: #fff8c5;
+    --warn-fg: #7d4e00;
+    --question-bg: #fbefff;
+    --question-fg: #6639ba;
+    --error-bg: #ffebe9;
+    --error-fg: #cf222e;
+    --calendar-bg: #dafbe1;
+    --calendar-fg: #1a7f37;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --fg: #e6edf3;
+      --fg-muted: #8b949e;
+      --bg: #0d1117;
+      --bg-subtle: #161b22;
+      --border: #30363d;
+      --accent: #58a6ff;
+      --pill-bg: #21262d;
+      --pill-fg: #e6edf3;
+      --pill-on-bg: #1f6feb;
+      --pill-on-fg: #ffffff;
+      --info-bg: #0c2d6b;
+      --info-fg: #a5d6ff;
+      --warn-bg: #3a2c00;
+      --warn-fg: #f0c674;
+      --question-bg: #2c1e44;
+      --question-fg: #d2a8ff;
+      --error-bg: #4c1118;
+      --error-fg: #ffaba8;
+      --calendar-bg: #0f3d22;
+      --calendar-fg: #7ee2a8;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    padding: 16px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-size: 14px;
+    color: var(--fg);
+    background: var(--bg);
+    line-height: 1.5;
+  }
+  .summary {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 8px 16px;
+    padding: 8px 12px;
+    background: var(--bg-subtle);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    margin-bottom: 12px;
+  }
+  .summary strong { font-size: 15px; }
+  .summary .by-type { color: var(--fg-muted); }
+  .controls { display: flex; flex-direction: column; gap: 8px; margin-bottom: 12px; }
+  .search {
+    width: 100%;
+    padding: 6px 10px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg);
+    color: var(--fg);
+    font: inherit;
+  }
+  .search:focus { outline: 2px solid var(--accent); outline-offset: -1px; }
+  .chips { display: flex; flex-wrap: wrap; gap: 6px; }
+  .chip {
+    border: 1px solid var(--border);
+    background: var(--pill-bg);
+    color: var(--pill-fg);
+    border-radius: 999px;
+    padding: 2px 10px;
+    font-size: 12px;
+    cursor: pointer;
+    user-select: none;
+  }
+  .chip.on { background: var(--pill-on-bg); color: var(--pill-on-fg); border-color: transparent; }
+  .cards { display: flex; flex-direction: column; gap: 8px; }
+  .card {
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg);
+    padding: 10px 12px;
+  }
+  .card.hidden { display: none; }
+  .card-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .subject { font-weight: 600; font-size: 15px; }
+  .type-badge {
+    font-size: 11px;
+    padding: 1px 8px;
+    border-radius: 999px;
+    text-transform: capitalize;
+    letter-spacing: 0.2px;
+    white-space: nowrap;
+  }
+  .type-badge.info { background: var(--info-bg); color: var(--info-fg); }
+  .type-badge.warn { background: var(--warn-bg); color: var(--warn-fg); }
+  .type-badge.question { background: var(--question-bg); color: var(--question-fg); }
+  .type-badge.error { background: var(--error-bg); color: var(--error-fg); }
+  .type-badge.calendar { background: var(--calendar-bg); color: var(--calendar-fg); }
+  .type-badge.neutral { background: var(--pill-bg); color: var(--pill-fg); }
+  .dates { color: var(--fg-muted); font-size: 12px; margin-top: 2px; }
+  .msg { margin-top: 8px; overflow-wrap: anywhere; }
+  .msg p { margin: 0 0 8px; }
+  .msg p:last-child { margin-bottom: 0; }
+  .msg a { color: var(--accent); }
+  .msg ul, .msg ol { margin: 0 0 8px; padding-left: 20px; }
+  .msg pre {
+    background: var(--bg-subtle);
+    padding: 8px;
+    border-radius: 6px;
+    overflow-x: auto;
+  }
+  .msg code { background: var(--bg-subtle); padding: 1px 4px; border-radius: 3px; }
+  .empty {
+    padding: 24px;
+    text-align: center;
+    color: var(--fg-muted);
+    border: 1px dashed var(--border);
+    border-radius: 6px;
+  }
+</style>
+</head>
+<body>
+<div id="root" class="empty">Loading announcements…</div>
+<script>
+(function () {
+  'use strict';
+
+  // Canvas account_notification icon values.
+  var TYPE_INFO = {
+    information: { cls: 'info', label: 'information' },
+    warning: { cls: 'warn', label: 'warning' },
+    question: { cls: 'question', label: 'question' },
+    error: { cls: 'error', label: 'error' },
+    calendar: { cls: 'calendar', label: 'calendar' }
+  };
+  var TYPE_ORDER = ['information', 'warning', 'question', 'error', 'calendar'];
+
+  // Allowlist sanitizer: only these inline/structural tags survive; everything else
+  // is either dropped entirely (scripts, styles, embeds) or unwrapped to its text.
+  var ALLOWED_TAGS = {
+    A: 1, ABBR: 1, B: 1, BLOCKQUOTE: 1, BR: 1, CODE: 1, DD: 1, DIV: 1, DL: 1,
+    DT: 1, EM: 1, H1: 1, H2: 1, H3: 1, H4: 1, H5: 1, H6: 1, HR: 1, I: 1, LI: 1,
+    OL: 1, P: 1, PRE: 1, SMALL: 1, SPAN: 1, STRONG: 1, SUB: 1, SUP: 1, U: 1, UL: 1
+  };
+  var DROP_TAGS = {
+    SCRIPT: 1, STYLE: 1, IFRAME: 1, OBJECT: 1, EMBED: 1, LINK: 1, META: 1,
+    TEMPLATE: 1, NOSCRIPT: 1, FORM: 1, INPUT: 1, BUTTON: 1, IMG: 1, SVG: 1
+  };
+
+  function readPayload() {
+    // Multi-sink probe: try documented hosts in order, fall back to a known shim variable.
+    try {
+      var openai = window.openai;
+      if (openai && openai.toolResult) return openai.toolResult;
+    } catch (_) {}
+    try {
+      if (window.__MCP_TOOL_RESULT__) return window.__MCP_TOOL_RESULT__;
+    } catch (_) {}
+    return null;
+  }
+
+  function looksLikeNotifications(value) {
+    if (!Array.isArray(value)) return false;
+    if (value.length === 0) return true;
+    var first = value[0];
+    return !!first && typeof first === 'object' &&
+      ('subject' in first || 'message' in first || 'icon' in first);
+  }
+
+  function extractNotifications(result) {
+    if (looksLikeNotifications(result)) return result;
+    if (result && typeof result === 'object' && Array.isArray(result.content)) {
+      for (var i = 0; i < result.content.length; i++) {
+        var block = result.content[i];
+        if (block && block.type === 'text' && typeof block.text === 'string') {
+          try {
+            var parsed = JSON.parse(block.text);
+            if (looksLikeNotifications(parsed)) return parsed;
+          } catch (_) {}
+        }
+      }
+    }
+    return null;
+  }
+
+  function renderEmpty(message) {
+    var root = document.getElementById('root');
+    root.className = 'empty';
+    root.textContent = '';
+    var p = document.createElement('div');
+    p.textContent = message;
+    root.appendChild(p);
+  }
+
+  function renderUnsupportedHost() {
+    renderEmpty('Open this tool in a host that supports MCP Apps to see the interactive announcements panel.');
+  }
+
+  function renderUnexpectedShape() {
+    renderEmpty('Unexpected payload shape — expected list_account_notifications response.');
+  }
+
+  function el(tag, attrs, children) {
+    var node = document.createElement(tag);
+    if (attrs) {
+      for (var k in attrs) {
+        if (!Object.prototype.hasOwnProperty.call(attrs, k)) continue;
+        var v = attrs[k];
+        if (k === 'class') node.className = v;
+        else if (k === 'text') node.textContent = v;
+        else node.setAttribute(k, v);
+      }
+    }
+    if (children) {
+      for (var i = 0; i < children.length; i++) {
+        if (children[i] != null) node.appendChild(children[i]);
+      }
+    }
+    return node;
+  }
+
+  function safeUrl(value) {
+    var v = (value == null ? '' : String(value)).trim();
+    if (/^https?:\\/\\//i.test(v)) return v;
+    if (/^mailto:/i.test(v)) return v;
+    return null;
+  }
+
+  function sanitizeInto(source, target) {
+    var nodes = source.childNodes;
+    for (var i = 0; i < nodes.length; i++) {
+      var child = nodes[i];
+      if (child.nodeType === 3) {
+        target.appendChild(document.createTextNode(child.nodeValue));
+      } else if (child.nodeType === 1) {
+        var tag = child.tagName;
+        if (ALLOWED_TAGS[tag]) {
+          var clean = document.createElement(tag.toLowerCase());
+          if (tag === 'A') {
+            var href = safeUrl(child.getAttribute('href'));
+            if (href) {
+              clean.setAttribute('href', href);
+              clean.setAttribute('target', '_blank');
+              clean.setAttribute('rel', 'noopener noreferrer');
+            }
+          }
+          sanitizeInto(child, clean);
+          target.appendChild(clean);
+        } else if (!DROP_TAGS[tag]) {
+          // Unknown but harmless container (e.g. TABLE/TD): unwrap, keep text.
+          sanitizeInto(child, target);
+        }
+        // DROP_TAGS are skipped entirely — their contents never reach the DOM.
+      }
+      // Comments and other node types are ignored.
+    }
+  }
+
+  function renderMessage(html) {
+    var container = el('div', { class: 'msg' });
+    var raw = html == null ? '' : String(html);
+    try {
+      var doc = new DOMParser().parseFromString(raw, 'text/html');
+      sanitizeInto(doc.body, container);
+    } catch (_) {
+      container.textContent = raw;
+    }
+    return container;
+  }
+
+  function formatDate(iso) {
+    if (!iso) return null;
+    var d = new Date(iso);
+    if (isNaN(d.getTime())) return String(iso);
+    try {
+      return d.toLocaleString(undefined, {
+        year: 'numeric', month: 'short', day: 'numeric',
+        hour: '2-digit', minute: '2-digit'
+      });
+    } catch (_) {
+      return d.toISOString();
+    }
+  }
+
+  function dateRange(note) {
+    var start = formatDate(note.start_at);
+    var end = formatDate(note.end_at);
+    if (start && end) return 'Active ' + start + ' – ' + end;
+    if (start) return 'Starts ' + start;
+    if (end) return 'Ends ' + end;
+    return null;
+  }
+
+  function render(notifications) {
+    var root = document.getElementById('root');
+    root.className = '';
+    root.textContent = '';
+
+    var counts = {};
+    notifications.forEach(function (note) {
+      var icon = note && note.icon;
+      if (TYPE_INFO[icon]) counts[icon] = (counts[icon] || 0) + 1;
+    });
+    var presentTypes = TYPE_ORDER.filter(function (t) {
+      return Object.prototype.hasOwnProperty.call(counts, t);
+    });
+
+    // Summary header.
+    var total = notifications.length;
+    var summaryEl = el('div', { class: 'summary' }, [
+      el('strong', { text: total + (total === 1 ? ' announcement' : ' announcements') })
+    ]);
+    if (presentTypes.length) {
+      var byType = presentTypes.map(function (t) { return t + ': ' + counts[t]; }).join(' • ');
+      summaryEl.appendChild(el('span', { class: 'by-type', text: byType }));
+    }
+    root.appendChild(summaryEl);
+
+    // Controls: search + type filter chips.
+    var search = el('input', {
+      class: 'search',
+      type: 'search',
+      placeholder: 'Search announcements by subject…',
+      'aria-label': 'Search announcements by subject'
+    });
+
+    var activeTypes = {};
+    var chipsContainer = el('div', { class: 'chips' });
+    presentTypes.forEach(function (t) {
+      var chip = el('button', { class: 'chip', type: 'button', text: t });
+      chip.addEventListener('click', function () {
+        if (activeTypes[t]) {
+          delete activeTypes[t];
+          chip.classList.remove('on');
+        } else {
+          activeTypes[t] = true;
+          chip.classList.add('on');
+        }
+        applyFilter();
+      });
+      chipsContainer.appendChild(chip);
+    });
+
+    var controlsChildren = [search];
+    if (presentTypes.length) controlsChildren.push(chipsContainer);
+    root.appendChild(el('div', { class: 'controls' }, controlsChildren));
+
+    // Announcement cards.
+    var cardsContainer = el('div', { class: 'cards' });
+    var cardNodes = [];
+
+    notifications.forEach(function (note) {
+      var icon = note && note.icon;
+      var typeInfo = TYPE_INFO[icon];
+      var badgeCls = typeInfo ? typeInfo.cls : 'neutral';
+      var badgeLabel = typeInfo ? typeInfo.label : (icon || 'announcement');
+
+      var head = el('div', { class: 'card-head' }, [
+        el('span', { class: 'type-badge ' + badgeCls, text: badgeLabel }),
+        el('span', { class: 'subject', text: (note && note.subject) || '(no subject)' })
+      ]);
+
+      var children = [head];
+      var range = dateRange(note || {});
+      if (range) children.push(el('div', { class: 'dates', text: range }));
+      if (note && note.message) children.push(renderMessage(note.message));
+
+      var card = el('div', { class: 'card' }, children);
+      card.dataset.type = (icon || '');
+      card.dataset.subject = ((note && note.subject) || '').toLowerCase();
+      cardsContainer.appendChild(card);
+      cardNodes.push(card);
+    });
+    root.appendChild(cardsContainer);
+
+    function applyFilter() {
+      var q = search.value.trim().toLowerCase();
+      var typeKeys = Object.keys(activeTypes);
+      var hasTypeFilter = typeKeys.length > 0;
+      for (var i = 0; i < cardNodes.length; i++) {
+        var node = cardNodes[i];
+        var typeOk = !hasTypeFilter || !!activeTypes[node.dataset.type];
+        var textOk = !q || node.dataset.subject.indexOf(q) !== -1;
+        node.classList.toggle('hidden', !(typeOk && textOk));
+      }
+    }
+
+    search.addEventListener('input', applyFilter);
+  }
+
+  function init() {
+    var payload = readPayload();
+    if (payload == null) {
+      renderUnsupportedHost();
+      return;
+    }
+    var notifications = extractNotifications(payload);
+    if (!notifications) {
+      renderUnexpectedShape();
+      return;
+    }
+    if (notifications.length === 0) {
+      renderEmpty('No active institution announcements.');
+      return;
+    }
+    try {
+      render(notifications);
+    } catch (err) {
+      console.error('view_account_notifications render error', err);
+      renderUnexpectedShape();
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();
+</script>
+</body>
+</html>`

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(120)
+    expect(manifest.tools).toHaveLength(121)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/resources/ui-account-notifications.test.ts
+++ b/tests/resources/ui-account-notifications.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { RESOURCE_MIME_TYPE } from '@modelcontextprotocol/ext-apps/server'
+import { registerAccountNotificationsUI } from '../../src/resources/ui-account-notifications'
+
+const RESOURCE_URI = 'ui://canvas-lms-mcp/account-notifications.html'
+
+describe('registerAccountNotificationsUI', () => {
+  function captureHandler() {
+    const server = new McpServer({ name: 'test', version: '1.0.0' })
+    const spy = vi.spyOn(server, 'registerResource')
+    registerAccountNotificationsUI(server)
+    const call = spy.mock.calls[0]
+    // server.registerResource(name, uri, config, callback) — callback is last
+    return call[call.length - 1] as (
+      uri: URL,
+      extra: Record<string, unknown>,
+    ) => Promise<{ contents: Array<{ uri: string; mimeType?: string; text: string }> }>
+  }
+
+  it('registers without throwing', () => {
+    const server = new McpServer({ name: 'test', version: '1.0.0' })
+    expect(() => registerAccountNotificationsUI(server)).not.toThrow()
+  })
+
+  it('returns content with the MCP Apps mime type', async () => {
+    const handler = captureHandler()
+    const result = await handler(new URL(RESOURCE_URI), {})
+    expect(result.contents[0].mimeType).toBe(RESOURCE_MIME_TYPE)
+  })
+
+  it('returns HTML content at the expected URI', async () => {
+    const handler = captureHandler()
+    const result = await handler(new URL(RESOURCE_URI), {})
+    expect(result.contents[0].uri).toBe(RESOURCE_URI)
+    expect(result.contents[0].text).toMatch(/<!doctype html>/i)
+  })
+
+  it('preserves the multi-sink data injection probe', async () => {
+    const handler = captureHandler()
+    const result = await handler(new URL(RESOURCE_URI), {})
+    const html = result.contents[0].text
+    // The widget must probe window.openai.toolResult first, then a fallback sink.
+    expect(html).toContain('window.openai')
+    expect(html).toContain('window.__MCP_TOOL_RESULT__')
+  })
+
+  it('renders announcement chrome that the payload will populate', async () => {
+    const handler = captureHandler()
+    const result = await handler(new URL(RESOURCE_URI), {})
+    const html = result.contents[0].text
+    // Sanity check the widget surfaces the expected UI affordances.
+    expect(html).toContain('cards')
+    expect(html).toContain('type-badge')
+  })
+
+  it('sanitizes institution HTML rather than executing it', async () => {
+    const handler = captureHandler()
+    const result = await handler(new URL(RESOURCE_URI), {})
+    const html = result.contents[0].text
+    // The message renderer must parse via DOMParser and drop scripts/styles/embeds.
+    expect(html).toContain('DOMParser')
+    expect(html).toContain('ALLOWED_TAGS')
+    expect(html).toContain('DROP_TAGS')
+    // <script> must never be added to the document via innerHTML in this widget.
+    expect(html).not.toContain('.innerHTML')
+  })
+})

--- a/tests/resources/ui-account-notifications.test.ts
+++ b/tests/resources/ui-account-notifications.test.ts
@@ -62,7 +62,9 @@ describe('registerAccountNotificationsUI', () => {
     expect(html).toContain('DOMParser')
     expect(html).toContain('ALLOWED_TAGS')
     expect(html).toContain('DROP_TAGS')
-    // <script> must never be added to the document via innerHTML in this widget.
-    expect(html).not.toContain('.innerHTML')
+    // The widget must never inject untrusted HTML via a raw-HTML sink. This is a
+    // cheap smoke check; the sanitizer's actual behavior is verified by the policy
+    // unit tests (tests/ui/account-notifications-sanitizer.test.ts).
+    expect(html).not.toMatch(/innerHTML|outerHTML|insertAdjacentHTML|document\.write/)
   })
 })

--- a/tests/tools/accounts.test.ts
+++ b/tests/tools/accounts.test.ts
@@ -73,8 +73,8 @@ describe('accountTools', () => {
     } as unknown as CanvasClient
   }
 
-  it('returns 7 tool definitions', () => {
-    expect(accountTools(buildMockCanvas())).toHaveLength(7)
+  it('returns 8 tool definitions', () => {
+    expect(accountTools(buildMockCanvas())).toHaveLength(8)
   })
 
   it('exports tools with correct names', () => {
@@ -87,6 +87,7 @@ describe('accountTools', () => {
       'list_account_users',
       'get_account_reports',
       'list_account_notifications',
+      'view_account_notifications',
     ])
   })
 
@@ -206,6 +207,64 @@ describe('accountTools', () => {
       )
       const tool = accountTools(canvas).find((t) => t.name === 'list_account_notifications')!
       await expect(tool.handler({})).rejects.toBeInstanceOf(CanvasApiError)
+    })
+  })
+
+  describe('view_account_notifications', () => {
+    it('has read-only annotations', () => {
+      const tool = accountTools(buildMockCanvas()).find(
+        (t) => t.name === 'view_account_notifications',
+      )!
+      expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+    })
+
+    it('declares the UI resource URI', () => {
+      const tool = accountTools(buildMockCanvas()).find(
+        (t) => t.name === 'view_account_notifications',
+      )!
+      expect(tool.ui?.resourceUri).toBe('ui://canvas-lms-mcp/account-notifications.html')
+    })
+
+    it('keeps CSP empty (widget is self-contained)', () => {
+      const tool = accountTools(buildMockCanvas()).find(
+        (t) => t.name === 'view_account_notifications',
+      )!
+      expect(tool.ui?.csp).toEqual({
+        connectDomains: [],
+        resourceDomains: [],
+        frameDomains: [],
+      })
+    })
+
+    it('defaults account_id to "self" when not provided', async () => {
+      const canvas = buildMockCanvas()
+      const tool = accountTools(canvas).find((t) => t.name === 'view_account_notifications')!
+      await tool.handler({})
+      expect(canvas.accounts.listNotifications).toHaveBeenCalledWith('self')
+    })
+
+    it('defaults account_id to "self" when an empty string is passed', async () => {
+      const canvas = buildMockCanvas()
+      const tool = accountTools(canvas).find((t) => t.name === 'view_account_notifications')!
+      await tool.handler({ account_id: '' })
+      expect(canvas.accounts.listNotifications).toHaveBeenCalledWith('self')
+    })
+
+    it('passes account_id to canvas.accounts.listNotifications when provided', async () => {
+      const canvas = buildMockCanvas()
+      const tool = accountTools(canvas).find((t) => t.name === 'view_account_notifications')!
+      await tool.handler({ account_id: '42' })
+      expect(canvas.accounts.listNotifications).toHaveBeenCalledWith('42')
+    })
+
+    it('returns the same payload as list_account_notifications', async () => {
+      const canvas = buildMockCanvas()
+      const tools = accountTools(canvas)
+      const list = tools.find((t) => t.name === 'list_account_notifications')!
+      const view = tools.find((t) => t.name === 'view_account_notifications')!
+      const listResult = await list.handler({})
+      const viewResult = await view.handler({})
+      expect(viewResult).toEqual(listResult)
     })
   })
 

--- a/tests/tools/accounts.test.ts
+++ b/tests/tools/accounts.test.ts
@@ -266,6 +266,16 @@ describe('accountTools', () => {
       const viewResult = await view.handler({})
       expect(viewResult).toEqual(listResult)
     })
+
+    it('propagates a 404 error from Canvas (same as the JSON tool)', async () => {
+      const { CanvasApiError } = await import('../../src/canvas/client')
+      const canvas = buildMockCanvas()
+      vi.mocked(canvas.accounts.listNotifications).mockRejectedValueOnce(
+        new CanvasApiError('Not Found', 404, '/api/v1/accounts/self/account_notifications'),
+      )
+      const tool = accountTools(canvas).find((t) => t.name === 'view_account_notifications')!
+      await expect(tool.handler({})).rejects.toBeInstanceOf(CanvasApiError)
+    })
   })
 
   describe('pseudonymization', () => {

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -173,7 +173,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 119 tools across all domains', () => {
+  it('returns all 121 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 
@@ -273,7 +273,7 @@ describe('getAllTools', () => {
     expect(names).toContain('get_submission_peer_reviews')
     expect(names).toContain('create_peer_review')
     expect(names).toContain('delete_peer_review')
-    // Accounts (7)
+    // Accounts (8)
     expect(names).toContain('get_account')
     expect(names).toContain('list_accounts')
     expect(names).toContain('list_sub_accounts')
@@ -281,6 +281,7 @@ describe('getAllTools', () => {
     expect(names).toContain('list_account_users')
     expect(names).toContain('get_account_reports')
     expect(names).toContain('list_account_notifications')
+    expect(names).toContain('view_account_notifications')
     // Analytics & Search (4)
     expect(names).toContain('search_course_content')
     expect(names).toContain('get_course_analytics')
@@ -322,7 +323,7 @@ describe('getAllTools', () => {
     expect(names).toContain('list_submission_comments_needing_attention')
     expect(names).toContain('list_students_needing_attention')
 
-    expect(tools).toHaveLength(120)
+    expect(tools).toHaveLength(121)
   })
 
   it('all tools have openWorldHint: true', () => {

--- a/tests/ui/account-notifications-sanitizer.test.ts
+++ b/tests/ui/account-notifications-sanitizer.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ALLOWED_TAGS,
+  DROP_TAGS,
+  SAFE_URL_PATTERNS,
+  classifyTag,
+  sanitizeUrl,
+} from '../../src/ui/account-notifications-sanitizer'
+import { ACCOUNT_NOTIFICATIONS_HTML } from '../../src/ui/account-notifications.html'
+
+// These guard the XSS trust boundary for institution-authored announcement HTML.
+// The widget cannot execute under vitest's node environment, so the policy that
+// drives it is defined as pure data/functions here and interpolated into the
+// widget — exercising it directly is what makes a sanitizer regression fail CI.
+describe('account-notifications sanitizer policy', () => {
+  describe('sanitizeUrl', () => {
+    it('keeps http(s) and mailto links', () => {
+      expect(sanitizeUrl('https://example.edu/notice')).toBe('https://example.edu/notice')
+      expect(sanitizeUrl('http://example.edu')).toBe('http://example.edu')
+      expect(sanitizeUrl('HTTPS://EXAMPLE.EDU')).toBe('HTTPS://EXAMPLE.EDU')
+      expect(sanitizeUrl('mailto:help@example.edu')).toBe('mailto:help@example.edu')
+    })
+
+    it('trims surrounding whitespace before matching', () => {
+      expect(sanitizeUrl('  https://example.edu  ')).toBe('https://example.edu')
+    })
+
+    it('drops javascript: URLs regardless of casing or leading whitespace', () => {
+      expect(sanitizeUrl('javascript:alert(1)')).toBeNull()
+      expect(sanitizeUrl('JavaScript:alert(1)')).toBeNull()
+      expect(sanitizeUrl('  javascript:alert(1)')).toBeNull()
+      expect(sanitizeUrl('\tjavascript:alert(1)')).toBeNull()
+    })
+
+    it('drops data:, vbscript:, file: and other dangerous schemes', () => {
+      expect(sanitizeUrl('data:text/html,<script>alert(1)</script>')).toBeNull()
+      expect(sanitizeUrl('vbscript:msgbox(1)')).toBeNull()
+      expect(sanitizeUrl('file:///etc/passwd')).toBeNull()
+    })
+
+    it('drops relative and protocol-relative URLs', () => {
+      expect(sanitizeUrl('/local/path')).toBeNull()
+      expect(sanitizeUrl('//evil.example')).toBeNull()
+      expect(sanitizeUrl('not-a-url')).toBeNull()
+    })
+
+    it('drops empty/nullish values', () => {
+      expect(sanitizeUrl('')).toBeNull()
+      expect(sanitizeUrl(null)).toBeNull()
+      expect(sanitizeUrl(undefined)).toBeNull()
+    })
+  })
+
+  describe('classifyTag', () => {
+    it('allows inline/structural tags', () => {
+      expect(classifyTag('A')).toBe('allow')
+      expect(classifyTag('p')).toBe('allow')
+      expect(classifyTag('Strong')).toBe('allow')
+      expect(classifyTag('UL')).toBe('allow')
+    })
+
+    it('drops script/style/embed/form tags entirely', () => {
+      expect(classifyTag('SCRIPT')).toBe('drop')
+      expect(classifyTag('script')).toBe('drop')
+      expect(classifyTag('STYLE')).toBe('drop')
+      expect(classifyTag('IFRAME')).toBe('drop')
+      expect(classifyTag('IMG')).toBe('drop')
+      expect(classifyTag('SVG')).toBe('drop')
+    })
+
+    it('unwraps unknown but non-dangerous containers (keeps their text)', () => {
+      expect(classifyTag('TABLE')).toBe('unwrap')
+      expect(classifyTag('TD')).toBe('unwrap')
+      expect(classifyTag('MARQUEE')).toBe('unwrap')
+    })
+
+    it('never both allows and drops the same tag', () => {
+      for (const tag of ALLOWED_TAGS) {
+        expect(DROP_TAGS).not.toContain(tag)
+      }
+    })
+
+    it('drops the highest-risk script/style/embed tags', () => {
+      for (const tag of ['SCRIPT', 'STYLE', 'IFRAME', 'OBJECT', 'EMBED', 'IMG', 'SVG']) {
+        expect(DROP_TAGS).toContain(tag)
+      }
+    })
+  })
+
+  describe('widget wiring', () => {
+    it('interpolates the shared policy into the shipped widget', () => {
+      // A regression to the policy module changes these strings, so the widget the
+      // user runs and the policy these tests verify cannot silently diverge.
+      expect(ACCOUNT_NOTIFICATIONS_HTML).toContain(JSON.stringify(DROP_TAGS))
+      expect(ACCOUNT_NOTIFICATIONS_HTML).toContain(JSON.stringify(ALLOWED_TAGS))
+      expect(ACCOUNT_NOTIFICATIONS_HTML).toContain(JSON.stringify(SAFE_URL_PATTERNS))
+      // The widget must build its guard from the shared patterns, not a stray literal.
+      expect(ACCOUNT_NOTIFICATIONS_HTML).toContain('SAFE_URL_RES')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

> **User story:** As an instructor or student using an AI assistant connected to Canvas, I want institution announcements rendered as an interactive panel (not a wall of text) so I can scan, filter, and open them at a glance.

Adds `view_account_notifications` — an interactive MCP Apps widget for institution-wide announcements, built directly on the `view_course_structure` pattern shipped in v1.22.0. The dependency (`list_account_notifications`, #178) is already on `main`.

## Approach

- **Tool** (`src/tools/accounts.ts`): new `view_account_notifications`. Inputs identical to `list_account_notifications` (`account_id` optional, default `"self"`). The handler delegates to the same `canvas.accounts.listNotifications` method — no duplicated logic. Read-only annotations; `ui.resourceUri: "ui://canvas-lms-mcp/account-notifications.html"` with an intentionally empty CSP.
- **Widget** (`src/ui/account-notifications.html.ts`): a single self-contained HTML/CSS/vanilla-JS literal — announcement cards with an icon-type badge (information / warning / question / error / calendar), subject, start/end date range, type filter chips, subject search, and a summary header with counts. Same multi-sink tool-result probe and "open in a supporting host" fallback as the course-structure widget.
- **Sanitized HTML rendering**: announcement `message` bodies are institution-authored HTML, so they are rendered through an allowlist DOM sanitizer — parsed with `DOMParser`, then rebuilt copying only an allowlist of inline/structural tags. `<script>`/`<style>`/`<iframe>`/embeds are dropped entirely, `javascript:`/`data:` URLs are stripped from links, and the widget never uses `innerHTML`. No script executes and no remote resources load.
- **Resource** (`src/resources/ui-account-notifications.ts`): registers the `ui://` resource, wired into `registerAllResources`. Registration uses the existing generic `registerAppTool` branch (any tool with a `ui` binding).
- No student PII in the payload → no pseudonymizer wrap (per the acceptance criteria).

## Test evidence

New tests mirror the course-structure suite: tool registration/annotations/`ui.resourceUri`/empty-CSP and delegation (`tests/tools/accounts.test.ts`), and `ui://` resource resolution + the sanitizer contract (`tests/resources/ui-account-notifications.test.ts`). Tool-count drift checks and the committed `docs/generated/tool-manifest.json` were updated/regenerated.

Full gate, all green:

```
pnpm typecheck   # tsc --noEmit — clean
pnpm lint        # eslint + prettier — All matched files use Prettier code style!
pnpm test        # Test Files 76 passed (76) | Tests 964 passed | 1 skipped (965)
pnpm build       # ⚡️ Build success
```

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)
