### PR TITLE
feat(content-exports): add course content export tools (create, get, list)

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 121,
+  "toolCount": 124,
   "tools": [
     {
       "name": "health_check",
@@ -1487,6 +1487,42 @@
       "name": "list_students_needing_attention",
       "domain": "attention",
       "description": "Report students who may need instructor attention based on inactivity, missing or late submissions, and low current score. Each finding lists the exact signals that fired and the thresholds used — this is a factual report, not a prediction. Requires instructor/TA permissions in the course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "create_content_export",
+      "domain": "content_exports",
+      "description": "Start a Canvas course content export (Common Cartridge / QTI / zip). Exports are asynchronous — this tool returns immediately with an export ID and initial workflow_state (\"created\"). Call get_content_export to poll progress and retrieve the time-limited download link when the export finishes.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_content_export",
+      "domain": "content_exports",
+      "description": "Get the status of a content export. When workflow_state is \"exported\", attachment.url contains a time-limited download link — download it promptly, as the URL expires (re-fetch to get a fresh one). Returns attachment: null while still \"created\"/\"exporting\" or on \"failed\".",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_content_exports",
+      "domain": "content_exports",
+      "description": "List all content exports for a course (most recent first).",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true

--- a/src/canvas/content-exports.ts
+++ b/src/canvas/content-exports.ts
@@ -1,0 +1,33 @@
+import type { CanvasHttpClient } from './client'
+import type { CanvasContentExport, ContentExportType } from './types'
+
+/**
+ * Canvas `content_exports` API — exports a course (or its assessments) as a
+ * Common Cartridge / QTI / zip package. Exports are asynchronous: `create`
+ * starts the job and returns immediately; `get` polls until the package is ready
+ * and surfaces a time-limited `attachment.url` download link.
+ */
+export class ContentExportsModule {
+  constructor(private client: CanvasHttpClient) {}
+
+  /** Start a content export. Returns the export in its initial `created` state. */
+  async create(courseId: number, exportType: ContentExportType): Promise<CanvasContentExport> {
+    // Canvas accepts `export_type` as a top-level param here (no `content_export:` envelope).
+    return this.client.request<CanvasContentExport>(`/api/v1/courses/${courseId}/content_exports`, {
+      method: 'POST',
+      body: JSON.stringify({ export_type: exportType }),
+    })
+  }
+
+  /** Poll a single export's status; `attachment` is populated only once `exported`. */
+  async get(courseId: number, exportId: number): Promise<CanvasContentExport> {
+    return this.client.request<CanvasContentExport>(
+      `/api/v1/courses/${courseId}/content_exports/${exportId}`,
+    )
+  }
+
+  /** List all content exports for a course (most recent first, per Canvas). */
+  async list(courseId: number): Promise<CanvasContentExport[]> {
+    return this.client.paginate<CanvasContentExport>(`/api/v1/courses/${courseId}/content_exports`)
+  }
+}

--- a/src/canvas/index.ts
+++ b/src/canvas/index.ts
@@ -21,6 +21,7 @@ import { DashboardModule } from './dashboard'
 import { OutcomesModule } from './outcomes'
 import { GradebookHistoryModule } from './gradebook-history'
 import { NewQuizzesModule } from './new-quizzes'
+import { ContentExportsModule } from './content-exports'
 
 /**
  * Standalone Canvas REST API client. Composed of modular per-domain classes
@@ -57,6 +58,7 @@ export class CanvasClient {
   outcomes: OutcomesModule
   gradebookHistory: GradebookHistoryModule
   newQuizzes: NewQuizzesModule
+  contentExports: ContentExportsModule
 
   constructor(config: CanvasClientConfig) {
     this.client = new CanvasHttpClient(config)
@@ -81,6 +83,7 @@ export class CanvasClient {
     this.outcomes = new OutcomesModule(this.client)
     this.gradebookHistory = new GradebookHistoryModule(this.client)
     this.newQuizzes = new NewQuizzesModule(this.client)
+    this.contentExports = new ContentExportsModule(this.client)
   }
 }
 

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -993,3 +993,35 @@ export interface CanvasPeerReview {
   asset_type: 'Submission'
   workflow_state: 'assigned' | 'completed'
 }
+
+// --- Content Exports ---
+
+export type ContentExportType = 'common_cartridge' | 'qti' | 'zip'
+
+export type ContentExportWorkflowState =
+  | 'created'
+  | 'exporting'
+  | 'exported'
+  | 'failed'
+  // Canvas may emit undocumented states (e.g. 'waiting_for_external_tool'); keep the
+  // union open as a hint type without losing autocomplete on the known states.
+  | (string & {})
+
+export interface CanvasContentExportAttachment {
+  url: string
+  filename: string
+}
+
+export interface CanvasContentExport {
+  id: number
+  export_type: ContentExportType
+  workflow_state: ContentExportWorkflowState
+  /** null while 'created'; a Canvas progress URL once 'exporting'/'exported'. */
+  progress_url: string | null
+  /** Non-null (time-limited download link) only when workflow_state === 'exported'. */
+  attachment: CanvasContentExportAttachment | null
+  /** Opaque integer — the teacher/admin who initiated the export, not a student identifier. */
+  user_id?: number
+  created_at: string
+  updated_at: string
+}

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -5,6 +5,7 @@ import { analyticsTools } from './analytics'
 import { attentionTools } from './attention'
 import { assignmentTools } from './assignments'
 import { calendarTools } from './calendar'
+import { contentExportsTools } from './content-exports'
 import { conversationTools } from './conversations'
 import { courseTools } from './courses'
 import { dashboardTools } from './dashboard'
@@ -152,5 +153,10 @@ export const toolDomainCatalog: readonly ToolDomainRegistration[] = [
     domain: 'attention',
     defaultPrimaryAudience: 'educator',
     getTools: attentionTools,
+  },
+  {
+    domain: 'content_exports',
+    defaultPrimaryAudience: 'educator',
+    getTools: contentExportsTools,
   },
 ]

--- a/src/tools/content-exports.ts
+++ b/src/tools/content-exports.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod'
+import type { CanvasClient } from '../canvas'
+import type { ContentExportType } from '../canvas/types'
+import type { ToolDefinition } from './types'
+
+export function contentExportsTools(canvas: CanvasClient): ToolDefinition[] {
+  return [
+    {
+      name: 'create_content_export',
+      description:
+        'Start a Canvas course content export (Common Cartridge / QTI / zip). Exports are asynchronous — this tool returns immediately with an export ID and initial workflow_state ("created"). Call get_content_export to poll progress and retrieve the time-limited download link when the export finishes.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        export_type: z
+          .enum(['common_cartridge', 'qti', 'zip'])
+          .describe(
+            'Export format: common_cartridge (IMS CC, widely portable for migration/backup), qti (assessments only), zip (Canvas-native files archive)',
+          ),
+      },
+      annotations: { destructiveHint: true, openWorldHint: true },
+      handler: async (params) =>
+        canvas.contentExports.create(
+          params.course_id as number,
+          params.export_type as ContentExportType,
+        ),
+    },
+    {
+      name: 'get_content_export',
+      description:
+        'Get the status of a content export. When workflow_state is "exported", attachment.url contains a time-limited download link — download it promptly, as the URL expires (re-fetch to get a fresh one). Returns attachment: null while still "created"/"exporting" or on "failed".',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        export_id: z.number().describe('The export ID returned by create_content_export'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      handler: async (params) =>
+        canvas.contentExports.get(params.course_id as number, params.export_id as number),
+    },
+    {
+      name: 'list_content_exports',
+      description: 'List all content exports for a course (most recent first).',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      handler: async (params) => canvas.contentExports.list(params.course_id as number),
+    },
+  ]
+}

--- a/tests/canvas/content-exports.test.ts
+++ b/tests/canvas/content-exports.test.ts
@@ -103,6 +103,13 @@ describe('ContentExportsModule', () => {
     expect(client.paginate).toHaveBeenCalledWith(`/api/v1/courses/${COURSE_ID}/content_exports`)
   })
 
+  it('lists content exports for a course with no exports (empty array)', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+    const result = await mod.list(COURSE_ID)
+    expect(result).toEqual([])
+    expect(client.paginate).toHaveBeenCalledWith(`/api/v1/courses/${COURSE_ID}/content_exports`)
+  })
+
   // --- Error propagation (CanvasApiError must surface, never be swallowed) ---
 
   it('surfaces a CanvasApiError with status 404 from get', async () => {
@@ -124,6 +131,18 @@ describe('ContentExportsModule', () => {
       json: async () => ({ message: 'user not authorized to perform that action' }),
     } as unknown as Response)
     await expect(mod.create(COURSE_ID, 'zip')).rejects.toMatchObject({
+      name: 'CanvasApiError',
+      status: 403,
+    })
+  })
+
+  it('surfaces a CanvasApiError with status 403 from list (paginate error branch)', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ message: 'user not authorized to perform that action' }),
+    } as unknown as Response)
+    await expect(mod.list(COURSE_ID)).rejects.toMatchObject({
       name: 'CanvasApiError',
       status: 403,
     })

--- a/tests/canvas/content-exports.test.ts
+++ b/tests/canvas/content-exports.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ContentExportsModule } from '../../src/canvas/content-exports'
+import { CanvasHttpClient } from '../../src/canvas/client'
+import type { CanvasContentExport } from '../../src/canvas/types'
+
+const COURSE_ID = 100
+const EXPORT_ID = 42
+
+const BASE_EXPORT: CanvasContentExport = {
+  id: EXPORT_ID,
+  export_type: 'common_cartridge',
+  workflow_state: 'created',
+  progress_url: null,
+  attachment: null,
+  user_id: 99,
+  created_at: '2026-06-14T10:00:00Z',
+  updated_at: '2026-06-14T10:00:00Z',
+}
+
+const EXPORTING_EXPORT: CanvasContentExport = {
+  ...BASE_EXPORT,
+  workflow_state: 'exporting',
+  progress_url: 'https://canvas.example.com/api/v1/progress/999',
+}
+
+const EXPORTED_EXPORT: CanvasContentExport = {
+  ...BASE_EXPORT,
+  workflow_state: 'exported',
+  progress_url: 'https://canvas.example.com/api/v1/progress/999',
+  attachment: {
+    url: 'https://s3.example.com/course_42.imscc',
+    filename: 'course_42_export.imscc',
+  },
+}
+
+const FAILED_EXPORT: CanvasContentExport = {
+  ...BASE_EXPORT,
+  workflow_state: 'failed',
+  progress_url: null,
+}
+
+describe('ContentExportsModule', () => {
+  let client: CanvasHttpClient
+  let mod: ContentExportsModule
+
+  beforeEach(() => {
+    client = new CanvasHttpClient({ token: 'test-token', baseUrl: 'https://canvas.example.com' })
+    mod = new ContentExportsModule(client)
+  })
+
+  it('creates a content export with a flat export_type body', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce(BASE_EXPORT)
+    const result = await mod.create(COURSE_ID, 'common_cartridge')
+    expect(result).toMatchObject({ id: EXPORT_ID, workflow_state: 'created', attachment: null })
+    expect(client.request).toHaveBeenCalledWith(
+      `/api/v1/courses/${COURSE_ID}/content_exports`,
+      expect.objectContaining({ method: 'POST' }),
+    )
+    // Body is flat JSON ({ export_type }), NOT wrapped in a content_export envelope.
+    const body = JSON.parse(vi.mocked(client.request).mock.calls[0][1]!.body as string)
+    expect(body).toEqual({ export_type: 'common_cartridge' })
+  })
+
+  it.each(['common_cartridge', 'qti', 'zip'] as const)(
+    'creates a %s export',
+    async (exportType) => {
+      vi.spyOn(client, 'request').mockResolvedValueOnce({ ...BASE_EXPORT, export_type: exportType })
+      await mod.create(COURSE_ID, exportType)
+      const body = JSON.parse(vi.mocked(client.request).mock.calls[0][1]!.body as string)
+      expect(body).toEqual({ export_type: exportType })
+    },
+  )
+
+  it('gets an in-progress export (attachment null, progress_url present)', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce(EXPORTING_EXPORT)
+    const result = await mod.get(COURSE_ID, EXPORT_ID)
+    expect(result.attachment).toBeNull()
+    expect(result.progress_url).not.toBeNull()
+    expect(client.request).toHaveBeenCalledWith(
+      `/api/v1/courses/${COURSE_ID}/content_exports/${EXPORT_ID}`,
+    )
+  })
+
+  it('gets a finished export and surfaces the attachment download URL', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce(EXPORTED_EXPORT)
+    const result = await mod.get(COURSE_ID, EXPORT_ID)
+    expect(result.workflow_state).toBe('exported')
+    expect(result.attachment?.url).toBe('https://s3.example.com/course_42.imscc')
+    expect(result.attachment?.filename).toBe('course_42_export.imscc')
+  })
+
+  it('gets a failed export without throwing (attachment null)', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce(FAILED_EXPORT)
+    const result = await mod.get(COURSE_ID, EXPORT_ID)
+    expect(result.workflow_state).toBe('failed')
+    expect(result.attachment).toBeNull()
+  })
+
+  it('lists content exports for a course', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([EXPORTED_EXPORT, BASE_EXPORT])
+    const result = await mod.list(COURSE_ID)
+    expect(result).toHaveLength(2)
+    expect(client.paginate).toHaveBeenCalledWith(`/api/v1/courses/${COURSE_ID}/content_exports`)
+  })
+
+  // --- Error propagation (CanvasApiError must surface, never be swallowed) ---
+
+  it('surfaces a CanvasApiError with status 404 from get', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: async () => ({ errors: [{ message: 'The specified resource does not exist.' }] }),
+    } as unknown as Response)
+    await expect(mod.get(COURSE_ID, 999)).rejects.toMatchObject({
+      name: 'CanvasApiError',
+      status: 404,
+    })
+  })
+
+  it('surfaces a CanvasApiError with status 403 from create', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ message: 'user not authorized to perform that action' }),
+    } as unknown as Response)
+    await expect(mod.create(COURSE_ID, 'zip')).rejects.toMatchObject({
+      name: 'CanvasApiError',
+      status: 403,
+    })
+  })
+})

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(121)
+    expect(manifest.tools).toHaveLength(124)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/tools/content-exports.test.ts
+++ b/tests/tools/content-exports.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { CanvasClient } from '../../src/canvas'
+import { contentExportsTools } from '../../src/tools/content-exports'
+import type { CanvasContentExport } from '../../src/canvas/types'
+
+const mockExport: CanvasContentExport = {
+  id: 42,
+  export_type: 'common_cartridge',
+  workflow_state: 'created',
+  progress_url: null,
+  attachment: null,
+  user_id: 99,
+  created_at: '2026-06-14T10:00:00Z',
+  updated_at: '2026-06-14T10:00:00Z',
+}
+
+const mockExported: CanvasContentExport = {
+  ...mockExport,
+  workflow_state: 'exported',
+  progress_url: 'https://canvas.example.com/api/v1/progress/999',
+  attachment: { url: 'https://s3.example.com/course_42.imscc', filename: 'course_42_export.imscc' },
+}
+
+function buildMockCanvas(): CanvasClient {
+  return {
+    contentExports: {
+      create: vi.fn().mockResolvedValue(mockExport),
+      get: vi.fn().mockResolvedValue(mockExported),
+      list: vi.fn().mockResolvedValue([mockExported, mockExport]),
+    },
+  } as unknown as CanvasClient
+}
+
+describe('contentExportsTools', () => {
+  it('returns 3 tool definitions', () => {
+    expect(contentExportsTools(buildMockCanvas())).toHaveLength(3)
+  })
+
+  it('exports tools with correct names', () => {
+    const names = contentExportsTools(buildMockCanvas()).map((t) => t.name)
+    expect(names).toEqual(['create_content_export', 'get_content_export', 'list_content_exports'])
+  })
+
+  describe('annotations', () => {
+    it('create_content_export has destructiveHint + openWorldHint', () => {
+      const tool = contentExportsTools(buildMockCanvas()).find(
+        (t) => t.name === 'create_content_export',
+      )!
+      expect(tool.annotations).toEqual({ destructiveHint: true, openWorldHint: true })
+    })
+
+    it('get_content_export has readOnlyHint + openWorldHint', () => {
+      const tool = contentExportsTools(buildMockCanvas()).find(
+        (t) => t.name === 'get_content_export',
+      )!
+      expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+    })
+
+    it('list_content_exports has readOnlyHint + openWorldHint', () => {
+      const tool = contentExportsTools(buildMockCanvas()).find(
+        (t) => t.name === 'list_content_exports',
+      )!
+      expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+    })
+  })
+
+  describe('create_content_export', () => {
+    it.each(['common_cartridge', 'qti', 'zip'] as const)(
+      'delegates a %s export to canvas.contentExports.create',
+      async (exportType) => {
+        const canvas = buildMockCanvas()
+        const tool = contentExportsTools(canvas).find((t) => t.name === 'create_content_export')!
+        const result = await tool.handler({ course_id: 7, export_type: exportType })
+        expect(canvas.contentExports.create).toHaveBeenCalledWith(7, exportType)
+        expect(result).toEqual(mockExport)
+      },
+    )
+  })
+
+  describe('get_content_export', () => {
+    it('delegates to canvas.contentExports.get and surfaces the attachment URL', async () => {
+      const canvas = buildMockCanvas()
+      const tool = contentExportsTools(canvas).find((t) => t.name === 'get_content_export')!
+      const result = (await tool.handler({ course_id: 7, export_id: 42 })) as CanvasContentExport
+      expect(canvas.contentExports.get).toHaveBeenCalledWith(7, 42)
+      expect(result.attachment?.url).toBe('https://s3.example.com/course_42.imscc')
+    })
+  })
+
+  describe('list_content_exports', () => {
+    it('delegates to canvas.contentExports.list', async () => {
+      const canvas = buildMockCanvas()
+      const tool = contentExportsTools(canvas).find((t) => t.name === 'list_content_exports')!
+      const result = await tool.handler({ course_id: 7 })
+      expect(canvas.contentExports.list).toHaveBeenCalledWith(7)
+      expect(result).toEqual([mockExported, mockExport])
+    })
+  })
+})

--- a/tests/tools/content-exports.test.ts
+++ b/tests/tools/content-exports.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { z } from 'zod'
 import type { CanvasClient } from '../../src/canvas'
 import { contentExportsTools } from '../../src/tools/content-exports'
 import type { CanvasContentExport } from '../../src/canvas/types'
@@ -94,6 +95,26 @@ describe('contentExportsTools', () => {
       const result = await tool.handler({ course_id: 7 })
       expect(canvas.contentExports.list).toHaveBeenCalledWith(7)
       expect(result).toEqual([mockExported, mockExport])
+    })
+  })
+
+  describe('input validation', () => {
+    it('create_content_export rejects an export_type outside the enum', () => {
+      const tool = contentExportsTools(buildMockCanvas()).find(
+        (t) => t.name === 'create_content_export',
+      )!
+      const schema = z.object(tool.inputSchema)
+      expect(schema.safeParse({ course_id: 7, export_type: 'pdf' }).success).toBe(false)
+      expect(schema.safeParse({ course_id: 7, export_type: 'common_cartridge' }).success).toBe(true)
+    })
+
+    it('create_content_export rejects a missing/non-numeric course_id', () => {
+      const tool = contentExportsTools(buildMockCanvas()).find(
+        (t) => t.name === 'create_content_export',
+      )!
+      const schema = z.object(tool.inputSchema)
+      expect(schema.safeParse({ export_type: 'zip' }).success).toBe(false)
+      expect(schema.safeParse({ course_id: 'abc', export_type: 'zip' }).success).toBe(false)
     })
   })
 })

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -164,6 +164,11 @@ function buildFullMockCanvas(): CanvasClient {
       updateItem: async () => ({}),
       deleteItem: async () => undefined,
     },
+    contentExports: {
+      create: async () => ({}),
+      get: async () => ({}),
+      list: async () => [],
+    },
   } as unknown as CanvasClient
 }
 
@@ -173,7 +178,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 121 tools across all domains', () => {
+  it('returns all 124 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 
@@ -322,8 +327,12 @@ describe('getAllTools', () => {
     // Attention (2)
     expect(names).toContain('list_submission_comments_needing_attention')
     expect(names).toContain('list_students_needing_attention')
+    // Content Exports (3)
+    expect(names).toContain('create_content_export')
+    expect(names).toContain('get_content_export')
+    expect(names).toContain('list_content_exports')
 
-    expect(tools).toHaveLength(121)
+    expect(tools).toHaveLength(124)
   })
 
   it('all tools have openWorldHint: true', () => {
@@ -370,6 +379,7 @@ describe('getAllTools', () => {
       'create_new_quiz_item',
       'update_new_quiz_item',
       'delete_new_quiz_item',
+      'create_content_export',
     ]
     const tools = getAllTools(buildFullMockCanvas())
     for (const name of writeToolNames) {
@@ -415,6 +425,7 @@ describe('getAllTools', () => {
       'create_new_quiz_item',
       'update_new_quiz_item',
       'delete_new_quiz_item',
+      'create_content_export',
     ])
     const tools = getAllTools(buildFullMockCanvas())
     for (const tool of tools) {


### PR DESCRIPTION
## Summary

Implements the merged design spec for #181 — wraps the Canvas `content_exports` API as a new `content_exports` tool domain.

> **User story:** As an instructor or admin using an AI assistant connected to Canvas, I want to export a course (or selected content) as a Common Cartridge / QTI / zip package and get a download link — so I can back up, migrate, or bulk-move courses by telling Claude "export this one, then do the rest" instead of hand-rolling REST scripts.

## Approach

Three tools modelling the async create → poll → list lifecycle (per the spec's retired unknowns):

| Tool | Access | Canvas endpoint |
|------|--------|-----------------|
| `create_content_export` | write (`destructiveHint`) | `POST /courses/:id/content_exports` |
| `get_content_export` | read (`readOnlyHint`) | `GET /courses/:id/content_exports/:export_id` |
| `list_content_exports` | read (`readOnlyHint`) | `GET /courses/:id/content_exports` |

- **Async create→poll split** (not a blocking tool): `create_content_export` returns immediately with `workflow_state: "created"`; the agent loops `get_content_export` until `"exported"` and then surfaces the time-limited `attachment.url` download link. Avoids MCP timeouts and double-export-on-retry.
- **Course-level export only** for the MVP (`export_type ∈ common_cartridge | qti | zip`); partial `select[]` exports and the `content_migrations` import side are out of scope per the spec.
- **Download delivery** = the pre-signed `attachment.url` (no streaming/base64), mirroring how `files.ts` surfaces `meta.url`. The tool description warns the URL is time-limited and that re-fetching yields a fresh one.
- **Canvas-only:** uses the existing `CanvasHttpClient.request()` / `paginate()`; no new dependencies, transports, or endpoints.
- **Pseudonymizer:** not required — `CanvasContentExport` carries only course-package metadata (IDs, export type, workflow state, attachment URL/filename, and an opaque initiating `user_id`); no student PII. No `PSEUDONYMIZER_WRAPPED_TOOLS` entry needed.

New files: `src/canvas/content-exports.ts`, `src/tools/content-exports.ts`, `tests/canvas/content-exports.test.ts`, `tests/tools/content-exports.test.ts`. Wired into `src/canvas/index.ts` and registered as the last entry in `src/tools/catalog.ts`.

## Deviations from the spec (followed code reality)

- **Tool count is 121 → 124**, not the spec's 120 → 123. The live `registry.test.ts` / manifest already asserted 121 tools (the spec was written against an earlier count). Updated both `tests/tools/registry.test.ts` and `tests/discovery/manifests.test.ts` to 124.
- **Regenerated `docs/generated/tool-manifest.json`** (`pnpm generate:manifests`). The spec didn't mention this committed artifact, but a discovery test diffs `buildToolManifest()` against it, so it had to be regenerated. The diff is exactly the three new tools + the `toolCount` bump.
- **`contentExportsTools(canvas)`** omits the unused `_pseudonymizer?` param, matching the most recent non-PII module (`newQuizTools`); the catalog's optional second arg is simply not consumed.

## Test evidence

Tests cover the module (create with flat `export_type` body, each export type, in-progress / exported / failed `get`, `list`, and `404`/`403` surfacing as `CanvasApiError`) and the tool layer (count, names, annotations, handler delegation). Full local gate green:

```
pnpm typecheck  → clean (tsc --noEmit)
pnpm lint       → eslint clean + "All matched files use Prettier code style!"
pnpm test       → Test Files 80 passed (80) | Tests 1003 passed | 1 skipped (1004)
pnpm build      → ESM + CJS build success
```

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)
