### PR TITLE
feat(course-setup): add check_course_setup course-readiness report

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 133,
+  "toolCount": 134,
   "tools": [
     {
       "name": "health_check",
@@ -1636,6 +1636,18 @@
         "openWorldHint": true
       },
       "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "check_course_setup",
+      "domain": "course_setup",
+      "description": "Run a factual course-readiness report that surfaces common configuration problems — assignments missing due dates, unpublished items students will not see, gradebook weighting gaps, and graded assignments with no points. Returns findings grouped by check with a plain-language detail per item. This is a config-health report only; it does not inspect student submissions or performance (see list_students_needing_attention / get_missing_submissions for those). Requires instructor permissions in the course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
       "primaryAudience": "educator",
       "relatedWorkflows": []
     }

--- a/src/canvas/modules.ts
+++ b/src/canvas/modules.ts
@@ -8,6 +8,21 @@ export class ModulesModule {
     return this.client.paginate<CanvasModule>(`/api/v1/courses/${courseId}/modules`)
   }
 
+  /**
+   * List a course's modules with each module's items inlined via `include[]=items`.
+   * Unlike `getCourseStructure`, this returns the raw Canvas shapes (including the
+   * `published` state on every module and item, even unpublished ones), which the
+   * course-setup health check needs to detect unpublished content.
+   */
+  async listWithItems(
+    courseId: number,
+  ): Promise<(CanvasModule & { items?: CanvasModuleItem[] })[]> {
+    return this.client.paginate<CanvasModule & { items?: CanvasModuleItem[] }>(
+      `/api/v1/courses/${courseId}/modules`,
+      { include: ['items'] },
+    )
+  }
+
   async get(courseId: number, moduleId: number): Promise<CanvasModule> {
     return this.client.request<CanvasModule>(`/api/v1/courses/${courseId}/modules/${moduleId}`)
   }

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -8,6 +8,7 @@ import { assignmentOverrideTools } from './assignment-overrides'
 import { calendarTools } from './calendar'
 import { contentExportsTools } from './content-exports'
 import { conversationTools } from './conversations'
+import { courseSetupTools } from './course-setup'
 import { courseTools } from './courses'
 import { dashboardTools } from './dashboard'
 import { discussionTools } from './discussions'
@@ -176,5 +177,10 @@ export const toolDomainCatalog: readonly ToolDomainRegistration[] = [
     domain: 'assignment_overrides',
     defaultPrimaryAudience: 'educator',
     getTools: assignmentOverrideTools,
+  },
+  {
+    domain: 'course_setup',
+    defaultPrimaryAudience: 'educator',
+    getTools: courseSetupTools,
   },
 ]

--- a/src/tools/course-setup.ts
+++ b/src/tools/course-setup.ts
@@ -1,0 +1,203 @@
+import { z } from 'zod'
+import type { CanvasClient } from '../canvas'
+import type {
+  CanvasAssignment,
+  CanvasAssignmentGroup,
+  CanvasCourse,
+  CanvasModule,
+  CanvasModuleItem,
+} from '../canvas/types'
+import type { ToolDefinition } from './types'
+
+const ALL_CHECKS = [
+  'missing_due_dates',
+  'unpublished_items',
+  'assignment_group_weights',
+  'ungraded_setup',
+] as const
+
+type CheckName = (typeof ALL_CHECKS)[number]
+
+interface SetupFinding {
+  type: string
+  id: number
+  name: string
+  detail: string
+  parent_module_name?: string
+}
+
+interface CheckResult {
+  check: CheckName
+  severity: 'warn'
+  items: SetupFinding[]
+}
+
+export function courseSetupTools(canvas: CanvasClient): ToolDefinition[] {
+  return [
+    {
+      name: 'check_course_setup',
+      description:
+        'Run a factual course-readiness report that surfaces common configuration problems — ' +
+        'assignments missing due dates, unpublished items students will not see, ' +
+        'gradebook weighting gaps, and graded assignments with no points. ' +
+        'Returns findings grouped by check with a plain-language detail per item. ' +
+        'This is a config-health report only; it does not inspect student submissions or performance ' +
+        '(see list_students_needing_attention / get_missing_submissions for those). ' +
+        'Requires instructor permissions in the course.',
+      inputSchema: {
+        course_id: z.number().int().positive().describe('Canvas course ID'),
+        checks: z
+          .array(
+            z.enum([
+              'missing_due_dates',
+              'unpublished_items',
+              'assignment_group_weights',
+              'ungraded_setup',
+            ]),
+          )
+          .optional()
+          .describe(
+            'Subset of checks to run. Omit to run all four checks. ' +
+              'Valid values: missing_due_dates, unpublished_items, ' +
+              'assignment_group_weights, ungraded_setup.',
+          ),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+        const requestedChecks = (params.checks as CheckName[] | undefined) ?? [...ALL_CHECKS]
+        const activeChecks = new Set<CheckName>(requestedChecks)
+
+        // Parallel fetch — skip API calls not needed for the active checks.
+        // `assignments.list` is always fetched (three of four checks need it).
+        const [course, assignments, assignmentGroups, modules]: [
+          CanvasCourse | null,
+          CanvasAssignment[],
+          CanvasAssignmentGroup[],
+          (CanvasModule & { items?: CanvasModuleItem[] })[],
+        ] = await Promise.all([
+          activeChecks.has('assignment_group_weights')
+            ? canvas.courses.get(courseId)
+            : Promise.resolve(null),
+          canvas.assignments.list(courseId, { include: ['all_dates'] }),
+          activeChecks.has('assignment_group_weights')
+            ? canvas.assignments.listGroups(courseId)
+            : Promise.resolve([]),
+          activeChecks.has('unpublished_items')
+            ? canvas.modules.listWithItems(courseId)
+            : Promise.resolve([]),
+        ])
+
+        const results: CheckResult[] = []
+
+        // ── check: missing_due_dates ──────────────────────────────────
+        if (activeChecks.has('missing_due_dates')) {
+          const items: SetupFinding[] = []
+          for (const a of assignments) {
+            if (a.published !== true) continue
+            if (a.due_at !== null) continue
+            const hasOverrideDueDate = (a.all_dates ?? []).some((d) => d.due_at !== null)
+            if (!hasOverrideDueDate) {
+              items.push({
+                type: 'assignment',
+                id: a.id,
+                name: a.name,
+                detail: 'published, no due_at and no override dates with a due date',
+              })
+            }
+          }
+          results.push({ check: 'missing_due_dates', severity: 'warn', items })
+        }
+
+        // ── check: unpublished_items ──────────────────────────────────
+        if (activeChecks.has('unpublished_items')) {
+          const items: SetupFinding[] = []
+
+          for (const a of assignments) {
+            if (a.published !== true) {
+              items.push({
+                type: 'assignment',
+                id: a.id,
+                name: a.name,
+                detail: 'not published — students cannot see this assignment',
+              })
+            }
+          }
+
+          for (const mod of modules) {
+            if (mod.published !== true) {
+              items.push({
+                type: 'module',
+                id: mod.id,
+                name: mod.name,
+                detail: 'not published — students cannot see this module or any of its items',
+              })
+            } else {
+              for (const item of mod.items ?? []) {
+                if (item.published !== true) {
+                  items.push({
+                    type: 'module_item',
+                    id: item.id,
+                    name: item.title,
+                    detail: `not published (inside published module "${mod.name}")`,
+                    parent_module_name: mod.name,
+                  })
+                }
+              }
+            }
+          }
+
+          results.push({ check: 'unpublished_items', severity: 'warn', items })
+        }
+
+        // ── check: assignment_group_weights ───────────────────────────
+        if (activeChecks.has('assignment_group_weights')) {
+          const items: SetupFinding[] = []
+          if (course !== null && course.apply_assignment_group_weights === true) {
+            const total = assignmentGroups.reduce((sum, g) => sum + (g.group_weight ?? 0), 0)
+            if (Math.abs(total - 100) > 0.5) {
+              items.push({
+                type: 'course',
+                id: courseId,
+                name: course.name,
+                detail: `weighting enabled; group weights sum to ${total.toFixed(2)}, not 100`,
+              })
+            }
+          }
+          results.push({ check: 'assignment_group_weights', severity: 'warn', items })
+        }
+
+        // ── check: ungraded_setup ─────────────────────────────────────
+        if (activeChecks.has('ungraded_setup')) {
+          const items: SetupFinding[] = []
+          for (const a of assignments) {
+            if (a.published !== true) continue
+            if (a.grading_type !== 'not_graded' && a.points_possible === 0) {
+              items.push({
+                type: 'assignment',
+                id: a.id,
+                name: a.name,
+                detail: `grading_type is "${a.grading_type}" but points_possible is 0 — will not affect gradebook totals`,
+              })
+            }
+          }
+          results.push({ check: 'ungraded_setup', severity: 'warn', items })
+        }
+
+        const totalFindings = results.reduce((n, r) => n + r.items.length, 0)
+
+        return {
+          summary: {
+            course_id: courseId,
+            checks_run: results.map((r) => r.check),
+            total_findings: totalFindings,
+          },
+          findings: results,
+        }
+      },
+    },
+  ]
+}

--- a/src/tools/course-setup.ts
+++ b/src/tools/course-setup.ts
@@ -94,6 +94,12 @@ export function courseSetupTools(canvas: CanvasClient): ToolDefinition[] {
         const results: CheckResult[] = []
 
         // ── check: missing_due_dates ──────────────────────────────────
+        // `published !== true` is deliberately conservative: only definitely-
+        // published assignments are scanned here and in ungraded_setup. An
+        // unpublished or unknown-publish-state assignment is intentional in-
+        // progress work, so it is skipped to avoid false positives (the spec's
+        // "only published assignments are flagged" rule). unpublished_items
+        // applies the inverse and surfaces those instead.
         if (activeChecks.has('missing_due_dates')) {
           const items: SetupFinding[] = []
           for (const a of assignments) {

--- a/tests/canvas/modules.test.ts
+++ b/tests/canvas/modules.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ModulesModule } from '../../src/canvas/modules'
-import { CanvasHttpClient } from '../../src/canvas/client'
+import { CanvasHttpClient, CanvasApiError } from '../../src/canvas/client'
 
 describe('ModulesModule', () => {
   let client: CanvasHttpClient
@@ -171,5 +171,42 @@ describe('ModulesModule', () => {
     const result = await modules.getCourseStructure(100)
     expect(result.modules).toHaveLength(0)
     expect(result.summary).toEqual({ total_modules: 0, total_items: 0, items_by_type: {} })
+  })
+
+  describe('listWithItems', () => {
+    it('returns modules with their items inlined', async () => {
+      const fixture = [
+        {
+          id: 1,
+          name: 'Module 1',
+          position: 1,
+          items_count: 2,
+          published: true,
+          items: [
+            { id: 10, module_id: 1, title: 'Reading', position: 1, type: 'Page', published: true },
+            { id: 11, module_id: 1, title: 'Quiz 1', position: 2, type: 'Quiz', published: false },
+          ],
+        },
+      ]
+      vi.spyOn(client, 'paginate').mockResolvedValueOnce(fixture)
+      const result = await modules.listWithItems(42)
+      expect(result).toEqual(fixture)
+      expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/42/modules', {
+        include: ['items'],
+      })
+    })
+
+    it('returns an empty array for a course with no modules', async () => {
+      vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+      const result = await modules.listWithItems(42)
+      expect(result).toEqual([])
+    })
+
+    it('propagates CanvasApiError from the client', async () => {
+      vi.spyOn(client, 'paginate').mockRejectedValueOnce(
+        new CanvasApiError('Not Found', 404, '/api/v1/courses/42/modules'),
+      )
+      await expect(modules.listWithItems(42)).rejects.toThrow(CanvasApiError)
+    })
   })
 })

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(133)
+    expect(manifest.tools).toHaveLength(134)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/tools/course-setup.test.ts
+++ b/tests/tools/course-setup.test.ts
@@ -1,0 +1,388 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { CanvasClient } from '../../src/canvas'
+import { courseSetupTools } from '../../src/tools/course-setup'
+
+interface SetupFinding {
+  type: string
+  id: number
+  name: string
+  detail: string
+  parent_module_name?: string
+}
+
+interface SetupReport {
+  summary: { course_id: number; checks_run: string[]; total_findings: number }
+  findings: Array<{ check: string; severity: string; items: SetupFinding[] }>
+}
+
+const DEFAULT_COURSE = { id: 10, name: 'Test Course', apply_assignment_group_weights: true }
+
+const DEFAULT_ASSIGNMENTS = [
+  {
+    id: 1,
+    name: 'Essay 1',
+    published: true,
+    due_at: null,
+    all_dates: [],
+    grading_type: 'points',
+    points_possible: 10,
+  },
+  {
+    id: 2,
+    name: 'Essay 2',
+    published: true,
+    due_at: '2026-09-01T23:59:00Z',
+    all_dates: [],
+    grading_type: 'points',
+    points_possible: 20,
+  },
+  {
+    id: 3,
+    name: 'Ungraded',
+    published: false,
+    due_at: null,
+    all_dates: [],
+    grading_type: 'not_graded',
+    points_possible: 0,
+  },
+]
+
+const DEFAULT_GROUPS = [
+  { id: 1, name: 'Homework', position: 1, group_weight: 50 },
+  { id: 2, name: 'Exams', position: 2, group_weight: 50 },
+]
+
+const DEFAULT_MODULES = [
+  {
+    id: 1,
+    name: 'Week 1',
+    published: true,
+    items: [
+      { id: 10, module_id: 1, title: 'Reading', type: 'Page', position: 1, published: true },
+      { id: 11, module_id: 1, title: 'Quiz', type: 'Quiz', position: 2, published: false },
+    ],
+  },
+  {
+    id: 2,
+    name: 'Week 2 (Draft)',
+    published: false,
+    items: [
+      { id: 20, module_id: 2, title: 'Lecture', type: 'Page', position: 1, published: false },
+    ],
+  },
+]
+
+function buildMockCanvas(
+  overrides: {
+    course?: unknown
+    assignments?: unknown[]
+    groups?: unknown[]
+    modules?: unknown[]
+  } = {},
+): CanvasClient {
+  return {
+    courses: {
+      get: vi.fn().mockResolvedValue(overrides.course ?? DEFAULT_COURSE),
+    },
+    assignments: {
+      list: vi.fn().mockResolvedValue(overrides.assignments ?? DEFAULT_ASSIGNMENTS),
+      listGroups: vi.fn().mockResolvedValue(overrides.groups ?? DEFAULT_GROUPS),
+    },
+    modules: {
+      listWithItems: vi.fn().mockResolvedValue(overrides.modules ?? DEFAULT_MODULES),
+    },
+  } as unknown as CanvasClient
+}
+
+function getTool(canvas: CanvasClient) {
+  const tools = courseSetupTools(canvas)
+  return tools[0]
+}
+
+async function run(canvas: CanvasClient, params: Record<string, unknown>): Promise<SetupReport> {
+  return (await getTool(canvas).handler(params)) as SetupReport
+}
+
+function itemsFor(report: SetupReport, check: string): SetupFinding[] {
+  return report.findings.find((f) => f.check === check)?.items ?? []
+}
+
+describe('courseSetupTools', () => {
+  it('returns exactly one tool definition named check_course_setup', () => {
+    const tools = courseSetupTools(buildMockCanvas())
+    expect(tools).toHaveLength(1)
+    expect(tools[0].name).toBe('check_course_setup')
+  })
+
+  it('declares read-only, open-world annotations', () => {
+    const tool = getTool(buildMockCanvas())
+    expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+  })
+
+  it('runs all four checks when no checks param is supplied', async () => {
+    const report = await run(buildMockCanvas(), { course_id: 10 })
+    expect(report.summary.checks_run).toEqual([
+      'missing_due_dates',
+      'unpublished_items',
+      'assignment_group_weights',
+      'ungraded_setup',
+    ])
+    expect(report.findings).toHaveLength(4)
+  })
+
+  describe('missing_due_dates', () => {
+    it('flags a published assignment with no due date', async () => {
+      const report = await run(buildMockCanvas(), { course_id: 10 })
+      const items = itemsFor(report, 'missing_due_dates')
+      expect(items).toHaveLength(1)
+      expect(items[0]).toMatchObject({ type: 'assignment', id: 1, name: 'Essay 1' })
+      expect(items[0].detail).toContain('published, no due_at')
+    })
+
+    it('skips unpublished assignments even when due_at is null', async () => {
+      const report = await run(buildMockCanvas(), { course_id: 10 })
+      const items = itemsFor(report, 'missing_due_dates')
+      expect(items.some((i) => i.id === 3)).toBe(false)
+    })
+
+    it('skips an assignment that has an override due date', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [
+          {
+            id: 1,
+            name: 'Essay 1',
+            published: true,
+            due_at: null,
+            all_dates: [{ due_at: '2026-09-15T23:59:00Z', unlock_at: null, lock_at: null }],
+            grading_type: 'points',
+            points_possible: 10,
+          },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      const items = itemsFor(report, 'missing_due_dates')
+      expect(items.some((i) => i.id === 1)).toBe(false)
+    })
+
+    it('is skipped when not requested but assignments are still fetched for other checks', async () => {
+      const canvas = buildMockCanvas()
+      const report = await run(canvas, { course_id: 10, checks: ['ungraded_setup'] })
+      expect(canvas.assignments.list).toHaveBeenCalled()
+      expect(report.summary.checks_run).toEqual(['ungraded_setup'])
+      expect(report.findings.some((f) => f.check === 'missing_due_dates')).toBe(false)
+    })
+  })
+
+  describe('unpublished_items', () => {
+    it('flags an unpublished assignment', async () => {
+      const report = await run(buildMockCanvas(), { course_id: 10 })
+      const items = itemsFor(report, 'unpublished_items')
+      expect(items).toContainEqual(
+        expect.objectContaining({ type: 'assignment', id: 3, name: 'Ungraded' }),
+      )
+    })
+
+    it('flags an unpublished module', async () => {
+      const report = await run(buildMockCanvas(), { course_id: 10 })
+      const items = itemsFor(report, 'unpublished_items')
+      expect(items).toContainEqual(
+        expect.objectContaining({ type: 'module', id: 2, name: 'Week 2 (Draft)' }),
+      )
+    })
+
+    it('flags an unpublished item inside a published module', async () => {
+      const report = await run(buildMockCanvas(), { course_id: 10 })
+      const items = itemsFor(report, 'unpublished_items')
+      expect(items).toContainEqual(
+        expect.objectContaining({
+          type: 'module_item',
+          id: 11,
+          name: 'Quiz',
+          parent_module_name: 'Week 1',
+        }),
+      )
+    })
+
+    it('does not flag items inside an unpublished module individually', async () => {
+      const report = await run(buildMockCanvas(), { course_id: 10 })
+      const items = itemsFor(report, 'unpublished_items')
+      // The unpublished module itself is reported once...
+      expect(items.filter((i) => i.type === 'module' && i.id === 2)).toHaveLength(1)
+      // ...but its child item (id 20) must NOT appear as a module_item finding.
+      expect(items.some((i) => i.type === 'module_item' && i.id === 20)).toBe(false)
+    })
+
+    it('returns an empty items array when everything is published', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [
+          {
+            id: 1,
+            name: 'Essay 1',
+            published: true,
+            due_at: '2026-09-01T23:59:00Z',
+            all_dates: [],
+            grading_type: 'points',
+            points_possible: 10,
+          },
+        ],
+        modules: [
+          {
+            id: 1,
+            name: 'Week 1',
+            published: true,
+            items: [
+              {
+                id: 10,
+                module_id: 1,
+                title: 'Reading',
+                type: 'Page',
+                position: 1,
+                published: true,
+              },
+            ],
+          },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'unpublished_items')).toEqual([])
+    })
+
+    it('does not fetch modules when unpublished_items is not requested', async () => {
+      const canvas = buildMockCanvas()
+      await run(canvas, { course_id: 10, checks: ['missing_due_dates'] })
+      expect(canvas.modules.listWithItems).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('assignment_group_weights', () => {
+    it('produces no finding when weights sum to 100', async () => {
+      const report = await run(buildMockCanvas(), { course_id: 10 })
+      expect(itemsFor(report, 'assignment_group_weights')).toEqual([])
+    })
+
+    it('flags weights that do not sum to 100', async () => {
+      const canvas = buildMockCanvas({
+        groups: [
+          { id: 1, name: 'Homework', position: 1, group_weight: 40 },
+          { id: 2, name: 'Exams', position: 2, group_weight: 50 },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      const items = itemsFor(report, 'assignment_group_weights')
+      expect(items).toHaveLength(1)
+      expect(items[0]).toMatchObject({ type: 'course', id: 10, name: 'Test Course' })
+      expect(items[0].detail).toContain('sum to 90.00, not 100')
+    })
+
+    it('produces no finding when weighting is disabled but still fetches the data on a full run', async () => {
+      const canvas = buildMockCanvas({
+        course: { id: 10, name: 'Test Course', apply_assignment_group_weights: false },
+        groups: [
+          { id: 1, name: 'Homework', position: 1, group_weight: 40 },
+          { id: 2, name: 'Exams', position: 2, group_weight: 50 },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(canvas.courses.get).toHaveBeenCalled()
+      expect(canvas.assignments.listGroups).toHaveBeenCalled()
+      expect(itemsFor(report, 'assignment_group_weights')).toEqual([])
+    })
+
+    it('does not fetch course or groups when the weight check is not requested', async () => {
+      const canvas = buildMockCanvas()
+      await run(canvas, { course_id: 10, checks: ['missing_due_dates', 'unpublished_items'] })
+      expect(canvas.assignments.listGroups).not.toHaveBeenCalled()
+      expect(canvas.courses.get).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('ungraded_setup', () => {
+    it('flags a graded assignment with zero points', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [
+          {
+            id: 4,
+            name: 'Extra Credit',
+            published: true,
+            due_at: null,
+            all_dates: [],
+            grading_type: 'points',
+            points_possible: 0,
+          },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      const items = itemsFor(report, 'ungraded_setup')
+      expect(items).toContainEqual(
+        expect.objectContaining({ type: 'assignment', id: 4, name: 'Extra Credit' }),
+      )
+      const finding = items.find((i) => i.id === 4)!
+      expect(finding.detail).toContain('grading_type is "points"')
+      expect(finding.detail).toContain('points_possible is 0')
+    })
+
+    it('does not flag a not_graded assignment with zero points', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [
+          {
+            id: 6,
+            name: 'Survey',
+            published: true,
+            due_at: null,
+            all_dates: [],
+            grading_type: 'not_graded',
+            points_possible: 0,
+          },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'ungraded_setup').some((i) => i.id === 6)).toBe(false)
+    })
+
+    it('does not flag an unpublished graded-zero assignment', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [
+          {
+            id: 5,
+            name: 'Draft Zero',
+            published: false,
+            due_at: null,
+            all_dates: [],
+            grading_type: 'points',
+            points_possible: 0,
+          },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'ungraded_setup').some((i) => i.id === 5)).toBe(false)
+    })
+
+    it('does not flag graded assignments with more than zero points', async () => {
+      const report = await run(buildMockCanvas(), { course_id: 10 })
+      const items = itemsFor(report, 'ungraded_setup')
+      expect(items.some((i) => i.id === 1)).toBe(false)
+      expect(items.some((i) => i.id === 2)).toBe(false)
+    })
+  })
+
+  describe('checks filter', () => {
+    it('runs only the requested subset and skips unneeded fetches', async () => {
+      const canvas = buildMockCanvas()
+      const report = await run(canvas, {
+        course_id: 10,
+        checks: ['missing_due_dates', 'ungraded_setup'],
+      })
+      expect(report.summary.checks_run).toHaveLength(2)
+      expect(report.findings).toHaveLength(2)
+      expect(canvas.modules.listWithItems).not.toHaveBeenCalled()
+      expect(canvas.assignments.listGroups).not.toHaveBeenCalled()
+      expect(canvas.courses.get).not.toHaveBeenCalled()
+    })
+
+    it('reports total_findings equal to the sum of all item counts', async () => {
+      const report = await run(buildMockCanvas(), { course_id: 10 })
+      const summed = report.findings.reduce((n, f) => n + f.items.length, 0)
+      expect(report.summary.total_findings).toBe(summed)
+    })
+  })
+})

--- a/tests/tools/course-setup.test.ts
+++ b/tests/tools/course-setup.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import type { CanvasClient } from '../../src/canvas'
+import { CanvasApiError } from '../../src/canvas/client'
 import { courseSetupTools } from '../../src/tools/course-setup'
 
 interface SetupFinding {
@@ -164,6 +165,32 @@ describe('courseSetupTools', () => {
       expect(items.some((i) => i.id === 1)).toBe(false)
     })
 
+    it('still flags when all_dates is populated but every entry has a null due date', async () => {
+      // Canvas inlines a base entry (base: true) in all_dates that mirrors the
+      // top-level due_at. When due_at is null the base entry is also null, so a
+      // populated-but-all-null all_dates must NOT suppress the finding. This pins
+      // the spec's explicit warning against adding a `!d.base` exclusion filter.
+      const canvas = buildMockCanvas({
+        assignments: [
+          {
+            id: 1,
+            name: 'Essay 1',
+            published: true,
+            due_at: null,
+            all_dates: [
+              { base: true, due_at: null, unlock_at: null, lock_at: null },
+              { due_at: null, unlock_at: null, lock_at: null },
+            ],
+            grading_type: 'points',
+            points_possible: 10,
+          },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      const items = itemsFor(report, 'missing_due_dates')
+      expect(items).toContainEqual(expect.objectContaining({ type: 'assignment', id: 1 }))
+    })
+
     it('is skipped when not requested but assignments are still fetched for other checks', async () => {
       const canvas = buildMockCanvas()
       const report = await run(canvas, { course_id: 10, checks: ['ungraded_setup'] })
@@ -274,6 +301,47 @@ describe('courseSetupTools', () => {
       expect(items[0].detail).toContain('sum to 90.00, not 100')
     })
 
+    it('does not flag a sum within the 0.5 rounding tolerance', async () => {
+      // Three groups each rounded to 2dp can accumulate rounding error; 99.98 is
+      // a legitimate "sums to 100" course and must not produce a false positive.
+      // Pins the spec's deliberate 0.5 tolerance against a regression to a tight bound.
+      const canvas = buildMockCanvas({
+        groups: [
+          { id: 1, name: 'A', position: 1, group_weight: 33.33 },
+          { id: 2, name: 'B', position: 2, group_weight: 33.33 },
+          { id: 3, name: 'C', position: 3, group_weight: 33.32 },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'assignment_group_weights')).toEqual([])
+    })
+
+    it('flags a sum just outside the 0.5 tolerance', async () => {
+      const canvas = buildMockCanvas({
+        groups: [
+          { id: 1, name: 'Homework', position: 1, group_weight: 49.4 },
+          { id: 2, name: 'Exams', position: 2, group_weight: 50 },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      const items = itemsFor(report, 'assignment_group_weights')
+      expect(items).toHaveLength(1)
+      expect(items[0].detail).toContain('sum to 99.40, not 100')
+    })
+
+    it('treats a group with no group_weight as contributing zero', async () => {
+      // Canvas can omit group_weight; the `?? 0` fallback must not poison the sum
+      // with NaN. Here 100 + (missing) should read as 100 → no finding.
+      const canvas = buildMockCanvas({
+        groups: [
+          { id: 1, name: 'Everything', position: 1, group_weight: 100 },
+          { id: 2, name: 'Unweighted', position: 2 },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'assignment_group_weights')).toEqual([])
+    })
+
     it('produces no finding when weighting is disabled but still fetches the data on a full run', async () => {
       const canvas = buildMockCanvas({
         course: { id: 10, name: 'Test Course', apply_assignment_group_weights: false },
@@ -363,6 +431,26 @@ describe('courseSetupTools', () => {
       expect(items.some((i) => i.id === 1)).toBe(false)
       expect(items.some((i) => i.id === 2)).toBe(false)
     })
+
+    it('does not flag an assignment whose points_possible is null', async () => {
+      // The check uses strict `=== 0`, so a null/undefined points_possible (which
+      // Canvas can return for some assignment types) does not trigger a finding.
+      const canvas = buildMockCanvas({
+        assignments: [
+          {
+            id: 7,
+            name: 'No Points Field',
+            published: true,
+            due_at: '2026-09-01T23:59:00Z',
+            all_dates: [],
+            grading_type: 'points',
+            points_possible: null,
+          },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'ungraded_setup').some((i) => i.id === 7)).toBe(false)
+    })
   })
 
   describe('checks filter', () => {
@@ -383,6 +471,20 @@ describe('courseSetupTools', () => {
       const report = await run(buildMockCanvas(), { course_id: 10 })
       const summed = report.findings.reduce((n, f) => n + f.items.length, 0)
       expect(report.summary.total_findings).toBe(summed)
+    })
+  })
+
+  describe('error propagation', () => {
+    it('rejects (does not swallow) when a Canvas fetch fails', async () => {
+      // The no-silent-failure guarantee relies on the handler re-throwing so the
+      // central catch in src/tools/index.ts can surface the error. A regression
+      // that wrapped a fetch in a swallowing try/catch (returning an empty report)
+      // would be caught here.
+      const canvas = buildMockCanvas()
+      ;(canvas.assignments.list as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new CanvasApiError('Not Found', 404, '/api/v1/courses/10/assignments'),
+      )
+      await expect(getTool(canvas).handler({ course_id: 10 })).rejects.toThrow(CanvasApiError)
     })
   })
 })

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -94,6 +94,7 @@ function buildFullMockCanvas(): CanvasClient {
         modules: [],
         summary: { total_modules: 0, total_items: 0, items_by_type: {} },
       }),
+      listWithItems: async () => [],
       create: async () => ({}),
       update: async () => ({}),
       createItem: async () => ({}),
@@ -188,7 +189,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 133 tools across all domains', () => {
+  it('returns all 134 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 
@@ -353,8 +354,10 @@ describe('getAllTools', () => {
     expect(names).toContain('list_assignment_overrides')
     expect(names).toContain('create_assignment_override')
     expect(names).toContain('set_student_assignment_dates')
+    // Course Setup (1)
+    expect(names).toContain('check_course_setup')
 
-    expect(tools).toHaveLength(133)
+    expect(tools).toHaveLength(134)
   })
 
   it('all tools have openWorldHint: true', () => {


### PR DESCRIPTION
## Summary

Implements the merged design spec for #200 — a read-only **`check_course_setup`** tool that answers the instructor question *"what's wrong with my course before I publish it?"* with one factual, config-only readiness report, instead of clicking through every assignment, module, and settings page by hand.

> **User story:** As an instructor using Claude, I want to ask "what's wrong with my course before I publish it?" and get one factual report of common setup problems — assignments missing due dates, unpublished items students won't see, and gradebook weighting gaps — so I can fix them before the term starts (or before an accreditation review).

This is deliberately **course-configuration health only** (structure/settings). It complements, and does not duplicate, `list_students_needing_attention` / `get_missing_submissions`, which cover student performance after the course is live.

## Approach

`check_course_setup` (read-only) composes existing Canvas read endpoints into one report. The caller can opt into a subset via `checks`; omitting it runs all four. Each requested check always appears in `findings` (even with an empty `items` array), so a zero-finding result is explicit, not ambiguous.

Four high-signal, unambiguous checks ship in v1 (severity `warn`):

| Check | Signal |
| --- | --- |
| `missing_due_dates` | Published assignment with no base `due_at` and no override with a due date |
| `unpublished_items` | Unpublished assignments; unpublished modules; items unpublished inside a *published* module |
| `assignment_group_weights` | Weighting enabled but group weights don't sum to 100 (0.5 float tolerance) |
| `ungraded_setup` | Published assignment with `grading_type !== 'not_graded'` and `points_possible === 0` |

Design decisions baked in (per the spec): published-only scope for `missing_due_dates` and `ungraded_setup`; items inside an unpublished module are not double-reported (the parent module finding covers them); fetches are gated per active check (`courses.get` + `listGroups` only for the weight check, `modules.listWithItems` only for `unpublished_items`; `assignments.list` is always fetched since three checks need it).

Adds one backing Canvas method, `ModulesModule.listWithItems`, returning raw modules with items inlined via `include[]=items` (the existing `getCourseStructure` projects/filters items, so it can't see unpublished ones).

**No student PII** in the payload (assignment/module/course metadata only) — no pseudonymizer wrapping, no `PSEUDONYMIZER_WRAPPED_TOOLS` entry, consistent with the spec's FERPA analysis.

### Note on spec deviations (followed code reality)

- **Tool count:** the spec quoted 130→131; the live count was **133**, so this PR bumps `registry.test.ts` and `manifests.test.ts` to **134** and regenerates `docs/generated/tool-manifest.json`.
- **Catalog placement:** the spec said "after `quiz_accommodations`"; the catalog's actual last entry is now `assignment_overrides`, so the `course_setup` domain is appended at the true end.

## Test evidence

Full local gate green on the final commit:

- `pnpm typecheck` — clean
- `pnpm lint` — `All matched files use Prettier code style!`
- `pnpm test` — **Test Files 88 passed (88); Tests 1182 passed | 1 skipped**
- `pnpm build` — `Build success`

New coverage: 3 cases for `ModulesModule.listWithItems` (happy path, empty, error propagation) and 23 cases for `check_course_setup` (all four checks, published/grading guards, override-date handling, per-check fetch gating, and the `checks` subset filter).

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
