### PR TITLE
feat(quizzes): add get_quiz_submission_events tool

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 124,
+  "toolCount": 125,
   "tools": [
     {
       "name": "health_check",
@@ -348,6 +348,18 @@
         "openWorldHint": true
       },
       "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_quiz_submission_events",
+      "domain": "quizzes",
+      "description": "Get the event log for a Classic Quiz submission in chronological order. Events include session_started, question_answered, question_flagged, page_blurred, and page_focused. Use this to understand the timeline of a student's attempt. Classic Quizzes only — New Quizzes does not expose event logs via the Canvas REST API. Events are scoped to a single submission; Canvas enforces access permissions (instructors and the submitting student only). Do not use event logs as the sole basis for academic-integrity conclusions; present them with context.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
       "primaryAudience": "educator",
       "relatedWorkflows": []
     },

--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -360,7 +360,7 @@
         "openWorldHint": true
       },
       "access": "read",
-      "primaryAudience": "educator",
+      "primaryAudience": "shared",
       "relatedWorkflows": []
     },
     {

--- a/docs/superpowers/specs/2026-06-14-issue-182-quiz-submission-event-logs.md
+++ b/docs/superpowers/specs/2026-06-14-issue-182-quiz-submission-event-logs.md
@@ -4,6 +4,12 @@
 **Issue**: [bruchris/canvas-lms-mcp#182](https://github.com/bruchris/canvas-lms-mcp/issues/182)
 **Status**: Design — awaiting CTO review
 
+> **Post-implementation correction (PR #193).** Two details below were corrected against the live Canvas API during implementation; the shipped code (`src/canvas/types.ts`) is the source of truth:
+>
+> - **`event_data` is a single object or `null`, never an array.** Canvas returns e.g. `{ "answer": "42" }` or `null` (on `page_blurred` / `page_focused`). The `Array<Record<string, unknown>>` type and the `[]` / `[{…}]` examples in the sections below are incorrect; the real type is `Record<string, unknown> | null`.
+> - **Each event has a string `id`** (e.g. `"3409"`), now included on `CanvasQuizSubmissionEvent`.
+> - **Audience:** the tool is tagged `shared` (the user story serves the submitting student), so it is exposed under student-role filtering — this was not addressed in the original design.
+
 ## Purpose
 
 Add a `get_quiz_submission_events` tool that surfaces the event timeline for a Classic Quiz submission — giving an AI assistant the raw, ordered log of behavioral events (page blurs, question answers, session transitions) so the assistant can narrate them in plain language instead of leaving the instructor (or student) to decode the Canvas UI's event list unaided.

--- a/src/canvas/quizzes.ts
+++ b/src/canvas/quizzes.ts
@@ -84,6 +84,8 @@ export class QuizzesModule {
       `/api/v1/courses/${courseId}/quizzes/${quizId}/submissions/${submissionId}/events`,
       { query },
     )
+    // Defensive: Canvas returns [] for an empty log; the guard also tolerates a
+    // null field without throwing. Real errors surface as CanvasApiError above.
     return response.quiz_submission_events ?? []
   }
 }

--- a/src/canvas/quizzes.ts
+++ b/src/canvas/quizzes.ts
@@ -1,9 +1,12 @@
 import type { CanvasHttpClient } from './client'
+import { type CanvasQueryParams } from './query'
 import type {
   CanvasQuiz,
   CanvasQuizSubmission,
   CanvasQuizQuestion,
   CanvasQuizSubmissionQuestion,
+  CanvasQuizSubmissionEvent,
+  CanvasQuizSubmissionEventsResponse,
 } from './types'
 
 export class QuizzesModule {
@@ -65,5 +68,22 @@ export class QuizzesModule {
         body: JSON.stringify(body),
       },
     )
+  }
+
+  async getSubmissionEvents(
+    courseId: number,
+    quizId: number,
+    submissionId: number,
+    attempt?: number,
+  ): Promise<CanvasQuizSubmissionEvent[]> {
+    const query: CanvasQueryParams = {}
+    if (attempt !== undefined) {
+      query.attempt = attempt
+    }
+    const response = await this.client.request<CanvasQuizSubmissionEventsResponse>(
+      `/api/v1/courses/${courseId}/quizzes/${quizId}/submissions/${submissionId}/events`,
+      { query },
+    )
+    return response.quiz_submission_events ?? []
   }
 }

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -422,12 +422,20 @@ export interface CanvasQuizSubmissionQuestion {
 // --- Quiz Submission Events ---
 
 export interface CanvasQuizSubmissionEvent {
+  // Canvas returns a stable per-event id as a string (e.g. "3409").
+  id: string
   event_type: string
   created_at: string
-  event_data: Array<Record<string, unknown>> | null
+  // Per the Canvas API, event_data is a single object of contextual key/value
+  // pairs (e.g. { answer: "42" } on question_answered) or null (e.g. on
+  // page_blurred / page_focused) — never an array. The keys vary by event_type,
+  // so the value bag is left opaque.
+  event_data: Record<string, unknown> | null
 }
 
 export interface CanvasQuizSubmissionEventsResponse {
+  // `| null` is a defensive allowance: Canvas returns an empty array for an
+  // empty log, but the client null-guards the field rather than assume it.
   quiz_submission_events: CanvasQuizSubmissionEvent[] | null
 }
 

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -419,6 +419,18 @@ export interface CanvasQuizSubmissionQuestion {
   flagged: boolean
 }
 
+// --- Quiz Submission Events ---
+
+export interface CanvasQuizSubmissionEvent {
+  event_type: string
+  created_at: string
+  event_data: Array<Record<string, unknown>> | null
+}
+
+export interface CanvasQuizSubmissionEventsResponse {
+  quiz_submission_events: CanvasQuizSubmissionEvent[] | null
+}
+
 // --- Files ---
 
 export interface CanvasFile {

--- a/src/discovery/catalog.ts
+++ b/src/discovery/catalog.ts
@@ -58,6 +58,7 @@ export const toolAudienceOverrides: Readonly<Record<string, ToolAudience>> = {
   list_quizzes: 'shared',
   get_quiz: 'shared',
   list_quiz_questions: 'shared',
+  get_quiz_submission_events: 'shared',
   list_files: 'shared',
   list_folders: 'shared',
   get_file: 'shared',

--- a/src/tools/quizzes.ts
+++ b/src/tools/quizzes.ts
@@ -127,6 +127,11 @@ export function quizTools(canvas: CanvasClient): ToolDefinition[] {
     },
     {
       name: 'get_quiz_submission_events',
+      // `shared`: the submitting student can read their own attempt's events
+      // (the #182 user story explicitly serves "a student reviewing their own
+      // attempt"), matching the `shared` audience on get_quiz / list_quizzes.
+      // Canvas still enforces real permissions server-side.
+      audience: 'shared',
       description: `Get the event log for a Classic Quiz submission in chronological order. Events include session_started, question_answered, question_flagged, page_blurred, and page_focused. Use this to understand the timeline of a student's attempt. Classic Quizzes only — New Quizzes does not expose event logs via the Canvas REST API. Events are scoped to a single submission; Canvas enforces access permissions (instructors and the submitting student only). Do not use event logs as the sole basis for academic-integrity conclusions; present them with context.`,
       inputSchema: {
         course_id: z.number().describe('The Canvas course ID'),

--- a/src/tools/quizzes.ts
+++ b/src/tools/quizzes.ts
@@ -125,5 +125,31 @@ export function quizTools(canvas: CanvasClient): ToolDefinition[] {
         return { success: true }
       },
     },
+    {
+      name: 'get_quiz_submission_events',
+      description: `Get the event log for a Classic Quiz submission in chronological order. Events include session_started, question_answered, question_flagged, page_blurred, and page_focused. Use this to understand the timeline of a student's attempt. Classic Quizzes only — New Quizzes does not expose event logs via the Canvas REST API. Events are scoped to a single submission; Canvas enforces access permissions (instructors and the submitting student only). Do not use event logs as the sole basis for academic-integrity conclusions; present them with context.`,
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        quiz_id: z.number().describe('The Canvas quiz ID (Classic Quizzes only)'),
+        submission_id: z.number().describe('The quiz submission ID'),
+        attempt: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe('Attempt number (1-based). Omit for the most recent attempt.'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const course_id = params.course_id as number
+        const quiz_id = params.quiz_id as number
+        const submission_id = params.submission_id as number
+        const attempt = params.attempt as number | undefined
+        return canvas.quizzes.getSubmissionEvents(course_id, quiz_id, submission_id, attempt)
+      },
+    },
   ]
 }

--- a/tests/canvas/quizzes.test.ts
+++ b/tests/canvas/quizzes.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { QuizzesModule } from '../../src/canvas/quizzes'
-import { CanvasHttpClient } from '../../src/canvas/client'
+import { CanvasHttpClient, CanvasApiError } from '../../src/canvas/client'
 
 describe('QuizzesModule', () => {
   let client: CanvasHttpClient
@@ -127,6 +127,61 @@ describe('QuizzesModule', () => {
           },
         ],
       }),
+    })
+  })
+
+  describe('getSubmissionEvents', () => {
+    it('returns the ordered events for a submission (no attempt)', async () => {
+      vi.spyOn(client, 'request').mockResolvedValueOnce({
+        quiz_submission_events: [
+          { event_type: 'session_started', created_at: '2026-01-01T10:00:00Z', event_data: [] },
+          {
+            event_type: 'question_answered',
+            created_at: '2026-01-01T10:01:00Z',
+            event_data: [{ quiz_question_id: '9', answer: '2' }],
+          },
+          { event_type: 'page_blurred', created_at: '2026-01-01T10:05:00Z', event_data: [] },
+        ],
+      })
+      const result = await quizzes.getSubmissionEvents(1, 2, 3)
+      expect(result).toHaveLength(3)
+      expect(result.map((e) => e.event_type)).toEqual([
+        'session_started',
+        'question_answered',
+        'page_blurred',
+      ])
+      expect(client.request).toHaveBeenCalledWith(
+        '/api/v1/courses/1/quizzes/2/submissions/3/events',
+        { query: {} },
+      )
+    })
+
+    it('passes the attempt query param when provided', async () => {
+      vi.spyOn(client, 'request').mockResolvedValueOnce({ quiz_submission_events: [] })
+      await quizzes.getSubmissionEvents(1, 2, 3, 2)
+      expect(client.request).toHaveBeenCalledWith(
+        '/api/v1/courses/1/quizzes/2/submissions/3/events',
+        { query: { attempt: 2 } },
+      )
+    })
+
+    it('returns an empty array for an empty event log', async () => {
+      vi.spyOn(client, 'request').mockResolvedValueOnce({ quiz_submission_events: [] })
+      const result = await quizzes.getSubmissionEvents(1, 2, 3)
+      expect(result).toEqual([])
+    })
+
+    it('returns an empty array when the envelope field is null', async () => {
+      vi.spyOn(client, 'request').mockResolvedValueOnce({ quiz_submission_events: null })
+      const result = await quizzes.getSubmissionEvents(1, 2, 3)
+      expect(result).toEqual([])
+    })
+
+    it('propagates Canvas API errors', async () => {
+      vi.spyOn(client, 'request').mockRejectedValueOnce(
+        new CanvasApiError('Forbidden', 403, '/api/v1/courses/1/quizzes/2/submissions/3/events'),
+      )
+      await expect(quizzes.getSubmissionEvents(1, 2, 3)).rejects.toBeInstanceOf(CanvasApiError)
     })
   })
 })

--- a/tests/canvas/quizzes.test.ts
+++ b/tests/canvas/quizzes.test.ts
@@ -132,15 +132,28 @@ describe('QuizzesModule', () => {
 
   describe('getSubmissionEvents', () => {
     it('returns the ordered events for a submission (no attempt)', async () => {
+      // Shapes mirror the real Canvas API: event_data is a single object or
+      // null (never an array), and each event carries a string id.
       vi.spyOn(client, 'request').mockResolvedValueOnce({
         quiz_submission_events: [
-          { event_type: 'session_started', created_at: '2026-01-01T10:00:00Z', event_data: [] },
           {
+            id: '100',
+            event_type: 'session_started',
+            created_at: '2026-01-01T10:00:00Z',
+            event_data: { user_agent: 'Mozilla/5.0' },
+          },
+          {
+            id: '101',
             event_type: 'question_answered',
             created_at: '2026-01-01T10:01:00Z',
-            event_data: [{ quiz_question_id: '9', answer: '2' }],
+            event_data: { quiz_question_id: '9', answer: '2' },
           },
-          { event_type: 'page_blurred', created_at: '2026-01-01T10:05:00Z', event_data: [] },
+          {
+            id: '102',
+            event_type: 'page_blurred',
+            created_at: '2026-01-01T10:05:00Z',
+            event_data: null,
+          },
         ],
       })
       const result = await quizzes.getSubmissionEvents(1, 2, 3)
@@ -150,10 +163,35 @@ describe('QuizzesModule', () => {
         'question_answered',
         'page_blurred',
       ])
+      // The null-per-event event_data round-trips unchanged (no transform).
+      expect(result[2].event_data).toBeNull()
       expect(client.request).toHaveBeenCalledWith(
         '/api/v1/courses/1/quizzes/2/submissions/3/events',
         { query: {} },
       )
+    })
+
+    it('carries no student identity fields in the event payload', async () => {
+      // Pins the no-pseudonymizer-wrap assumption: the events envelope exposes
+      // no name / email / login_id / user_name (envelope or event_data keys).
+      vi.spyOn(client, 'request').mockResolvedValueOnce({
+        quiz_submission_events: [
+          {
+            id: '200',
+            event_type: 'question_answered',
+            created_at: '2026-01-01T10:01:00Z',
+            event_data: { quiz_question_id: '9', answer: '2' },
+          },
+        ],
+      })
+      const result = await quizzes.getSubmissionEvents(1, 2, 3)
+      const identityKeys = ['name', 'email', 'login_id', 'user_name', 'sis_user_id']
+      for (const event of result) {
+        for (const key of identityKeys) {
+          expect(event).not.toHaveProperty(key)
+          expect(event.event_data ?? {}).not.toHaveProperty(key)
+        }
+      }
     })
 
     it('passes the attempt query param when provided', async () => {

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(124)
+    expect(manifest.tools).toHaveLength(125)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/pseudonym/coverage.test.ts
+++ b/tests/pseudonym/coverage.test.ts
@@ -51,6 +51,7 @@ function buildMinimalCanvas(): CanvasClient {
       listQuestions: list,
       getSubmissionAnswers: list,
       scoreQuestion: noop,
+      getSubmissionEvents: list,
     },
     files: { list, listFolders: list, get: noop, upload: noop, delete: noop, download: noop },
     gradebookHistory: { listDays: list, getDay: list, listSubmissions: list, getFeed: list },

--- a/tests/tools/quizzes.test.ts
+++ b/tests/tools/quizzes.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi } from 'vitest'
 import type { CanvasClient } from '../../src/canvas'
+import { CanvasApiError } from '../../src/canvas/client'
+import { formatError } from '../../src/tools/errors'
 import type {
   CanvasQuiz,
   CanvasQuizSubmission,
   CanvasQuizQuestion,
   CanvasQuizSubmissionQuestion,
+  CanvasQuizSubmissionEvent,
 } from '../../src/canvas/types'
 import { quizTools } from '../../src/tools/quizzes'
 
@@ -51,6 +54,15 @@ describe('quizTools', () => {
     correct: true,
   }
 
+  const mockEvents: CanvasQuizSubmissionEvent[] = [
+    { event_type: 'session_started', created_at: '2026-01-01T10:00:00Z', event_data: [] },
+    {
+      event_type: 'question_answered',
+      created_at: '2026-01-01T10:01:00Z',
+      event_data: [{ quiz_question_id: '9', answer: '2' }],
+    },
+  ]
+
   function buildMockCanvas(): CanvasClient {
     return {
       quizzes: {
@@ -60,12 +72,13 @@ describe('quizTools', () => {
         listQuestions: vi.fn().mockResolvedValue([mockQuestion]),
         getSubmissionAnswers: vi.fn().mockResolvedValue([mockSubQuestion]),
         scoreQuestion: vi.fn().mockResolvedValue(undefined),
+        getSubmissionEvents: vi.fn().mockResolvedValue([]),
       },
     } as unknown as CanvasClient
   }
 
-  it('returns an array with 6 tool definitions', () => {
-    expect(quizTools(buildMockCanvas())).toHaveLength(6)
+  it('returns an array with 7 tool definitions', () => {
+    expect(quizTools(buildMockCanvas())).toHaveLength(7)
   })
 
   it('exports tools with correct names', () => {
@@ -77,6 +90,7 @@ describe('quizTools', () => {
       'list_quiz_questions',
       'get_quiz_submission_answers',
       'score_quiz_question',
+      'get_quiz_submission_events',
     ])
   })
 
@@ -211,6 +225,66 @@ describe('quizTools', () => {
         attempt: 2,
       })
       expect(canvas.quizzes.scoreQuestion).toHaveBeenCalledWith(1, 1, 1, 1, 10, undefined, 2)
+    })
+  })
+
+  describe('get_quiz_submission_events', () => {
+    it('has read-only annotations', () => {
+      const tool = quizTools(buildMockCanvas()).find(
+        (t) => t.name === 'get_quiz_submission_events',
+      )!
+      expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+    })
+
+    it('returns the events from canvas.quizzes.getSubmissionEvents', async () => {
+      const canvas = buildMockCanvas()
+      vi.mocked(canvas.quizzes.getSubmissionEvents).mockResolvedValue(mockEvents)
+      const tool = quizTools(canvas).find((t) => t.name === 'get_quiz_submission_events')!
+      const result = await tool.handler({ course_id: 1, quiz_id: 2, submission_id: 3 })
+      expect(result).toEqual(mockEvents)
+    })
+
+    it('delegates to getSubmissionEvents with the attempt parameter', async () => {
+      const canvas = buildMockCanvas()
+      const tool = quizTools(canvas).find((t) => t.name === 'get_quiz_submission_events')!
+      await tool.handler({ course_id: 1, quiz_id: 2, submission_id: 3, attempt: 1 })
+      expect(canvas.quizzes.getSubmissionEvents).toHaveBeenCalledWith(1, 2, 3, 1)
+    })
+
+    it('delegates with attempt undefined when omitted', async () => {
+      const canvas = buildMockCanvas()
+      const tool = quizTools(canvas).find((t) => t.name === 'get_quiz_submission_events')!
+      await tool.handler({ course_id: 1, quiz_id: 2, submission_id: 3 })
+      expect(canvas.quizzes.getSubmissionEvents).toHaveBeenCalledWith(1, 2, 3, undefined)
+    })
+
+    it('maps a 403 Canvas error to the permission message', async () => {
+      const canvas = buildMockCanvas()
+      vi.mocked(canvas.quizzes.getSubmissionEvents).mockRejectedValue(
+        new CanvasApiError('Forbidden', 403, '/events'),
+      )
+      const tool = quizTools(canvas).find((t) => t.name === 'get_quiz_submission_events')!
+      await expect(
+        tool.handler({ course_id: 1, quiz_id: 2, submission_id: 3 }),
+      ).rejects.toBeInstanceOf(CanvasApiError)
+      // formatError (applied by the registry handler wrapper) maps the status:
+      expect(formatError(new CanvasApiError('Forbidden', 403, '/events'))).toBe(
+        "You don't have permission to perform this action in this course",
+      )
+    })
+
+    it('maps a 404 Canvas error to the not-found message', async () => {
+      expect(formatError(new CanvasApiError('Not Found', 404, '/events'))).toBe(
+        'Course/assignment/submission not found — check the ID',
+      )
+    })
+
+    it('returns an empty array for an empty event log', async () => {
+      const canvas = buildMockCanvas()
+      vi.mocked(canvas.quizzes.getSubmissionEvents).mockResolvedValue([])
+      const tool = quizTools(canvas).find((t) => t.name === 'get_quiz_submission_events')!
+      const result = await tool.handler({ course_id: 1, quiz_id: 2, submission_id: 3 })
+      expect(result).toEqual([])
     })
   })
 })

--- a/tests/tools/quizzes.test.ts
+++ b/tests/tools/quizzes.test.ts
@@ -55,11 +55,17 @@ describe('quizTools', () => {
   }
 
   const mockEvents: CanvasQuizSubmissionEvent[] = [
-    { event_type: 'session_started', created_at: '2026-01-01T10:00:00Z', event_data: [] },
     {
+      id: '100',
+      event_type: 'session_started',
+      created_at: '2026-01-01T10:00:00Z',
+      event_data: null,
+    },
+    {
+      id: '101',
       event_type: 'question_answered',
       created_at: '2026-01-01T10:01:00Z',
-      event_data: [{ quiz_question_id: '9', answer: '2' }],
+      event_data: { quiz_question_id: '9', answer: '2' },
     },
   ]
 

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -390,6 +390,15 @@ describe('getAllTools', () => {
     }
   })
 
+  it('exposes get_quiz_submission_events to the student role (shared audience)', () => {
+    // The #182 user story serves "a student reviewing their own attempt", so the
+    // tool is tagged `shared` and must survive student-role filtering.
+    const studentTools = getAllTools(buildFullMockCanvas(), undefined, 'student').map((t) => t.name)
+    expect(studentTools).toContain('get_quiz_submission_events')
+    const teacherTools = getAllTools(buildFullMockCanvas(), undefined, 'teacher').map((t) => t.name)
+    expect(teacherTools).toContain('get_quiz_submission_events')
+  })
+
   it('read tools have readOnlyHint: true', () => {
     const writeToolNames = new Set([
       'create_assignment',

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -42,6 +42,7 @@ function buildFullMockCanvas(): CanvasClient {
       listQuestions: async () => [],
       getSubmissionAnswers: async () => [],
       scoreQuestion: async () => {},
+      getSubmissionEvents: async () => [],
     },
     files: {
       list: async () => [],
@@ -178,7 +179,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 124 tools across all domains', () => {
+  it('returns all 125 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 
@@ -208,13 +209,14 @@ describe('getAllTools', () => {
     expect(names).toContain('get_rubric_assessment')
     expect(names).toContain('submit_rubric_assessment')
     expect(names).toContain('create_rubric')
-    // Quizzes (6)
+    // Quizzes (7)
     expect(names).toContain('list_quizzes')
     expect(names).toContain('get_quiz')
     expect(names).toContain('list_quiz_submissions')
     expect(names).toContain('list_quiz_questions')
     expect(names).toContain('get_quiz_submission_answers')
     expect(names).toContain('score_quiz_question')
+    expect(names).toContain('get_quiz_submission_events')
     // Files (6)
     expect(names).toContain('list_files')
     expect(names).toContain('list_folders')
@@ -332,7 +334,7 @@ describe('getAllTools', () => {
     expect(names).toContain('get_content_export')
     expect(names).toContain('list_content_exports')
 
-    expect(tools).toHaveLength(124)
+    expect(tools).toHaveLength(125)
   })
 
   it('all tools have openWorldHint: true', () => {


### PR DESCRIPTION
## Summary

Implements the merged design spec for #182 (`docs/superpowers/specs/2026-06-14-issue-182-quiz-submission-event-logs.md`).

> **User story:** As an instructor (or a student reviewing their own attempt) using an AI assistant connected to Canvas, I want to pull a quiz submission''s event log and have it explained in plain language — so I can understand what "navigated away" / page-blur / answer-change events actually mean before drawing conclusions in an academic-integrity conversation.

Adds a single read-only tool, `get_quiz_submission_events`, that surfaces the chronological event timeline for a **Classic Quiz** submission so a model can narrate it.

## Approach

- **New tool** `get_quiz_submission_events(course_id, quiz_id, submission_id, attempt?)` → `GET /api/v1/courses/:course_id/quizzes/:quiz_id/submissions/:submission_id/events`, with an optional `attempt` query param (defaults to the latest attempt).
- **Canvas client**: new `QuizzesModule.getSubmissionEvents()` method; non-paginated `client.request()` with a `{ query }` option. Returns the array extracted from the `quiz_submission_events` envelope, with a `?? []` guard for the `null` envelope case.
- **Types**: `CanvasQuizSubmissionEvent` (`event_type: string`, open-ended to absorb future Canvas event types) and `CanvasQuizSubmissionEventsResponse` (`| null` envelope).
- **Classic Quizzes only** — New Quizzes does not expose an equivalent REST endpoint; the tool description states this. A New Quizzes ID yields a Canvas 404, handled by the existing generic mapping.
- **No pseudonymizer wrapping** (per design unknown §2): the events envelope carries no `CanvasUser` / `participants` / `user_name`. `PSEUDONYMIZER_WRAPPED_TOOLS` is intentionally unchanged; the FERPA usage guidance lives in the tool description (neutral framing, not a "cheating detector").

## Deviations from the spec

- The spec''s test plan did not call out the **tool-count gates**, but adding a tool requires them: bumped `124 → 125` in `tests/tools/registry.test.ts` and `tests/discovery/manifests.test.ts`, added the new name + `getSubmissionEvents` stub in the registry full mock, and regenerated `docs/generated/tool-manifest.json` via `pnpm generate:manifests`.
- The tool description is a single-line string (the spec wrapped it across lines for readability); semantic content is identical and avoids embedding newlines in the generated manifest.

## Test evidence

TDD: tests written first (red), then implementation (green). Added client tests (happy path, attempt param, empty log, null envelope, error propagation) and tool tests (annotations, delegation with/without attempt, 403/404 error mapping, empty log).

```
pnpm typecheck   ✓ (tsc --noEmit, exit 0)
pnpm lint        ✓ (eslint + prettier, exit 0)
pnpm test        ✓ 82 files | 1056 passed | 1 skipped
pnpm build       ✓ Build success
```

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)
