### PR TITLE
feat(grading-standards): list, create, and apply course grading standards

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 125,
+  "toolCount": 128,
   "tools": [
     {
       "name": "health_check",
@@ -1540,6 +1540,42 @@
         "openWorldHint": true
       },
       "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_grading_standards",
+      "domain": "grading_standards",
+      "description": "List grading standards available in a course or account context. Provide either course_id (to see standards scoped to a course) or account_id (to see account-level standards, requires admin access). Returns an array of grading standard objects, each with an id, title, context, and grading_scheme array of { name, value } entries.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "create_grading_standard",
+      "domain": "grading_standards",
+      "description": "Create a new grading standard (letter-to-percentage scheme) in a course or account context. Provide either course_id or account_id (account requires admin). scheme_entries is an array of { name, value } objects where value is the lower-bound percentage as a fraction 0–1 (e.g. { name: \"A\", value: 0.94 } means A ≥ 94%). Entries will be sorted descending by value before sending to Canvas. Canvas POST body key is grading_scheme_entry (singular); the returned object uses grading_scheme (plural). Returns the created grading standard object including its id — use that id with apply_grading_standard_to_course to activate it on a course.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "apply_grading_standard_to_course",
+      "domain": "grading_standards",
+      "description": "Apply an existing grading standard to a course so the gradebook uses it. Pass the grading_standard_id returned by create_grading_standard or list_grading_standards. Pass null for grading_standard_id to remove the current grading standard from the course. Returns the updated course object.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
       "primaryAudience": "educator",
       "relatedWorkflows": []
     }

--- a/src/canvas/grading-standards.ts
+++ b/src/canvas/grading-standards.ts
@@ -1,0 +1,56 @@
+import type { CanvasHttpClient } from './client'
+import type { CanvasGradingSchemeEntry, CanvasGradingStandard } from './types'
+
+/**
+ * Canvas grading standards (letter-to-percentage grading schemes).
+ *
+ * Canvas API asymmetry: the GET/response key is `grading_scheme` (plural),
+ * while the POST body key is `grading_scheme_entry` (singular). The POST body
+ * is flat — there is no `grading_standard:` wrapper. List endpoints return a
+ * plain JSON array, so we use `client.paginate` (not `paginateEnvelope`).
+ */
+export class GradingStandardsModule {
+  constructor(private client: CanvasHttpClient) {}
+
+  async listForCourse(courseId: number): Promise<CanvasGradingStandard[]> {
+    return this.client.paginate<CanvasGradingStandard>(
+      `/api/v1/courses/${courseId}/grading_standards`,
+    )
+  }
+
+  async listForAccount(accountId: number): Promise<CanvasGradingStandard[]> {
+    return this.client.paginate<CanvasGradingStandard>(
+      `/api/v1/accounts/${accountId}/grading_standards`,
+    )
+  }
+
+  async createForCourse(
+    courseId: number,
+    title: string,
+    schemeEntries: CanvasGradingSchemeEntry[],
+  ): Promise<CanvasGradingStandard> {
+    const sorted = [...schemeEntries].sort((a, b) => b.value - a.value)
+    return this.client.request<CanvasGradingStandard>(
+      `/api/v1/courses/${courseId}/grading_standards`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ title, grading_scheme_entry: sorted }),
+      },
+    )
+  }
+
+  async createForAccount(
+    accountId: number,
+    title: string,
+    schemeEntries: CanvasGradingSchemeEntry[],
+  ): Promise<CanvasGradingStandard> {
+    const sorted = [...schemeEntries].sort((a, b) => b.value - a.value)
+    return this.client.request<CanvasGradingStandard>(
+      `/api/v1/accounts/${accountId}/grading_standards`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ title, grading_scheme_entry: sorted }),
+      },
+    )
+  }
+}

--- a/src/canvas/index.ts
+++ b/src/canvas/index.ts
@@ -22,6 +22,7 @@ import { OutcomesModule } from './outcomes'
 import { GradebookHistoryModule } from './gradebook-history'
 import { NewQuizzesModule } from './new-quizzes'
 import { ContentExportsModule } from './content-exports'
+import { GradingStandardsModule } from './grading-standards'
 
 /**
  * Standalone Canvas REST API client. Composed of modular per-domain classes
@@ -59,6 +60,7 @@ export class CanvasClient {
   gradebookHistory: GradebookHistoryModule
   newQuizzes: NewQuizzesModule
   contentExports: ContentExportsModule
+  gradingStandards: GradingStandardsModule
 
   constructor(config: CanvasClientConfig) {
     this.client = new CanvasHttpClient(config)
@@ -84,6 +86,7 @@ export class CanvasClient {
     this.gradebookHistory = new GradebookHistoryModule(this.client)
     this.newQuizzes = new NewQuizzesModule(this.client)
     this.contentExports = new ContentExportsModule(this.client)
+    this.gradingStandards = new GradingStandardsModule(this.client)
   }
 }
 

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -68,6 +68,7 @@ export interface CanvasCourse {
   banner_image_download_url?: string | null
   concluded?: boolean
   post_manually?: boolean
+  grading_standard_id?: number | null
 }
 
 export interface CanvasCourseSection {
@@ -150,6 +151,7 @@ export interface UpdateCourseParams {
   end_at?: string
   default_view?: 'feed' | 'wiki' | 'modules' | 'assignments' | 'syllabus'
   syllabus_body?: string
+  grading_standard_id?: number | null
 }
 
 // --- Assignments ---
@@ -847,6 +849,23 @@ export interface CanvasAccountReport {
     ended_at: string | null
     attachment: CanvasFile | null
   } | null
+}
+
+// --- Grading Standards ---
+
+export interface CanvasGradingSchemeEntry {
+  name: string
+  value: number
+}
+
+export type CanvasGradingStandardContextType = 'Course' | 'Account'
+
+export interface CanvasGradingStandard {
+  id: number
+  title: string
+  context_type: CanvasGradingStandardContextType
+  context_id: number
+  grading_scheme: CanvasGradingSchemeEntry[]
 }
 
 // --- Assignments (params) ---

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -13,6 +13,7 @@ import { discussionTools } from './discussions'
 import { enrollmentTools } from './enrollments'
 import { fileTools } from './files'
 import { gradebookHistoryTools } from './gradebook-history'
+import { gradingStandardsTools } from './grading-standards'
 import { groupTools } from './groups'
 import { healthTools } from './health'
 import { moduleTools } from './modules'
@@ -158,5 +159,10 @@ export const toolDomainCatalog: readonly ToolDomainRegistration[] = [
     domain: 'content_exports',
     defaultPrimaryAudience: 'educator',
     getTools: contentExportsTools,
+  },
+  {
+    domain: 'grading_standards',
+    defaultPrimaryAudience: 'educator',
+    getTools: gradingStandardsTools,
   },
 ]

--- a/src/tools/grading-standards.ts
+++ b/src/tools/grading-standards.ts
@@ -1,0 +1,154 @@
+import { z } from 'zod'
+import type { CanvasClient } from '../canvas'
+import { CanvasApiError } from '../canvas/client'
+import type { ToolDefinition } from './types'
+
+const schemeEntrySchema = z.object({
+  name: z.string().min(1).describe('Letter grade name (e.g. "A", "B+", "F")'),
+  value: z
+    .number()
+    .min(0)
+    .max(1)
+    .describe(
+      'Lower-bound threshold as a fraction 0–1 (e.g. 0.94 means this grade starts at 94%). ' +
+        "Canvas computes the upper bound as the next higher grade's value.",
+    ),
+})
+
+export function gradingStandardsTools(canvas: CanvasClient): ToolDefinition[] {
+  return [
+    {
+      name: 'list_grading_standards',
+      description:
+        'List grading standards available in a course or account context. ' +
+        'Provide either course_id (to see standards scoped to a course) or account_id ' +
+        '(to see account-level standards, requires admin access). ' +
+        'Returns an array of grading standard objects, each with an id, title, context, ' +
+        'and grading_scheme array of { name, value } entries.',
+      inputSchema: {
+        course_id: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe('Course ID to list standards for (mutually exclusive with account_id)'),
+        account_id: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe(
+            'Account ID to list standards for (mutually exclusive with course_id; requires admin)',
+          ),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const courseId = params.course_id as number | undefined
+        const accountId = params.account_id as number | undefined
+        if (courseId !== undefined) {
+          return canvas.gradingStandards.listForCourse(courseId)
+        }
+        if (accountId !== undefined) {
+          return canvas.gradingStandards.listForAccount(accountId)
+        }
+        throw new Error('Provide either course_id or account_id.')
+      },
+    },
+    {
+      name: 'create_grading_standard',
+      description:
+        'Create a new grading standard (letter-to-percentage scheme) in a course or account context. ' +
+        'Provide either course_id or account_id (account requires admin). ' +
+        'scheme_entries is an array of { name, value } objects where value is the lower-bound ' +
+        'percentage as a fraction 0–1 (e.g. { name: "A", value: 0.94 } means A ≥ 94%). ' +
+        'Entries will be sorted descending by value before sending to Canvas. ' +
+        'Canvas POST body key is grading_scheme_entry (singular); the returned object uses grading_scheme (plural). ' +
+        'Returns the created grading standard object including its id — use that id with ' +
+        'apply_grading_standard_to_course to activate it on a course.',
+      inputSchema: {
+        course_id: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe('Course ID to create the standard in (mutually exclusive with account_id)'),
+        account_id: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe(
+            'Account ID to create the standard in (requires admin; mutually exclusive with course_id)',
+          ),
+        title: z
+          .string()
+          .min(1)
+          .describe('Display name for this grading standard (e.g. "GPA 4.0 Scale")'),
+        scheme_entries: z
+          .array(schemeEntrySchema)
+          .min(1)
+          .describe(
+            'Grading scheme entries. Each entry: { name: string, value: number (0–1) }. ' +
+              'The lowest grade should have value 0.0.',
+          ),
+      },
+      annotations: {
+        destructiveHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const courseId = params.course_id as number | undefined
+        const accountId = params.account_id as number | undefined
+        const title = params.title as string
+        const schemeEntries = params.scheme_entries as Array<{ name: string; value: number }>
+        try {
+          if (courseId !== undefined) {
+            return await canvas.gradingStandards.createForCourse(courseId, title, schemeEntries)
+          }
+          if (accountId !== undefined) {
+            return await canvas.gradingStandards.createForAccount(accountId, title, schemeEntries)
+          }
+          throw new Error('Provide either course_id or account_id.')
+        } catch (error) {
+          if (error instanceof CanvasApiError && error.status === 403 && accountId !== undefined) {
+            throw new Error(
+              'Creating grading standards at the account level requires Canvas admin permissions. ' +
+                'Try creating the standard in a course context instead (use course_id).',
+              { cause: error },
+            )
+          }
+          throw error
+        }
+      },
+    },
+    {
+      name: 'apply_grading_standard_to_course',
+      description:
+        'Apply an existing grading standard to a course so the gradebook uses it. ' +
+        'Pass the grading_standard_id returned by create_grading_standard or list_grading_standards. ' +
+        'Pass null for grading_standard_id to remove the current grading standard from the course. ' +
+        'Returns the updated course object.',
+      inputSchema: {
+        course_id: z.number().int().positive().describe('The Canvas course ID to update'),
+        grading_standard_id: z
+          .number()
+          .int()
+          .positive()
+          .nullable()
+          .describe('The grading standard ID to apply, or null to remove the current standard'),
+      },
+      annotations: {
+        destructiveHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+        const gradingStandardId = params.grading_standard_id as number | null
+        return canvas.courses.update(courseId, { grading_standard_id: gradingStandardId })
+      },
+    },
+  ]
+}

--- a/src/tools/grading-standards.ts
+++ b/src/tools/grading-standards.ts
@@ -119,14 +119,17 @@ export function gradingStandardsTools(canvas: CanvasClient): ToolDefinition[] {
           }
           throw new Error('Provide either course_id or account_id.')
         } catch (error) {
-          // Only re-wrap a 403 from a true account-only call. The mutual-exclusivity
-          // guard above guarantees course_id is unset here, so a course-context 403
-          // (which routes through createForCourse) keeps its own formatError message.
+          // Only re-wrap a permissions 403 from a true account-only call. The
+          // mutual-exclusivity guard above guarantees course_id is unset here, so a
+          // course-context 403 (which routes through createForCourse) keeps its own
+          // formatError message. Exclude rate-limit 403s ("Rate Limit Exceeded"),
+          // which formatError surfaces with its own "wait and retry" guidance.
           if (
             error instanceof CanvasApiError &&
             error.status === 403 &&
             courseId === undefined &&
-            accountId !== undefined
+            accountId !== undefined &&
+            !error.message.toLowerCase().includes('rate limit exceeded')
           ) {
             throw new Error(
               'Creating grading standards at the account level requires Canvas admin permissions. ' +

--- a/src/tools/grading-standards.ts
+++ b/src/tools/grading-standards.ts
@@ -48,6 +48,9 @@ export function gradingStandardsTools(canvas: CanvasClient): ToolDefinition[] {
       handler: async (params) => {
         const courseId = params.course_id as number | undefined
         const accountId = params.account_id as number | undefined
+        if (courseId !== undefined && accountId !== undefined) {
+          throw new Error('Provide either course_id or account_id, not both.')
+        }
         if (courseId !== undefined) {
           return canvas.gradingStandards.listForCourse(courseId)
         }
@@ -104,6 +107,9 @@ export function gradingStandardsTools(canvas: CanvasClient): ToolDefinition[] {
         const accountId = params.account_id as number | undefined
         const title = params.title as string
         const schemeEntries = params.scheme_entries as Array<{ name: string; value: number }>
+        if (courseId !== undefined && accountId !== undefined) {
+          throw new Error('Provide either course_id or account_id, not both.')
+        }
         try {
           if (courseId !== undefined) {
             return await canvas.gradingStandards.createForCourse(courseId, title, schemeEntries)
@@ -113,7 +119,15 @@ export function gradingStandardsTools(canvas: CanvasClient): ToolDefinition[] {
           }
           throw new Error('Provide either course_id or account_id.')
         } catch (error) {
-          if (error instanceof CanvasApiError && error.status === 403 && accountId !== undefined) {
+          // Only re-wrap a 403 from a true account-only call. The mutual-exclusivity
+          // guard above guarantees course_id is unset here, so a course-context 403
+          // (which routes through createForCourse) keeps its own formatError message.
+          if (
+            error instanceof CanvasApiError &&
+            error.status === 403 &&
+            courseId === undefined &&
+            accountId !== undefined
+          ) {
             throw new Error(
               'Creating grading standards at the account level requires Canvas admin permissions. ' +
                 'Try creating the standard in a course context instead (use course_id).',

--- a/tests/canvas/facade.test.ts
+++ b/tests/canvas/facade.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { CanvasClient, CanvasHttpClient, CanvasApiError } from '../../src/canvas/index'
 import { CoursesModule } from '../../src/canvas/courses'
 import { GradebookHistoryModule } from '../../src/canvas/gradebook-history'
+import { GradingStandardsModule } from '../../src/canvas/grading-standards'
 import { UsersModule } from '../../src/canvas/users'
 
 describe('CanvasClient facade', () => {
@@ -21,6 +22,15 @@ describe('CanvasClient facade', () => {
     })
 
     expect(client.gradebookHistory).toBeInstanceOf(GradebookHistoryModule)
+  })
+
+  it('creates a CanvasClient with gradingStandards module', () => {
+    const client = new CanvasClient({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+    })
+
+    expect(client.gradingStandards).toBeInstanceOf(GradingStandardsModule)
   })
 
   it('re-exports CanvasHttpClient', () => {

--- a/tests/canvas/grading-standards.test.ts
+++ b/tests/canvas/grading-standards.test.ts
@@ -102,12 +102,30 @@ describe('GradingStandardsModule', () => {
     ])
   })
 
-  it('createForAccount posts to the account endpoint', async () => {
+  it('createForAccount posts to the account endpoint with the singular key, without mutating input', async () => {
     const requestSpy = vi.spyOn(client, 'request').mockResolvedValueOnce(mockStandard)
-    await module.createForAccount(1, 'GPA 4.0 Scale', schemeEntries)
+    const input = [
+      { name: 'F', value: 0.0 },
+      { name: 'A', value: 0.94 },
+      { name: 'B', value: 0.84 },
+    ]
+    await module.createForAccount(1, 'GPA 4.0 Scale', input)
     const [endpoint, options] = requestSpy.mock.calls[0]
     expect(endpoint).toBe('/api/v1/accounts/1/grading_standards')
     expect(options?.method).toBe('POST')
+    const body = JSON.parse(options?.body as string)
+    expect(body.grading_scheme).toBeUndefined()
+    expect(body.grading_scheme_entry).toEqual([
+      { name: 'A', value: 0.94 },
+      { name: 'B', value: 0.84 },
+      { name: 'F', value: 0.0 },
+    ])
+    // input array order is preserved (sort operates on a copy)
+    expect(input).toEqual([
+      { name: 'F', value: 0.0 },
+      { name: 'A', value: 0.94 },
+      { name: 'B', value: 0.84 },
+    ])
   })
 
   it('propagates CanvasApiError from createForAccount (no client-layer catch)', async () => {

--- a/tests/canvas/grading-standards.test.ts
+++ b/tests/canvas/grading-standards.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GradingStandardsModule } from '../../src/canvas/grading-standards'
+import { CanvasHttpClient, CanvasApiError } from '../../src/canvas/client'
+
+const mockStandard = {
+  id: 42,
+  title: 'GPA 4.0 Scale',
+  context_type: 'Course' as const,
+  context_id: 100,
+  grading_scheme: [
+    { name: 'A', value: 0.94 },
+    { name: 'B', value: 0.84 },
+    { name: 'F', value: 0.0 },
+  ],
+}
+
+const schemeEntries = [
+  { name: 'A', value: 0.94 },
+  { name: 'B', value: 0.84 },
+  { name: 'F', value: 0.0 },
+]
+
+describe('GradingStandardsModule', () => {
+  let client: CanvasHttpClient
+  let module: GradingStandardsModule
+
+  beforeEach(() => {
+    client = new CanvasHttpClient({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+    })
+    module = new GradingStandardsModule(client)
+  })
+
+  it('listForCourse returns standards and hits the course endpoint', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([mockStandard])
+    const result = await module.listForCourse(100)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ id: 42, title: 'GPA 4.0 Scale' })
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/100/grading_standards')
+  })
+
+  it('listForCourse returns an empty array when there are no standards', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+    const result = await module.listForCourse(100)
+    expect(result).toEqual([])
+  })
+
+  it('listForAccount hits the account endpoint', async () => {
+    vi.spyOn(client, 'paginate').mockResolvedValueOnce([mockStandard])
+    const result = await module.listForAccount(1)
+    expect(result).toHaveLength(1)
+    expect(client.paginate).toHaveBeenCalledWith('/api/v1/accounts/1/grading_standards')
+  })
+
+  it('createForCourse posts with the singular grading_scheme_entry key', async () => {
+    const requestSpy = vi.spyOn(client, 'request').mockResolvedValueOnce(mockStandard)
+    const result = await module.createForCourse(100, 'GPA 4.0 Scale', schemeEntries)
+    expect(result).toEqual(mockStandard)
+
+    const [endpoint, options] = requestSpy.mock.calls[0]
+    expect(endpoint).toBe('/api/v1/courses/100/grading_standards')
+    expect(options?.method).toBe('POST')
+    const body = JSON.parse(options?.body as string)
+    expect(body.title).toBe('GPA 4.0 Scale')
+    // POST body uses grading_scheme_entry (singular), NOT grading_scheme (plural).
+    expect(body.grading_scheme).toBeUndefined()
+    expect(body.grading_scheme_entry).toEqual([
+      { name: 'A', value: 0.94 },
+      { name: 'B', value: 0.84 },
+      { name: 'F', value: 0.0 },
+    ])
+  })
+
+  it('createForCourse sorts entries descending by value before posting', async () => {
+    const requestSpy = vi.spyOn(client, 'request').mockResolvedValueOnce(mockStandard)
+    await module.createForCourse(100, 'GPA 4.0 Scale', [
+      { name: 'F', value: 0.0 },
+      { name: 'B', value: 0.84 },
+      { name: 'A', value: 0.94 },
+    ])
+    const body = JSON.parse(requestSpy.mock.calls[0][1]?.body as string)
+    expect(body.grading_scheme_entry).toEqual([
+      { name: 'A', value: 0.94 },
+      { name: 'B', value: 0.84 },
+      { name: 'F', value: 0.0 },
+    ])
+  })
+
+  it('createForCourse does not mutate the caller input array', async () => {
+    vi.spyOn(client, 'request').mockResolvedValueOnce(mockStandard)
+    const input = [
+      { name: 'F', value: 0.0 },
+      { name: 'B', value: 0.84 },
+      { name: 'A', value: 0.94 },
+    ]
+    await module.createForCourse(100, 'GPA 4.0 Scale', input)
+    expect(input).toEqual([
+      { name: 'F', value: 0.0 },
+      { name: 'B', value: 0.84 },
+      { name: 'A', value: 0.94 },
+    ])
+  })
+
+  it('createForAccount posts to the account endpoint', async () => {
+    const requestSpy = vi.spyOn(client, 'request').mockResolvedValueOnce(mockStandard)
+    await module.createForAccount(1, 'GPA 4.0 Scale', schemeEntries)
+    const [endpoint, options] = requestSpy.mock.calls[0]
+    expect(endpoint).toBe('/api/v1/accounts/1/grading_standards')
+    expect(options?.method).toBe('POST')
+  })
+
+  it('propagates CanvasApiError from createForAccount (no client-layer catch)', async () => {
+    vi.spyOn(client, 'request').mockRejectedValueOnce(
+      new CanvasApiError('Forbidden', 403, '/api/v1/accounts/1/grading_standards'),
+    )
+    await expect(module.createForAccount(1, 'GPA 4.0 Scale', schemeEntries)).rejects.toThrow(
+      CanvasApiError,
+    )
+  })
+})

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(125)
+    expect(manifest.tools).toHaveLength(128)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/tools/grading-standards.test.ts
+++ b/tests/tools/grading-standards.test.ts
@@ -85,6 +85,15 @@ describe('gradingStandardsTools', () => {
       )
     })
 
+    it('throws when both course_id and account_id are provided', async () => {
+      const canvas = buildMockCanvas()
+      await expect(
+        tool(canvas, 'list_grading_standards').handler({ course_id: 100, account_id: 1 }),
+      ).rejects.toThrow('Provide either course_id or account_id, not both.')
+      expect(canvas.gradingStandards.listForCourse).not.toHaveBeenCalled()
+      expect(canvas.gradingStandards.listForAccount).not.toHaveBeenCalled()
+    })
+
     it('propagates a 404 CanvasApiError', async () => {
       const canvas = buildMockCanvas()
       vi.mocked(canvas.gradingStandards.listForCourse).mockRejectedValueOnce(
@@ -141,6 +150,20 @@ describe('gradingStandardsTools', () => {
           scheme_entries: schemeEntries,
         }),
       ).rejects.toThrow('Provide either course_id or account_id.')
+    })
+
+    it('throws when both course_id and account_id are provided (no API call, no admin re-wrap)', async () => {
+      const canvas = buildMockCanvas()
+      await expect(
+        tool(canvas, 'create_grading_standard').handler({
+          course_id: 100,
+          account_id: 1,
+          title: 'GPA 4.0 Scale',
+          scheme_entries: schemeEntries,
+        }),
+      ).rejects.toThrow('Provide either course_id or account_id, not both.')
+      expect(canvas.gradingStandards.createForCourse).not.toHaveBeenCalled()
+      expect(canvas.gradingStandards.createForAccount).not.toHaveBeenCalled()
     })
 
     it('re-throws an account-context 403 as a plain Error mentioning admin permissions', async () => {

--- a/tests/tools/grading-standards.test.ts
+++ b/tests/tools/grading-standards.test.ts
@@ -180,6 +180,20 @@ describe('gradingStandardsTools', () => {
       await expect(promise).rejects.not.toBeInstanceOf(CanvasApiError)
     })
 
+    it('does NOT re-wrap an account-context rate-limit 403 (lets formatError keep its hint)', async () => {
+      const canvas = buildMockCanvas()
+      vi.mocked(canvas.gradingStandards.createForAccount).mockRejectedValueOnce(
+        new CanvasApiError('Rate Limit Exceeded', 403, '/api/v1/accounts/1/grading_standards'),
+      )
+      await expect(
+        tool(canvas, 'create_grading_standard').handler({
+          account_id: 1,
+          title: 'GPA 4.0 Scale',
+          scheme_entries: schemeEntries,
+        }),
+      ).rejects.toBeInstanceOf(CanvasApiError)
+    })
+
     it('propagates a course-context 403 as CanvasApiError (no admin re-wrap)', async () => {
       const canvas = buildMockCanvas()
       vi.mocked(canvas.gradingStandards.createForCourse).mockRejectedValueOnce(

--- a/tests/tools/grading-standards.test.ts
+++ b/tests/tools/grading-standards.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi } from 'vitest'
+import { z } from 'zod'
+import type { CanvasClient } from '../../src/canvas'
+import { CanvasApiError } from '../../src/canvas/client'
+import { gradingStandardsTools } from '../../src/tools/grading-standards'
+
+const mockStandard = {
+  id: 42,
+  title: 'GPA 4.0 Scale',
+  context_type: 'Course' as const,
+  context_id: 100,
+  grading_scheme: [
+    { name: 'A', value: 0.94 },
+    { name: 'B', value: 0.84 },
+    { name: 'F', value: 0.0 },
+  ],
+}
+
+const schemeEntries = [
+  { name: 'A', value: 0.94 },
+  { name: 'B', value: 0.84 },
+  { name: 'F', value: 0.0 },
+]
+
+function buildMockCanvas(): CanvasClient {
+  return {
+    gradingStandards: {
+      listForCourse: vi.fn().mockResolvedValue([mockStandard]),
+      listForAccount: vi.fn().mockResolvedValue([mockStandard]),
+      createForCourse: vi.fn().mockResolvedValue(mockStandard),
+      createForAccount: vi.fn().mockResolvedValue(mockStandard),
+    },
+    courses: {
+      update: vi.fn().mockResolvedValue({ id: 100, grading_standard_id: 42 }),
+    },
+  } as unknown as CanvasClient
+}
+
+const tool = (canvas: CanvasClient, name: string) =>
+  gradingStandardsTools(canvas).find((t) => t.name === name)!
+
+describe('gradingStandardsTools', () => {
+  it('returns 3 tool definitions', () => {
+    expect(gradingStandardsTools(buildMockCanvas())).toHaveLength(3)
+  })
+
+  it('exports tools with correct names', () => {
+    const names = gradingStandardsTools(buildMockCanvas()).map((t) => t.name)
+    expect(names).toEqual([
+      'list_grading_standards',
+      'create_grading_standard',
+      'apply_grading_standard_to_course',
+    ])
+  })
+
+  describe('list_grading_standards', () => {
+    it('has readOnlyHint + openWorldHint', () => {
+      expect(tool(buildMockCanvas(), 'list_grading_standards').annotations).toEqual({
+        readOnlyHint: true,
+        openWorldHint: true,
+      })
+    })
+
+    it('lists by course_id', async () => {
+      const canvas = buildMockCanvas()
+      const result = await tool(canvas, 'list_grading_standards').handler({ course_id: 100 })
+      expect(canvas.gradingStandards.listForCourse).toHaveBeenCalledWith(100)
+      expect(result).toEqual([mockStandard])
+    })
+
+    it('lists by account_id', async () => {
+      const canvas = buildMockCanvas()
+      const result = await tool(canvas, 'list_grading_standards').handler({ account_id: 1 })
+      expect(canvas.gradingStandards.listForAccount).toHaveBeenCalledWith(1)
+      expect(result).toEqual([mockStandard])
+    })
+
+    it('throws a plain Error when neither id is provided', async () => {
+      const canvas = buildMockCanvas()
+      await expect(tool(canvas, 'list_grading_standards').handler({})).rejects.toThrow(
+        'Provide either course_id or account_id.',
+      )
+      await expect(tool(canvas, 'list_grading_standards').handler({})).rejects.not.toBeInstanceOf(
+        CanvasApiError,
+      )
+    })
+
+    it('propagates a 404 CanvasApiError', async () => {
+      const canvas = buildMockCanvas()
+      vi.mocked(canvas.gradingStandards.listForCourse).mockRejectedValueOnce(
+        new CanvasApiError('Not Found', 404, '/api/v1/courses/100/grading_standards'),
+      )
+      await expect(
+        tool(canvas, 'list_grading_standards').handler({ course_id: 100 }),
+      ).rejects.toBeInstanceOf(CanvasApiError)
+    })
+  })
+
+  describe('create_grading_standard', () => {
+    it('has destructiveHint + openWorldHint', () => {
+      expect(tool(buildMockCanvas(), 'create_grading_standard').annotations).toEqual({
+        destructiveHint: true,
+        openWorldHint: true,
+      })
+    })
+
+    it('creates in a course context', async () => {
+      const canvas = buildMockCanvas()
+      const result = await tool(canvas, 'create_grading_standard').handler({
+        course_id: 100,
+        title: 'GPA 4.0 Scale',
+        scheme_entries: schemeEntries,
+      })
+      expect(canvas.gradingStandards.createForCourse).toHaveBeenCalledWith(
+        100,
+        'GPA 4.0 Scale',
+        schemeEntries,
+      )
+      expect(result).toEqual(mockStandard)
+    })
+
+    it('creates in an account context', async () => {
+      const canvas = buildMockCanvas()
+      await tool(canvas, 'create_grading_standard').handler({
+        account_id: 1,
+        title: 'GPA 4.0 Scale',
+        scheme_entries: schemeEntries,
+      })
+      expect(canvas.gradingStandards.createForAccount).toHaveBeenCalledWith(
+        1,
+        'GPA 4.0 Scale',
+        schemeEntries,
+      )
+    })
+
+    it('throws a plain Error when neither id is provided', async () => {
+      const canvas = buildMockCanvas()
+      await expect(
+        tool(canvas, 'create_grading_standard').handler({
+          title: 'GPA 4.0 Scale',
+          scheme_entries: schemeEntries,
+        }),
+      ).rejects.toThrow('Provide either course_id or account_id.')
+    })
+
+    it('re-throws an account-context 403 as a plain Error mentioning admin permissions', async () => {
+      const canvas = buildMockCanvas()
+      vi.mocked(canvas.gradingStandards.createForAccount).mockRejectedValueOnce(
+        new CanvasApiError('Forbidden', 403, '/api/v1/accounts/1/grading_standards'),
+      )
+      const promise = tool(canvas, 'create_grading_standard').handler({
+        account_id: 1,
+        title: 'GPA 4.0 Scale',
+        scheme_entries: schemeEntries,
+      })
+      await expect(promise).rejects.toThrow(/Canvas admin permissions/)
+      await expect(promise).rejects.not.toBeInstanceOf(CanvasApiError)
+    })
+
+    it('propagates a course-context 403 as CanvasApiError (no admin re-wrap)', async () => {
+      const canvas = buildMockCanvas()
+      vi.mocked(canvas.gradingStandards.createForCourse).mockRejectedValueOnce(
+        new CanvasApiError('Forbidden', 403, '/api/v1/courses/100/grading_standards'),
+      )
+      await expect(
+        tool(canvas, 'create_grading_standard').handler({
+          course_id: 100,
+          title: 'GPA 4.0 Scale',
+          scheme_entries: schemeEntries,
+        }),
+      ).rejects.toBeInstanceOf(CanvasApiError)
+    })
+
+    it('propagates a 422 CanvasApiError unchanged', async () => {
+      const canvas = buildMockCanvas()
+      vi.mocked(canvas.gradingStandards.createForCourse).mockRejectedValueOnce(
+        new CanvasApiError('Unprocessable', 422, '/api/v1/courses/100/grading_standards'),
+      )
+      await expect(
+        tool(canvas, 'create_grading_standard').handler({
+          course_id: 100,
+          title: 'GPA 4.0 Scale',
+          scheme_entries: schemeEntries,
+        }),
+      ).rejects.toBeInstanceOf(CanvasApiError)
+    })
+
+    it('validates scheme entry value bounds (0–1) and non-empty entries', () => {
+      const schema = z.object(tool(buildMockCanvas(), 'create_grading_standard').inputSchema)
+      expect(
+        schema.safeParse({ course_id: 100, title: 'x', scheme_entries: schemeEntries }).success,
+      ).toBe(true)
+      // value above 1 is rejected
+      expect(
+        schema.safeParse({
+          course_id: 100,
+          title: 'x',
+          scheme_entries: [{ name: 'A', value: 1.5 }],
+        }).success,
+      ).toBe(false)
+      // empty scheme_entries is rejected
+      expect(schema.safeParse({ course_id: 100, title: 'x', scheme_entries: [] }).success).toBe(
+        false,
+      )
+    })
+  })
+
+  describe('apply_grading_standard_to_course', () => {
+    it('has destructiveHint + openWorldHint', () => {
+      expect(tool(buildMockCanvas(), 'apply_grading_standard_to_course').annotations).toEqual({
+        destructiveHint: true,
+        openWorldHint: true,
+      })
+    })
+
+    it('applies a grading standard id to the course', async () => {
+      const canvas = buildMockCanvas()
+      const result = await tool(canvas, 'apply_grading_standard_to_course').handler({
+        course_id: 100,
+        grading_standard_id: 42,
+      })
+      expect(canvas.courses.update).toHaveBeenCalledWith(100, { grading_standard_id: 42 })
+      expect(result).toEqual({ id: 100, grading_standard_id: 42 })
+    })
+
+    it('removes the grading standard when passed null', async () => {
+      const canvas = buildMockCanvas()
+      await tool(canvas, 'apply_grading_standard_to_course').handler({
+        course_id: 100,
+        grading_standard_id: null,
+      })
+      expect(canvas.courses.update).toHaveBeenCalledWith(100, { grading_standard_id: null })
+    })
+
+    it('propagates a 404 CanvasApiError', async () => {
+      const canvas = buildMockCanvas()
+      vi.mocked(canvas.courses.update).mockRejectedValueOnce(
+        new CanvasApiError('Not Found', 404, '/api/v1/courses/100'),
+      )
+      await expect(
+        tool(canvas, 'apply_grading_standard_to_course').handler({
+          course_id: 100,
+          grading_standard_id: 42,
+        }),
+      ).rejects.toBeInstanceOf(CanvasApiError)
+    })
+  })
+})

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -170,6 +170,12 @@ function buildFullMockCanvas(): CanvasClient {
       get: async () => ({}),
       list: async () => [],
     },
+    gradingStandards: {
+      listForCourse: async () => [],
+      listForAccount: async () => [],
+      createForCourse: async () => ({}),
+      createForAccount: async () => ({}),
+    },
   } as unknown as CanvasClient
 }
 
@@ -179,7 +185,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 125 tools across all domains', () => {
+  it('returns all 128 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 
@@ -333,8 +339,12 @@ describe('getAllTools', () => {
     expect(names).toContain('create_content_export')
     expect(names).toContain('get_content_export')
     expect(names).toContain('list_content_exports')
+    // Grading Standards (3)
+    expect(names).toContain('list_grading_standards')
+    expect(names).toContain('create_grading_standard')
+    expect(names).toContain('apply_grading_standard_to_course')
 
-    expect(tools).toHaveLength(125)
+    expect(tools).toHaveLength(128)
   })
 
   it('all tools have openWorldHint: true', () => {
@@ -382,6 +392,8 @@ describe('getAllTools', () => {
       'update_new_quiz_item',
       'delete_new_quiz_item',
       'create_content_export',
+      'create_grading_standard',
+      'apply_grading_standard_to_course',
     ]
     const tools = getAllTools(buildFullMockCanvas())
     for (const name of writeToolNames) {
@@ -437,6 +449,8 @@ describe('getAllTools', () => {
       'update_new_quiz_item',
       'delete_new_quiz_item',
       'create_content_export',
+      'create_grading_standard',
+      'apply_grading_standard_to_course',
     ])
     const tools = getAllTools(buildFullMockCanvas())
     for (const tool of tools) {


### PR DESCRIPTION
## Summary

Implements the merged spec for #186 (grading standards tooling).

> **User story:** As an instructor using Claude, I want to describe my letter-to-points grading scale in plain language and have the agent create it in Canvas and apply it to my course — so my gradebook auto-converts letter entries to a numeric/GPA scale without me hunting through course settings.

Adds a `grading_standards` Canvas client module and three MCP tools:

- **`list_grading_standards`** — list standards in a course or account context (`readOnlyHint`).
- **`create_grading_standard`** — create a standard from `{ name, value }` scheme entries (`destructiveHint`). Entries are sorted descending by `value` before posting; the POST body is flat and uses the singular `grading_scheme_entry` key (Canvas asymmetry — the response uses `grading_scheme`).
- **`apply_grading_standard_to_course`** — wire a `grading_standard_id` to a course's gradebook via `courses.update()`; passing `null` clears it (`destructiveHint`).

## Approach

- New `GradingStandardsModule` (`src/canvas/grading-standards.ts`) injected into the `CanvasClient` facade; uses `client.paginate()` (list endpoints return a plain array, not an envelope).
- Type additions in `src/canvas/types.ts`: `CanvasGradingSchemeEntry`, `CanvasGradingStandardContextType`, `CanvasGradingStandard`, plus `grading_standard_id?: number | null` on `UpdateCourseParams` and `CanvasCourse` (prerequisite for the apply tool to type-check).
- Account-context `403` is re-thrown as a plain `Error` with an admin-permission message (preserving the original via `cause`); course-context `403`/`404`/`422` propagate as `CanvasApiError` to `formatError`.
- Domain registered in `src/tools/catalog.ts` with `educator` audience.

## FERPA / pseudonymizer

No student PII is involved — grading standards are course-level config (`id`, `title`, `context_*`, `grading_scheme`). `apply_grading_standard_to_course` returns `CanvasCourse` without requesting `include[]=enrollments`. No pseudonymizer wrapping required; `tests/pseudonym/coverage.test.ts` is unchanged.

## Deviations from the spec (followed code reality)

- **Tool count:** the spec assumed 121 → 124, but `main` is at **125** today (PRs landed since the spec merged). Bumped the registry test and the discovery manifest test to **128** and regenerated `docs/generated/tool-manifest.json`.
- **Manifest gate:** the spec omitted the manifest artifact. Ran `pnpm generate:manifests` and updated `tests/discovery/manifests.test.ts` (the spec's `tests/tools/manifests.test.ts` path does not exist).
- **`facade.test.ts`:** the spec described a "checked properties array" that doesn't exist; added a dedicated `it()` block asserting the `gradingStandards` module instead.
- **`preserve-caught-error` lint rule:** the spec's verbatim re-throw failed lint; added `{ cause: error }` to the re-thrown `Error` (stays a plain `Error`, so `formatError` behaviour and tests are unaffected).

## Test evidence

New tests: `tests/canvas/grading-standards.test.ts` (8 cases — endpoints, singular POST key, descending sort, no-input-mutation, error propagation) and `tests/tools/grading-standards.test.ts` (handler delegation, account-403 re-wrap vs course-403 passthrough, 422/404 propagation, Zod bounds, null-clear).

Full gate green:

- `pnpm typecheck` — clean
- `pnpm lint` — clean (ESLint + Prettier)
- `pnpm test` — **1088 passed**, 1 skipped (84 files)
- `pnpm build` — success

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)
