### PR TITLE
feat(discussions): expose is_announcement and delayed_post_at params

### DIFF
--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -625,6 +625,8 @@ export interface CreateDiscussionParams {
   discussion_type?: 'side_comment' | 'threaded'
   published?: boolean
   require_initial_post?: boolean
+  is_announcement?: boolean
+  delayed_post_at?: string
 }
 
 export interface UpdateDiscussionParams {
@@ -632,6 +634,8 @@ export interface UpdateDiscussionParams {
   message?: string
   published?: boolean
   require_initial_post?: boolean
+  is_announcement?: boolean
+  delayed_post_at?: string
 }
 
 // --- Calendar ---

--- a/src/tools/discussions.ts
+++ b/src/tools/discussions.ts
@@ -87,6 +87,15 @@ export function discussionTools(canvas: CanvasClient): ToolDefinition[] {
           .boolean()
           .optional()
           .describe('Require students to post before seeing replies'),
+        is_announcement: z
+          .boolean()
+          .optional()
+          .describe('When true, creates an announcement instead of a discussion topic'),
+        delayed_post_at: z
+          .string()
+          .datetime()
+          .optional()
+          .describe('ISO 8601 datetime to schedule the topic for future posting'),
       },
       annotations: {
         destructiveHint: true,
@@ -100,6 +109,8 @@ export function discussionTools(canvas: CanvasClient): ToolDefinition[] {
           discussion_type: params.discussion_type as 'side_comment' | 'threaded' | undefined,
           published: params.published as boolean | undefined,
           require_initial_post: params.require_initial_post as boolean | undefined,
+          is_announcement: params.is_announcement as boolean | undefined,
+          delayed_post_at: params.delayed_post_at as string | undefined,
         })
       },
     },
@@ -117,6 +128,15 @@ export function discussionTools(canvas: CanvasClient): ToolDefinition[] {
           .boolean()
           .optional()
           .describe('Require students to post before seeing replies'),
+        is_announcement: z
+          .boolean()
+          .optional()
+          .describe('When true, marks the topic as an announcement'),
+        delayed_post_at: z
+          .string()
+          .datetime()
+          .optional()
+          .describe('ISO 8601 datetime to schedule the topic for future posting'),
       },
       annotations: {
         destructiveHint: true,
@@ -130,6 +150,8 @@ export function discussionTools(canvas: CanvasClient): ToolDefinition[] {
           message: params.message as string | undefined,
           published: params.published as boolean | undefined,
           require_initial_post: params.require_initial_post as boolean | undefined,
+          is_announcement: params.is_announcement as boolean | undefined,
+          delayed_post_at: params.delayed_post_at as string | undefined,
         }
         if (Object.values(updateParams).every((v) => v === undefined)) {
           throw new Error('At least one field must be provided to update a discussion topic')

--- a/tests/tools/discussions.test.ts
+++ b/tests/tools/discussions.test.ts
@@ -139,6 +139,8 @@ describe('discussionTools', () => {
         discussion_type: undefined,
         published: undefined,
         require_initial_post: undefined,
+        is_announcement: undefined,
+        delayed_post_at: undefined,
       })
     })
 
@@ -159,6 +161,28 @@ describe('discussionTools', () => {
         discussion_type: 'threaded',
         published: true,
         require_initial_post: true,
+        is_announcement: undefined,
+        delayed_post_at: undefined,
+      })
+    })
+
+    it('forwards is_announcement and delayed_post_at to canvas.discussions.create', async () => {
+      const canvas = buildMockCanvas()
+      const tool = discussionTools(canvas).find((t) => t.name === 'create_discussion')!
+      await tool.handler({
+        course_id: 1,
+        title: 'Course Update',
+        is_announcement: true,
+        delayed_post_at: '2026-09-01T08:00:00.000Z',
+      })
+      expect(canvas.discussions.create).toHaveBeenCalledWith(1, {
+        title: 'Course Update',
+        message: undefined,
+        discussion_type: undefined,
+        published: undefined,
+        require_initial_post: undefined,
+        is_announcement: true,
+        delayed_post_at: '2026-09-01T08:00:00.000Z',
       })
     })
   })
@@ -178,6 +202,27 @@ describe('discussionTools', () => {
         message: undefined,
         published: false,
         require_initial_post: undefined,
+        is_announcement: undefined,
+        delayed_post_at: undefined,
+      })
+    })
+
+    it('forwards is_announcement and delayed_post_at to canvas.discussions.update', async () => {
+      const canvas = buildMockCanvas()
+      const tool = discussionTools(canvas).find((t) => t.name === 'update_discussion')!
+      await tool.handler({
+        course_id: 1,
+        topic_id: 2,
+        is_announcement: true,
+        delayed_post_at: '2026-10-15T09:00:00.000Z',
+      })
+      expect(canvas.discussions.update).toHaveBeenCalledWith(1, 2, {
+        title: undefined,
+        message: undefined,
+        published: undefined,
+        require_initial_post: undefined,
+        is_announcement: true,
+        delayed_post_at: '2026-10-15T09:00:00.000Z',
       })
     })
   })


### PR DESCRIPTION
## Summary

- Adds `is_announcement` (boolean) and `delayed_post_at` (ISO 8601 datetime) optional params to `create_discussion` and `update_discussion` tools
- Updates `CreateDiscussionParams` and `UpdateDiscussionParams` interfaces in `src/canvas/types.ts`
- No change to `src/canvas/discussions.ts` — the create/update methods already pass params straight through to Canvas
- Adds test cases asserting both new params appear in request body for create and update

Closes #194

## Test plan
- [ ] `pnpm typecheck` — passes
- [ ] `pnpm test` — 1060 tests pass, 1 skipped
- [ ] `pnpm lint` — clean
- [ ] `pnpm build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)