### PR TITLE
feat(grade-explanation): add explain_grade weighted-grade reconciliation tool

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 134,
+  "toolCount": 135,
   "tools": [
     {
       "name": "health_check",
@@ -1649,6 +1649,18 @@
       },
       "access": "read",
       "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "explain_grade",
+      "domain": "grade_explanation",
+      "description": "Recomputes and explains the weighted course grade for a student, including assignment-group weights, drop_lowest / drop_highest / never_drop rules, per-group breakdowns (earned points, dropped assignments, weighted contributions), the mapped letter grade (via the course grading standard when present), and a reconciliation check against Canvas's posted current_score / final_score.\n\nUse this when you need to verify that Canvas's displayed grade matches the rules, or to explain to a student or instructor how their grade was calculated.\n\nLimitations:\n- V1 computes one student per call. Omit student_id to compute for the authenticated user.\n- Instructor-applied curves and fudge points are not exposed via the Canvas REST API and cannot be reflected in the computation; a caveat is added when the discrepancy exceeds 0.5 pp.\n- When the course uses grading periods, reconciliation is against the overall (cross-period) grade.\n- When CANVAS_PSEUDONYMIZE_STUDENTS is enabled and you are passing a student_id, first call resolve_pseudonym to obtain the real Canvas user_id.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
       "relatedWorkflows": []
     }
   ]

--- a/src/canvas/users.ts
+++ b/src/canvas/users.ts
@@ -52,6 +52,10 @@ export class UsersModule {
     return this.client.request<CanvasUser>(`/api/v1/users/${userId}`)
   }
 
+  async getSelf(): Promise<CanvasUser> {
+    return this.client.request<CanvasUser>('/api/v1/users/self')
+  }
+
   async getProfile(): Promise<CanvasUserProfile> {
     return this.client.request<CanvasUserProfile>('/api/v1/users/self/profile')
   }

--- a/src/pseudonym/coverage.ts
+++ b/src/pseudonym/coverage.ts
@@ -50,4 +50,7 @@ export const PSEUDONYMIZER_WRAPPED_TOOLS: readonly string[] = [
   // src/tools/attention.ts
   'list_submission_comments_needing_attention',
   'list_students_needing_attention',
+
+  // src/tools/grade-explanation.ts
+  'explain_grade',
 ] as const

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -15,6 +15,7 @@ import { discussionTools } from './discussions'
 import { enrollmentTools } from './enrollments'
 import { fileTools } from './files'
 import { gradebookHistoryTools } from './gradebook-history'
+import { gradeExplanationTools } from './grade-explanation'
 import { gradingStandardsTools } from './grading-standards'
 import { groupTools } from './groups'
 import { healthTools } from './health'
@@ -182,5 +183,10 @@ export const toolDomainCatalog: readonly ToolDomainRegistration[] = [
     domain: 'course_setup',
     defaultPrimaryAudience: 'educator',
     getTools: courseSetupTools,
+  },
+  {
+    domain: 'grade_explanation',
+    defaultPrimaryAudience: 'shared',
+    getTools: gradeExplanationTools,
   },
 ]

--- a/src/tools/grade-explanation.ts
+++ b/src/tools/grade-explanation.ts
@@ -32,10 +32,22 @@ interface GradeItem {
   status: AssignmentStatus
   /** Effective score: a number for graded assignments, otherwise null. */
   score: number | null
+  /**
+   * points_possible normalized to a finite number. Canvas can return null or
+   * omit the field for "no points" assignments; coercing it through arithmetic
+   * would either silently inflate the percentage (null → +0 denominator) or
+   * poison the total to NaN (undefined). Normalizing once keeps the math safe.
+   */
+  points: number
   /** never_drop assignments are pinned: never considered for dropping. */
   pinned: boolean
   dropped: boolean
   dropReason: DropReason
+}
+
+/** Coerce a possibly-null/absent points_possible to a finite number. */
+function normalizePoints(value: number | null | undefined): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
 }
 
 interface GroupModeResult {
@@ -87,7 +99,12 @@ function classify(
   sub: CanvasSubmission | undefined,
   neverDrop: ReadonlySet<number>,
 ): GradeItem {
-  const base = { assignment, dropped: false, dropReason: null as DropReason }
+  const base = {
+    assignment,
+    points: normalizePoints(assignment.points_possible),
+    dropped: false,
+    dropReason: null as DropReason,
+  }
   if (assignment.grading_type === 'not_graded') {
     return { ...base, status: 'not_graded', score: null, pinned: false }
   }
@@ -117,7 +134,7 @@ function retainedFraction(items: readonly GradeItem[], mode: Mode): number | nul
   for (const item of items) {
     if (mode === 'current' && item.score === null) continue
     earned += item.score ?? 0
-    possible += item.assignment.points_possible
+    possible += item.points
   }
   return possible === 0 ? null : earned / possible
 }
@@ -125,9 +142,10 @@ function retainedFraction(items: readonly GradeItem[], mode: Mode): number | nul
 /** score/points ratio for greedy ranking; null scores sort worst per mode. */
 function sortRatio(item: GradeItem, mode: Mode): number {
   if (item.score === null) return mode === 'current' ? -Infinity : 0
-  const pts = item.assignment.points_possible
-  if (pts <= 0) return item.score > 0 ? Infinity : 0
-  return item.score / pts
+  // A zero/absent points_possible cannot yield a meaningful ratio; treat it as
+  // neutral so a 0-point item never corrupts the greedy ranking with Infinity.
+  if (item.points <= 0) return 0
+  return item.score / item.points
 }
 
 interface DropOutcome {
@@ -240,7 +258,7 @@ function computeGroupGrade(
   for (const item of [...working, ...pinned]) {
     if (mode === 'current' && item.score === null) continue
     earned += item.score ?? 0
-    possible += item.assignment.points_possible
+    possible += item.points
   }
 
   return { items, earned, possible, usedGreedy }
@@ -327,7 +345,7 @@ function buildGroupOutput(
     assignments: current.items.map((item) => ({
       assignment_id: item.assignment.id,
       assignment_name: item.assignment.name,
-      points_possible: item.assignment.points_possible,
+      points_possible: item.points,
       score: item.score,
       status: item.status,
       dropped: item.dropped,
@@ -473,9 +491,14 @@ export function gradeExplanationTools(
         const caveats: string[] = []
 
         const enrollment = selectGradedEnrollment(enrollments)
-        if (enrollments.length === 0) {
+        // Reconciliation needs an enrollment that actually carries `grades`.
+        // An empty list OR an enrollment without a grades object (observer/TA
+        // records, hidden final grades) both leave posted scores unavailable —
+        // surface that rather than returning a silent null reconciliation.
+        if (!enrollment?.grades) {
           caveats.push(
-            'No student enrollment found for this course — Canvas posted scores are unavailable.',
+            'No student enrollment found with posted grades for this course — Canvas posted ' +
+              'scores are unavailable.',
           )
         }
 
@@ -530,6 +553,27 @@ export function gradeExplanationTools(
         const computedCurrent = computeOverall(currentResults, weighted)
         const computedFinal = computeOverall(finalResults, weighted)
 
+        // Explain weighted-mode edge cases so a null/odd total is never silent.
+        if (weighted && groupFilter === undefined) {
+          const hasGradedWork = currentResults.some((r) => r.result.possible > 0)
+          if (computedCurrent === null && hasGradedWork) {
+            caveats.push(
+              'This course is set to weight assignment groups, but no group weights are ' +
+                'configured, so the overall percentage cannot be computed.',
+            )
+          } else if (
+            hasGradedWork &&
+            currentResults.some((r) => (r.group.group_weight ?? 0) > 0 && r.result.possible <= 0)
+          ) {
+            caveats.push(
+              'One or more weighted assignment groups have no graded work yet, so their weight ' +
+                'is redistributed across the remaining groups (matching Canvas). Per-group ' +
+                'weighted_contribution values are nominal (group_weight × percentage) and may ' +
+                'not sum to the overall percentage.',
+            )
+          }
+        }
+
         const totalsCurrent = buildTotals(
           computedCurrent,
           enrollment?.grades?.current_score ?? null,
@@ -560,10 +604,12 @@ export function gradeExplanationTools(
         }
 
         // FERPA: pseudonymize only when viewing another student's data. Viewing
-        // one's own grade (self) exposes no third-party PII.
+        // one's own grade (self) exposes no third-party PII. Pass the already-
+        // fetched enrollments so role classification uses real enrollment types
+        // (a staff member fetched by id is correctly left un-pseudonymized).
         const anonUser =
-          pseudonymizer && typeof studentId === 'number'
-            ? await pseudonymizer.anonymizeUser(courseId, user)
+          pseudonymizer?.isEnabled() && typeof studentId === 'number'
+            ? await pseudonymizer.anonymizeUser(courseId, user, enrollments)
             : user
 
         return {

--- a/src/tools/grade-explanation.ts
+++ b/src/tools/grade-explanation.ts
@@ -1,0 +1,584 @@
+import { z } from 'zod'
+import type { CanvasClient } from '../canvas'
+import type {
+  CanvasAssignment,
+  CanvasAssignmentGroup,
+  CanvasCourse,
+  CanvasEnrollment,
+  CanvasGradingSchemeEntry,
+  CanvasSubmission,
+} from '../canvas/types'
+import type { Pseudonymizer } from '../pseudonym/pseudonymizer'
+import type { ToolDefinition } from './types'
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+/** Rounding drift (in percentage points) absorbed before a difference counts. */
+const RECONCILIATION_TOLERANCE = 0.5
+/** Discrepancy (pp) above which a curve/fudge-points caveat is surfaced. */
+const CURVE_CAVEAT_THRESHOLD = 0.5
+/** Hard cap on brute-force drop combinations before falling back to greedy. */
+const MAX_DROP_COMBINATIONS = 10_000
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+type Mode = 'current' | 'final'
+type AssignmentStatus = 'graded' | 'submitted' | 'missing' | 'excused' | 'not_graded'
+type DropReason = 'drop_lowest' | 'drop_highest' | null
+type DropStrategy = 'maximize_retained' | 'minimize_retained'
+
+interface GradeItem {
+  assignment: CanvasAssignment
+  status: AssignmentStatus
+  /** Effective score: a number for graded assignments, otherwise null. */
+  score: number | null
+  /** never_drop assignments are pinned: never considered for dropping. */
+  pinned: boolean
+  dropped: boolean
+  dropReason: DropReason
+}
+
+interface GroupModeResult {
+  items: GradeItem[]
+  earned: number
+  possible: number
+  usedGreedy: boolean
+}
+
+// ── Combinatorial helpers (in-tree, no dependencies) ─────────────────────────
+
+/** C(n, k) computed iteratively to avoid factorial overflow. */
+function binomial(n: number, k: number): number {
+  if (k < 0 || k > n) return 0
+  if (k === 0 || k === n) return 1
+  const kk = Math.min(k, n - k)
+  let result = 1
+  for (let i = 0; i < kk; i++) {
+    result = (result * (n - i)) / (i + 1)
+  }
+  return Math.round(result)
+}
+
+/** All k-element subsets of `items` (each subset is an array of references). */
+function combinations<T>(items: readonly T[], k: number): T[][] {
+  const result: T[][] = []
+  const combo: T[] = []
+  const recurse = (start: number): void => {
+    if (combo.length === k) {
+      result.push([...combo])
+      return
+    }
+    for (let i = start; i < items.length; i++) {
+      const item = items[i]
+      if (item === undefined) continue
+      combo.push(item)
+      recurse(i + 1)
+      combo.pop()
+    }
+  }
+  recurse(0)
+  return result
+}
+
+// ── Grade computation ────────────────────────────────────────────────────────
+
+function classify(
+  assignment: CanvasAssignment,
+  sub: CanvasSubmission | undefined,
+  neverDrop: ReadonlySet<number>,
+): GradeItem {
+  const base = { assignment, dropped: false, dropReason: null as DropReason }
+  if (assignment.grading_type === 'not_graded') {
+    return { ...base, status: 'not_graded', score: null, pinned: false }
+  }
+  if (sub?.excused === true) {
+    return { ...base, status: 'excused', score: null, pinned: false }
+  }
+  const pinned = neverDrop.has(assignment.id)
+  if (sub?.workflow_state === 'graded' && sub.score !== null) {
+    return { ...base, status: 'graded', score: sub.score ?? null, pinned }
+  }
+  if (sub?.workflow_state === 'submitted' || sub?.workflow_state === 'pending_review') {
+    return { ...base, status: 'submitted', score: null, pinned }
+  }
+  // missing / unsubmitted / no submission record (sub === undefined)
+  return { ...base, status: 'missing', score: null, pinned }
+}
+
+/** Excused and not_graded assignments never participate in the grade. */
+function isCountable(item: GradeItem): boolean {
+  return item.status !== 'excused' && item.status !== 'not_graded'
+}
+
+/** Percentage (0–1) of a retained set, applying mode null-score semantics. */
+function retainedFraction(items: readonly GradeItem[], mode: Mode): number | null {
+  let earned = 0
+  let possible = 0
+  for (const item of items) {
+    if (mode === 'current' && item.score === null) continue
+    earned += item.score ?? 0
+    possible += item.assignment.points_possible
+  }
+  return possible === 0 ? null : earned / possible
+}
+
+/** score/points ratio for greedy ranking; null scores sort worst per mode. */
+function sortRatio(item: GradeItem, mode: Mode): number {
+  if (item.score === null) return mode === 'current' ? -Infinity : 0
+  const pts = item.assignment.points_possible
+  if (pts <= 0) return item.score > 0 ? Infinity : 0
+  return item.score / pts
+}
+
+interface DropOutcome {
+  retained: GradeItem[]
+  dropped: GradeItem[]
+  usedGreedy: boolean
+}
+
+/**
+ * Greedy fallback for pathologically large groups: rank by score/points ratio
+ * and drop the `count` best (drop_highest) or worst (drop_lowest) items.
+ */
+function greedyDrop(
+  items: GradeItem[],
+  count: number,
+  strategy: DropStrategy,
+  mode: Mode,
+): DropOutcome {
+  const ranked = [...items].sort((a, b) => sortRatio(a, mode) - sortRatio(b, mode))
+  const dropped =
+    strategy === 'minimize_retained'
+      ? ranked.slice(ranked.length - count) // drop the highest-ratio items
+      : ranked.slice(0, count) // drop the lowest-ratio items
+  const droppedSet = new Set(dropped)
+  return { retained: items.filter((i) => !droppedSet.has(i)), dropped, usedGreedy: true }
+}
+
+/**
+ * Choose the `count` items to drop. Brute-force searches every combination and
+ * keeps the one that best serves the strategy: `maximize_retained` (drop_lowest,
+ * helps the grade most) or `minimize_retained` (drop_highest, bonus exclusion).
+ */
+function applyDrop(
+  items: GradeItem[],
+  count: number,
+  strategy: DropStrategy,
+  mode: Mode,
+): DropOutcome {
+  if (items.length === 0 || count >= items.length) {
+    return { retained: items, dropped: [], usedGreedy: false }
+  }
+  if (binomial(items.length, count) > MAX_DROP_COMBINATIONS) {
+    return greedyDrop(items, count, strategy, mode)
+  }
+
+  let bestRetained: GradeItem[] = items
+  let bestDropped: GradeItem[] = []
+  let bestFraction: number | null = null
+
+  for (const combo of combinations(items, count)) {
+    const droppedSet = new Set(combo)
+    const retained = items.filter((i) => !droppedSet.has(i))
+    const fraction = retainedFraction(retained, mode) ?? (mode === 'current' ? -Infinity : 0)
+    if (
+      bestFraction === null ||
+      (strategy === 'maximize_retained' && fraction > bestFraction) ||
+      (strategy === 'minimize_retained' && fraction < bestFraction)
+    ) {
+      bestRetained = retained
+      bestDropped = combo
+      bestFraction = fraction
+    }
+  }
+
+  return { retained: bestRetained, dropped: bestDropped, usedGreedy: false }
+}
+
+/** Compute one group's earned/possible totals for a single mode. */
+function computeGroupGrade(
+  group: CanvasAssignmentGroup,
+  submissionsById: ReadonlyMap<number, CanvasSubmission>,
+  mode: Mode,
+): GroupModeResult {
+  const dropLowest = group.rules?.drop_lowest ?? 0
+  const dropHighest = group.rules?.drop_highest ?? 0
+  const neverDrop = new Set(group.rules?.never_drop ?? [])
+
+  // Fresh items per call so per-mode drop annotations never leak between passes.
+  const items = (group.assignments ?? []).map((a) =>
+    classify(a, submissionsById.get(a.id), neverDrop),
+  )
+
+  const countable = items.filter(isCountable)
+  let working = countable.filter((i) => !i.pinned)
+  const pinned = countable.filter((i) => i.pinned)
+  let usedGreedy = false
+
+  // Canvas documented order: drop_highest first, then drop_lowest.
+  if (dropHighest > 0 && working.length > dropHighest) {
+    const outcome = applyDrop(working, dropHighest, 'minimize_retained', mode)
+    for (const d of outcome.dropped) {
+      d.dropped = true
+      d.dropReason = 'drop_highest'
+    }
+    working = outcome.retained
+    usedGreedy = usedGreedy || outcome.usedGreedy
+  }
+  if (dropLowest > 0 && working.length > dropLowest) {
+    const outcome = applyDrop(working, dropLowest, 'maximize_retained', mode)
+    for (const d of outcome.dropped) {
+      d.dropped = true
+      d.dropReason = 'drop_lowest'
+    }
+    working = outcome.retained
+    usedGreedy = usedGreedy || outcome.usedGreedy
+  }
+
+  let earned = 0
+  let possible = 0
+  for (const item of [...working, ...pinned]) {
+    if (mode === 'current' && item.score === null) continue
+    earned += item.score ?? 0
+    possible += item.assignment.points_possible
+  }
+
+  return { items, earned, possible, usedGreedy }
+}
+
+function percentageOf(earned: number, possible: number): number | null {
+  return possible === 0 ? null : (earned / possible) * 100
+}
+
+/** Overall course percentage for a single mode, weighted or not. */
+function computeOverall(
+  results: ReadonlyArray<{ group: CanvasAssignmentGroup; result: GroupModeResult }>,
+  weighted: boolean,
+): number | null {
+  if (!weighted) {
+    let earned = 0
+    let possible = 0
+    for (const { result } of results) {
+      earned += result.earned
+      possible += result.possible
+    }
+    return percentageOf(earned, possible)
+  }
+
+  let contributionSum = 0
+  let activeWeightSum = 0
+  for (const { group, result } of results) {
+    if (result.possible <= 0) continue
+    const weight = group.group_weight ?? 0
+    const fraction = result.earned / result.possible
+    contributionSum += weight * fraction
+    activeWeightSum += weight
+  }
+  if (activeWeightSum === 0) return null
+  return (contributionSum / activeWeightSum) * 100
+}
+
+/** Map a 0–100 percentage to a letter via a (descending) grading scheme. */
+function mapLetter(
+  percentage: number | null,
+  scheme: ReadonlyArray<CanvasGradingSchemeEntry> | null,
+): string | null {
+  if (percentage === null || !scheme || scheme.length === 0) return null
+  const sorted = [...scheme].sort((a, b) => b.value - a.value)
+  const fraction = percentage / 100
+  for (const entry of sorted) {
+    if (fraction >= entry.value) return entry.name
+  }
+  const lowest = sorted[sorted.length - 1]
+  return lowest ? lowest.name : null
+}
+
+// ── Output assembly ──────────────────────────────────────────────────────────
+
+function buildGroupOutput(
+  group: CanvasAssignmentGroup,
+  current: GroupModeResult,
+  final: GroupModeResult,
+  weighted: boolean,
+): unknown {
+  const groupWeight = group.group_weight ?? 0
+  const block = (result: GroupModeResult): unknown => {
+    const percentage = percentageOf(result.earned, result.possible)
+    return {
+      earned_points: result.earned,
+      possible_points: result.possible,
+      percentage,
+      weighted_contribution:
+        weighted && percentage !== null ? groupWeight * (percentage / 100) : null,
+    }
+  }
+
+  return {
+    group_id: group.id,
+    group_name: group.name,
+    group_weight: groupWeight,
+    rules: {
+      drop_lowest: group.rules?.drop_lowest ?? 0,
+      drop_highest: group.rules?.drop_highest ?? 0,
+      never_drop: group.rules?.never_drop ?? [],
+    },
+    // current-mode annotations drive the displayed dropped/status fields; both
+    // modes share identical status and score (only earned/possible differ).
+    assignments: current.items.map((item) => ({
+      assignment_id: item.assignment.id,
+      assignment_name: item.assignment.name,
+      points_possible: item.assignment.points_possible,
+      score: item.score,
+      status: item.status,
+      dropped: item.dropped,
+      drop_reason: item.dropReason,
+    })),
+    current: block(current),
+    final: block(final),
+  }
+}
+
+function buildTotals(
+  computedPercentage: number | null,
+  postedScore: number | null,
+  postedLetter: string | null,
+  letter: string | null,
+): unknown {
+  const discrepancy =
+    computedPercentage !== null && postedScore !== null
+      ? Math.abs(computedPercentage - postedScore)
+      : null
+  const matches = discrepancy === null ? null : discrepancy <= RECONCILIATION_TOLERANCE
+  return {
+    computed_percentage: computedPercentage,
+    canvas_posted_score: postedScore,
+    discrepancy,
+    matches,
+    letter,
+    canvas_posted_letter: postedLetter,
+  }
+}
+
+// ── Canvas orchestration ─────────────────────────────────────────────────────
+
+/** Pick the enrollment that carries grades (prefer the student enrollment). */
+function selectGradedEnrollment(
+  enrollments: ReadonlyArray<CanvasEnrollment>,
+): CanvasEnrollment | null {
+  return (
+    enrollments.find((e) => e.type === 'StudentEnrollment' && e.grades) ??
+    enrollments.find((e) => e.grades) ??
+    enrollments[0] ??
+    null
+  )
+}
+
+/** Resolve the course grading scheme, falling back to the account standard. */
+async function resolveGradingScheme(
+  canvas: CanvasClient,
+  courseId: number,
+  course: CanvasCourse,
+): Promise<ReadonlyArray<CanvasGradingSchemeEntry> | null> {
+  const targetId = course.grading_standard_id
+  if (targetId == null) return null
+
+  const courseStandards = await canvas.gradingStandards.listForCourse(courseId)
+  const courseMatch = courseStandards.find((s) => s.id === targetId)
+  if (courseMatch) return courseMatch.grading_scheme
+
+  if (course.account_id != null) {
+    const accountStandards = await canvas.gradingStandards.listForAccount(course.account_id)
+    const accountMatch = accountStandards.find((s) => s.id === targetId)
+    if (accountMatch) return accountMatch.grading_scheme
+  }
+  return null
+}
+
+// ── Tool definition ──────────────────────────────────────────────────────────
+
+export function gradeExplanationTools(
+  canvas: CanvasClient,
+  pseudonymizer?: Pseudonymizer,
+): ToolDefinition[] {
+  return [
+    {
+      name: 'explain_grade',
+      description:
+        'Recomputes and explains the weighted course grade for a student, including assignment-group ' +
+        'weights, drop_lowest / drop_highest / never_drop rules, per-group breakdowns (earned points, ' +
+        'dropped assignments, weighted contributions), the mapped letter grade (via the course grading ' +
+        "standard when present), and a reconciliation check against Canvas's posted current_score / " +
+        'final_score.\n\n' +
+        "Use this when you need to verify that Canvas's displayed grade matches the rules, or to explain " +
+        'to a student or instructor how their grade was calculated.\n\n' +
+        'Limitations:\n' +
+        '- V1 computes one student per call. Omit student_id to compute for the authenticated user.\n' +
+        '- Instructor-applied curves and fudge points are not exposed via the Canvas REST API and cannot ' +
+        'be reflected in the computation; a caveat is added when the discrepancy exceeds 0.5 pp.\n' +
+        '- When the course uses grading periods, reconciliation is against the overall (cross-period) grade.\n' +
+        '- When CANVAS_PSEUDONYMIZE_STUDENTS is enabled and you are passing a student_id, first call ' +
+        'resolve_pseudonym to obtain the real Canvas user_id.',
+      inputSchema: {
+        course_id: z
+          .number()
+          .int()
+          .positive()
+          .describe('Canvas course ID to compute the grade for.'),
+        student_id: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe(
+            'Canvas user_id of the student to compute the grade for. Omit to compute for the ' +
+              "currently authenticated user. Instructors may pass any enrolled student's user_id. " +
+              'When CANVAS_PSEUDONYMIZE_STUDENTS is enabled, pass the numeric Canvas user_id after ' +
+              'resolving the pseudonym via resolve_pseudonym.',
+          ),
+        assignment_group_id: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe(
+            'Narrow the output to a single assignment group. When omitted all groups are included and ' +
+              'the overall course grade is computed.',
+          ),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+        const studentParam = params.student_id as number | undefined
+        const studentId: number | 'self' = studentParam === undefined ? 'self' : studentParam
+        const groupFilter = params.assignment_group_id as number | undefined
+
+        const course = await canvas.courses.get(courseId)
+
+        const [groups, submissions, enrollments, user] = await Promise.all([
+          canvas.assignments.listGroups(courseId, { include: ['assignments'] }),
+          studentId === 'self'
+            ? canvas.submissions.listMy(courseId)
+            : canvas.submissions.listForStudents(courseId, { student_ids: [studentId] }),
+          canvas.enrollments.listForCourse(courseId, {
+            user_id: studentId === 'self' ? 'self' : studentId,
+            include: ['grades'],
+          }),
+          studentId === 'self' ? canvas.users.getSelf() : canvas.users.get(studentId),
+        ])
+
+        const caveats: string[] = []
+
+        const enrollment = selectGradedEnrollment(enrollments)
+        if (enrollments.length === 0) {
+          caveats.push(
+            'No student enrollment found for this course — Canvas posted scores are unavailable.',
+          )
+        }
+
+        let gradingScheme: ReadonlyArray<CanvasGradingSchemeEntry> | null = null
+        if (course.grading_standard_id != null) {
+          gradingScheme = await resolveGradingScheme(canvas, courseId, course)
+          if (gradingScheme === null) {
+            caveats.push(
+              `The course's grading standard (id: ${course.grading_standard_id}) could not be ` +
+                'retrieved — letter grades are unavailable.',
+            )
+          }
+        }
+
+        const submissionsById = new Map<number, CanvasSubmission>()
+        for (const sub of submissions) submissionsById.set(sub.assignment_id, sub)
+
+        const weighted = course.apply_assignment_group_weights ?? false
+
+        let selectedGroups = groups
+        if (groupFilter !== undefined) {
+          selectedGroups = groups.filter((g) => g.id === groupFilter)
+          const matched = selectedGroups[0]
+          if (matched === undefined) {
+            caveats.push(`Assignment group ${groupFilter} was not found in this course.`)
+          } else {
+            caveats.push(
+              `Results are filtered to assignment group '${matched.name}' — totals reflect only ` +
+                'this group, not the overall course grade.',
+            )
+          }
+        }
+
+        const groupOutputs: unknown[] = []
+        const currentResults: Array<{ group: CanvasAssignmentGroup; result: GroupModeResult }> = []
+        const finalResults: Array<{ group: CanvasAssignmentGroup; result: GroupModeResult }> = []
+
+        for (const group of selectedGroups) {
+          const current = computeGroupGrade(group, submissionsById, 'current')
+          const final = computeGroupGrade(group, submissionsById, 'final')
+          if (current.usedGreedy || final.usedGreedy) {
+            caveats.push(
+              `Drop-rule optimisation used a greedy approximation for group '${group.name}' due to ` +
+                'the large number of assignments. Result may differ slightly from Canvas.',
+            )
+          }
+          groupOutputs.push(buildGroupOutput(group, current, final, weighted))
+          currentResults.push({ group, result: current })
+          finalResults.push({ group, result: final })
+        }
+
+        const computedCurrent = computeOverall(currentResults, weighted)
+        const computedFinal = computeOverall(finalResults, weighted)
+
+        const totalsCurrent = buildTotals(
+          computedCurrent,
+          enrollment?.grades?.current_score ?? null,
+          enrollment?.grades?.current_grade ?? null,
+          mapLetter(computedCurrent, gradingScheme),
+        ) as { discrepancy: number | null }
+        const totalsFinal = buildTotals(
+          computedFinal,
+          enrollment?.grades?.final_score ?? null,
+          enrollment?.grades?.final_grade ?? null,
+          mapLetter(computedFinal, gradingScheme),
+        ) as { discrepancy: number | null }
+
+        // Curve caveat — suppressed in single-group mode, where a large
+        // discrepancy against the full-course posted score is expected.
+        if (groupFilter === undefined) {
+          const discrepancies = [totalsCurrent.discrepancy, totalsFinal.discrepancy].filter(
+            (d): d is number => d !== null,
+          )
+          const maxDiscrepancy = discrepancies.length > 0 ? Math.max(...discrepancies) : null
+          if (maxDiscrepancy !== null && maxDiscrepancy > CURVE_CAVEAT_THRESHOLD) {
+            caveats.push(
+              `Canvas's posted score differs from the computed value by ${maxDiscrepancy.toFixed(1)} ` +
+                'pp. If the instructor applied a curve or fudge points these are not accessible via ' +
+                'the API and cannot be reflected here.',
+            )
+          }
+        }
+
+        // FERPA: pseudonymize only when viewing another student's data. Viewing
+        // one's own grade (self) exposes no third-party PII.
+        const anonUser =
+          pseudonymizer && typeof studentId === 'number'
+            ? await pseudonymizer.anonymizeUser(courseId, user)
+            : user
+
+        return {
+          student: { id: anonUser.id, name: anonUser.name },
+          course: {
+            id: course.id,
+            name: course.name,
+            weighted,
+            grading_standard_id: course.grading_standard_id ?? null,
+          },
+          groups: groupOutputs,
+          totals: { current: totalsCurrent, final: totalsFinal },
+          caveats,
+        }
+      },
+    },
+  ]
+}

--- a/src/tools/grade-explanation.ts
+++ b/src/tools/grade-explanation.ts
@@ -113,7 +113,7 @@ function classify(
   }
   const pinned = neverDrop.has(assignment.id)
   if (sub?.workflow_state === 'graded' && sub.score !== null) {
-    return { ...base, status: 'graded', score: sub.score ?? null, pinned }
+    return { ...base, status: 'graded', score: sub.score, pinned }
   }
   if (sub?.workflow_state === 'submitted' || sub?.workflow_state === 'pending_review') {
     return { ...base, status: 'submitted', score: null, pinned }

--- a/src/tools/grade-explanation.ts
+++ b/src/tools/grade-explanation.ts
@@ -491,14 +491,24 @@ export function gradeExplanationTools(
         const caveats: string[] = []
 
         const enrollment = selectGradedEnrollment(enrollments)
-        // Reconciliation needs an enrollment that actually carries `grades`.
-        // An empty list OR an enrollment without a grades object (observer/TA
-        // records, hidden final grades) both leave posted scores unavailable —
-        // surface that rather than returning a silent null reconciliation.
+        // Reconciliation needs an enrollment that actually carries posted scores.
+        // Two distinct "unavailable" cases must each be surfaced rather than
+        // returning a silent null reconciliation:
+        //   1. no enrollment / no grades object (empty list, observer/TA records);
+        //   2. a grades object whose current_score AND final_score are both null
+        //      (muted/hidden grades, or no grade posted yet).
         if (!enrollment?.grades) {
           caveats.push(
             'No student enrollment found with posted grades for this course — Canvas posted ' +
               'scores are unavailable.',
+          )
+        } else if (
+          enrollment.grades.current_score == null &&
+          enrollment.grades.final_score == null
+        ) {
+          caveats.push(
+            'Canvas has not posted a current or final score for this student (grades may be ' +
+              'hidden or not yet released), so the reconciliation could not be performed.',
           )
         }
 

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(134)
+    expect(manifest.tools).toHaveLength(135)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/pseudonym/coverage.test.ts
+++ b/tests/pseudonym/coverage.test.ts
@@ -27,6 +27,7 @@ const EXPECTED_PII_BEARING_TOOLS = new Set([
   'list_group_members',
   'list_submission_comments_needing_attention',
   'list_students_needing_attention',
+  'explain_grade',
 ])
 
 function buildMinimalCanvas(): CanvasClient {

--- a/tests/tools/grade-explanation.test.ts
+++ b/tests/tools/grade-explanation.test.ts
@@ -416,6 +416,32 @@ describe('explain_grade — Fixture F (pseudonymization)', () => {
     )
     expect(result.student.name).toBe('Real Name')
   })
+
+  it('leaves a staff member fetched by id un-pseudonymized (real enrollment types)', async () => {
+    const ps = new Pseudonymizer({
+      baseUrl: 'https://school.instructure.com/api/v1',
+      rootDir: tmpRoot,
+      env: { CANVAS_PSEUDONYMIZE_STUDENTS: 'true' },
+    })
+    const result = await run(
+      {
+        course: {
+          id: 1,
+          name: 'Course',
+          apply_assignment_group_weights: false,
+          grading_standard_id: null,
+        },
+        groups: [],
+        user: { id: 555, name: 'Dr. Teacher' },
+        // enrollments fetched for the target id carry a staff type → not student
+        enrollments: [{ type: 'TeacherEnrollment', grades: { current_score: null } }],
+        pseudonymizer: ps,
+      },
+      { course_id: 1, student_id: 555 },
+    )
+    expect(result.student.name).toBe('Dr. Teacher')
+    expect(result.student.id).toBe(555)
+  })
 })
 
 // ── Fixture G — missing enrollment ───────────────────────────────────────────
@@ -717,6 +743,43 @@ describe('explain_grade — robustness', () => {
     expect(result.caveats.some((c) => c.includes('Canvas posted scores are unavailable'))).toBe(
       true,
     )
+  })
+
+  it('caveats when the enrollment carries grades but the posted scores are null', async () => {
+    const result = await run({
+      course: {
+        id: 1,
+        name: 'C',
+        apply_assignment_group_weights: false,
+        grading_standard_id: null,
+      },
+      groups: [
+        {
+          id: 1,
+          name: 'G',
+          position: 1,
+          group_weight: 0,
+          assignments: [{ id: 1, name: 'A1', points_possible: 10, grading_type: 'points' }],
+        },
+      ],
+      submissions: [graded(1, 8)],
+      // grades object exists, but Canvas has posted no score (hidden/unreleased)
+      enrollments: [
+        {
+          type: 'StudentEnrollment',
+          grades: {
+            current_score: null,
+            current_grade: null,
+            final_score: null,
+            final_grade: null,
+          },
+        },
+      ],
+    })
+    expect(result.totals.current.canvas_posted_score).toBeNull()
+    expect(result.totals.current.matches).toBeNull()
+    expect(result.totals.current.discrepancy).toBeNull()
+    expect(result.caveats.some((c) => c.includes('has not posted'))).toBe(true)
   })
 
   it('treats a null/absent points_possible as zero without poisoning the total', async () => {

--- a/tests/tools/grade-explanation.test.ts
+++ b/tests/tools/grade-explanation.test.ts
@@ -516,3 +516,281 @@ describe('explain_grade — tool metadata', () => {
     await expect(tool(canvas).handler({ course_id: 1 })).rejects.toThrow(CanvasApiError)
   })
 })
+
+// ── Grading-standard resolution (course vs. account fallback) ─────────────────
+
+describe('explain_grade — grading standard resolution', () => {
+  const oneGradedGroup = [
+    {
+      id: 1,
+      name: 'G',
+      position: 1,
+      group_weight: 0,
+      assignments: [{ id: 1, name: 'A1', points_possible: 100, grading_type: 'points' }],
+    },
+  ]
+
+  it('falls back to the account standard when the course list has no match', async () => {
+    const canvas = buildMockCanvas({
+      course: {
+        id: 1,
+        name: 'Course',
+        apply_assignment_group_weights: false,
+        grading_standard_id: 99,
+        account_id: 7,
+      },
+      groups: oneGradedGroup,
+      submissions: [graded(1, 95)],
+      courseStandards: [], // no course-level match
+      accountStandards: [
+        {
+          id: 99,
+          title: 'Acct',
+          context_type: 'Account',
+          context_id: 7,
+          grading_scheme: GRADING_SCHEME,
+        },
+      ],
+    })
+    const result = (await tool(canvas).handler({ course_id: 1 })) as GradeExplanation
+    expect(result.totals.current.letter).toBe('A') // 95% → 0.95 ≥ 0.9
+    expect(canvas.gradingStandards.listForAccount).toHaveBeenCalledWith(7)
+  })
+
+  it('does not query the account when the course standard already matches', async () => {
+    const canvas = buildMockCanvas({
+      course: {
+        id: 1,
+        name: 'Course',
+        apply_assignment_group_weights: false,
+        grading_standard_id: 42,
+        account_id: 7,
+      },
+      groups: oneGradedGroup,
+      submissions: [graded(1, 95)],
+      courseStandards: [
+        {
+          id: 42,
+          title: 'Std',
+          context_type: 'Course',
+          context_id: 1,
+          grading_scheme: GRADING_SCHEME,
+        },
+      ],
+    })
+    const result = (await tool(canvas).handler({ course_id: 1 })) as GradeExplanation
+    expect(result.totals.current.letter).toBe('A')
+    expect(canvas.gradingStandards.listForAccount).not.toHaveBeenCalled()
+  })
+
+  it('caveats and yields a null letter when the standard cannot be resolved', async () => {
+    const result = await run({
+      course: {
+        id: 1,
+        name: 'Course',
+        apply_assignment_group_weights: false,
+        grading_standard_id: 5,
+        account_id: null,
+      },
+      groups: oneGradedGroup,
+      submissions: [graded(1, 95)],
+      courseStandards: [], // no match, and no account to fall back to
+    })
+    expect(result.caveats.some((c) => c.includes('could not be'))).toBe(true)
+    expect(result.totals.current.letter).toBeNull()
+    expect(result.totals.current.computed_percentage).toBeCloseTo(95, 5)
+  })
+})
+
+// ── Weighted edge cases (renormalization, redistribution, no weights) ─────────
+
+describe('explain_grade — weighted edge cases', () => {
+  it('renormalizes by active weight when a weighted group has no graded work', async () => {
+    const result = await run({
+      course: { id: 1, name: 'C', apply_assignment_group_weights: true, grading_standard_id: null },
+      groups: [
+        {
+          id: 1,
+          name: 'Empty',
+          position: 1,
+          group_weight: 30,
+          assignments: [{ id: 1, name: 'A1', points_possible: 10, grading_type: 'points' }],
+        },
+        {
+          id: 2,
+          name: 'Exams',
+          position: 2,
+          group_weight: 70,
+          assignments: [{ id: 2, name: 'Exam', points_possible: 100, grading_type: 'points' }],
+        },
+      ],
+      submissions: [graded(2, 80)], // group 1 has no submission → no graded work
+    })
+    // Group 1 (weight 30) excluded from current normalization → overall == 80%
+    expect(result.totals.current.computed_percentage).toBeCloseTo(80, 5)
+    expect(result.caveats.some((c) => c.includes('redistributed'))).toBe(true)
+  })
+
+  it('returns a null overall (no caveat) when no group has graded work', async () => {
+    const result = await run({
+      course: { id: 1, name: 'C', apply_assignment_group_weights: true, grading_standard_id: null },
+      groups: [
+        {
+          id: 1,
+          name: 'G1',
+          position: 1,
+          group_weight: 50,
+          assignments: [{ id: 1, name: 'A1', points_possible: 10, grading_type: 'points' }],
+        },
+      ],
+      submissions: [], // nothing graded anywhere
+    })
+    expect(result.totals.current.computed_percentage).toBeNull()
+  })
+
+  it('caveats a weighted course that has no configured group weights', async () => {
+    const result = await run({
+      course: { id: 1, name: 'C', apply_assignment_group_weights: true, grading_standard_id: null },
+      groups: [
+        {
+          id: 1,
+          name: 'G1',
+          position: 1,
+          group_weight: 0,
+          assignments: [{ id: 1, name: 'A1', points_possible: 100, grading_type: 'points' }],
+        },
+      ],
+      submissions: [graded(1, 90)],
+    })
+    expect(result.totals.current.computed_percentage).toBeNull()
+    expect(result.caveats.some((c) => c.includes('no group weights are configured'))).toBe(true)
+  })
+})
+
+// ── Final-mode reconciliation ────────────────────────────────────────────────
+
+describe('explain_grade — final-mode reconciliation', () => {
+  it('reconciles the final column and fires the curve caveat off a final discrepancy', async () => {
+    const result = await run({
+      ...FIXTURE_A,
+      enrollments: [
+        {
+          type: 'StudentEnrollment',
+          grades: { current_score: 78.05, current_grade: 'C', final_score: 85, final_grade: 'B' },
+        },
+      ],
+    })
+    expect(result.totals.current.matches).toBe(true) // current reconciles
+    expect(result.totals.final.canvas_posted_score).toBe(85)
+    expect(result.totals.final.canvas_posted_letter).toBe('B')
+    expect(result.totals.final.discrepancy).toBeCloseTo(6.95, 2)
+    expect(result.totals.final.matches).toBe(false)
+    // curve caveat is driven by the (larger) final-mode discrepancy
+    expect(result.caveats.some((c) => c.includes('curve') || c.includes('fudge'))).toBe(true)
+  })
+})
+
+// ── Robustness: enrollment-without-grades, null points, never_drop, not_graded ─
+
+describe('explain_grade — robustness', () => {
+  it('caveats when an enrollment exists but carries no grades', async () => {
+    const result = await run({
+      course: {
+        id: 1,
+        name: 'C',
+        apply_assignment_group_weights: false,
+        grading_standard_id: null,
+      },
+      groups: [
+        {
+          id: 1,
+          name: 'G',
+          position: 1,
+          group_weight: 0,
+          assignments: [{ id: 1, name: 'A1', points_possible: 10, grading_type: 'points' }],
+        },
+      ],
+      submissions: [graded(1, 8)],
+      enrollments: [{ type: 'ObserverEnrollment' }], // present, but no `grades`
+    })
+    expect(result.totals.current.canvas_posted_score).toBeNull()
+    expect(result.caveats.some((c) => c.includes('Canvas posted scores are unavailable'))).toBe(
+      true,
+    )
+  })
+
+  it('treats a null/absent points_possible as zero without poisoning the total', async () => {
+    const result = await run({
+      course: {
+        id: 1,
+        name: 'C',
+        apply_assignment_group_weights: false,
+        grading_standard_id: null,
+      },
+      groups: [
+        {
+          id: 1,
+          name: 'G',
+          position: 1,
+          group_weight: 0,
+          assignments: [
+            { id: 1, name: 'A1', points_possible: 10, grading_type: 'points' },
+            { id: 2, name: 'EC', points_possible: null, grading_type: 'points' },
+          ],
+        },
+      ],
+      submissions: [graded(1, 8), graded(2, 5)],
+    })
+    const group = findGroup(result, 1)
+    // The null-points item contributes its score to earned but 0 to possible
+    // (extra-credit semantics) — and never produces NaN/null.
+    expect(group.current.possible_points).toBe(10)
+    expect(group.current.earned_points).toBe(13)
+    expect(findAssignment(group, 2).points_possible).toBe(0)
+    expect(Number.isFinite(result.totals.current.computed_percentage)).toBe(true)
+    expect(result.totals.current.computed_percentage).toBeCloseTo(130, 5)
+  })
+
+  it('keeps a never_drop missing assignment and excludes not_graded from totals', async () => {
+    const result = await run({
+      course: {
+        id: 1,
+        name: 'C',
+        apply_assignment_group_weights: false,
+        grading_standard_id: null,
+      },
+      groups: [
+        {
+          id: 1,
+          name: 'G',
+          position: 1,
+          group_weight: 0,
+          rules: { drop_lowest: 1, never_drop: [1] },
+          assignments: [
+            { id: 1, name: 'Pinned', points_possible: 10, grading_type: 'points' },
+            { id: 2, name: 'High', points_possible: 10, grading_type: 'points' },
+            { id: 3, name: 'Low', points_possible: 10, grading_type: 'points' },
+            { id: 4, name: 'Survey', points_possible: 10, grading_type: 'not_graded' },
+          ],
+        },
+      ],
+      // A1 missing (no submission); A2/A3 graded; A4 not_graded
+      submissions: [graded(2, 8), graded(3, 4)],
+    })
+    const group = findGroup(result, 1)
+    expect(findAssignment(group, 1)).toMatchObject({ status: 'missing', dropped: false })
+    expect(findAssignment(group, 4).status).toBe('not_graded')
+    // current: A3 dropped (drop_lowest), A1 missing excluded → only A2 counts → 8/10
+    expect(group.current.earned_points).toBe(8)
+    expect(group.current.possible_points).toBe(10)
+    // final: pinned-missing A1 adds 10 possible / 0 earned; A2 8/10; A3 dropped; A4 excluded
+    expect(group.final.earned_points).toBe(8)
+    expect(group.final.possible_points).toBe(20)
+  })
+
+  it('caveats when the assignment_group_id filter matches no group', async () => {
+    const result = await run(FIXTURE_A, { course_id: 1, assignment_group_id: 999 })
+    expect(result.groups).toHaveLength(0)
+    expect(result.caveats.some((c) => c.includes('was not found in this course'))).toBe(true)
+  })
+})

--- a/tests/tools/grade-explanation.test.ts
+++ b/tests/tools/grade-explanation.test.ts
@@ -1,0 +1,518 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CanvasClient } from '../../src/canvas'
+import { CanvasApiError } from '../../src/canvas/client'
+import { Pseudonymizer } from '../../src/pseudonym/pseudonymizer'
+import { gradeExplanationTools } from '../../src/tools/grade-explanation'
+
+// ── Output shape (mirrors the tool contract; partial for assertion typing) ───
+
+interface AssignmentOut {
+  assignment_id: number
+  assignment_name: string
+  points_possible: number
+  score: number | null
+  status: string
+  dropped: boolean
+  drop_reason: string | null
+}
+
+interface ModeBlock {
+  earned_points: number
+  possible_points: number
+  percentage: number | null
+  weighted_contribution: number | null
+}
+
+interface GroupOut {
+  group_id: number
+  group_name: string
+  group_weight: number
+  rules: { drop_lowest: number; drop_highest: number; never_drop: number[] }
+  assignments: AssignmentOut[]
+  current: ModeBlock
+  final: ModeBlock
+}
+
+interface TotalsBlock {
+  computed_percentage: number | null
+  canvas_posted_score: number | null
+  discrepancy: number | null
+  matches: boolean | null
+  letter: string | null
+  canvas_posted_letter: string | null
+}
+
+interface GradeExplanation {
+  student: { id: number; name: string }
+  course: { id: number; name: string; weighted: boolean; grading_standard_id: number | null }
+  groups: GroupOut[]
+  totals: { current: TotalsBlock; final: TotalsBlock }
+  caveats: string[]
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const GRADING_SCHEME = [
+  { name: 'A', value: 0.9 },
+  { name: 'B', value: 0.8 },
+  { name: 'C', value: 0.7 },
+  { name: 'F', value: 0.0 },
+]
+
+interface MockOverrides {
+  course?: unknown
+  groups?: unknown[]
+  submissions?: unknown[]
+  enrollments?: unknown[]
+  user?: unknown
+  courseStandards?: unknown[]
+  accountStandards?: unknown[]
+  pseudonymizer?: Pseudonymizer
+}
+
+function buildMockCanvas(overrides: MockOverrides = {}): CanvasClient {
+  return {
+    courses: {
+      get: vi.fn().mockResolvedValue(overrides.course ?? { id: 1, name: 'Course' }),
+    },
+    assignments: {
+      listGroups: vi.fn().mockResolvedValue(overrides.groups ?? []),
+    },
+    submissions: {
+      listMy: vi.fn().mockResolvedValue(overrides.submissions ?? []),
+      listForStudents: vi.fn().mockResolvedValue(overrides.submissions ?? []),
+    },
+    enrollments: {
+      listForCourse: vi.fn().mockResolvedValue(overrides.enrollments ?? []),
+    },
+    users: {
+      getSelf: vi.fn().mockResolvedValue(overrides.user ?? { id: 1, name: 'Self User' }),
+      get: vi.fn().mockResolvedValue(overrides.user ?? { id: 1, name: 'Self User' }),
+    },
+    gradingStandards: {
+      listForCourse: vi.fn().mockResolvedValue(overrides.courseStandards ?? []),
+      listForAccount: vi.fn().mockResolvedValue(overrides.accountStandards ?? []),
+    },
+  } as unknown as CanvasClient
+}
+
+function tool(canvas: CanvasClient, pseudonymizer?: Pseudonymizer) {
+  return gradeExplanationTools(canvas, pseudonymizer)[0]
+}
+
+async function run(
+  overrides: MockOverrides,
+  params: Record<string, unknown> = { course_id: 1 },
+): Promise<GradeExplanation> {
+  const canvas = buildMockCanvas(overrides)
+  return (await tool(canvas, overrides.pseudonymizer).handler(params)) as GradeExplanation
+}
+
+function graded(assignment_id: number, score: number): unknown {
+  return { assignment_id, workflow_state: 'graded', score }
+}
+
+function findGroup(result: GradeExplanation, id: number): GroupOut {
+  return result.groups.find((g) => g.group_id === id)!
+}
+
+function findAssignment(group: GroupOut, id: number): AssignmentOut {
+  return group.assignments.find((a) => a.assignment_id === id)!
+}
+
+// ── Fixture A — weighted, drop_lowest + never_drop ───────────────────────────
+
+const FIXTURE_A: MockOverrides = {
+  course: {
+    id: 1,
+    name: 'Bio 101',
+    apply_assignment_group_weights: true,
+    grading_standard_id: 42,
+    account_id: 7,
+  },
+  groups: [
+    {
+      id: 1,
+      name: 'Homework',
+      position: 1,
+      group_weight: 30,
+      rules: { drop_lowest: 1, never_drop: [3] },
+      assignments: [
+        { id: 1, name: 'HW1', points_possible: 10, grading_type: 'points' },
+        { id: 2, name: 'HW2', points_possible: 10, grading_type: 'points' },
+        { id: 3, name: 'HW3', points_possible: 10, grading_type: 'points' },
+      ],
+    },
+    {
+      id: 2,
+      name: 'Exams',
+      position: 2,
+      group_weight: 70,
+      assignments: [
+        { id: 4, name: 'Midterm', points_possible: 100, grading_type: 'points' },
+        { id: 5, name: 'Final', points_possible: 100, grading_type: 'points' },
+      ],
+    },
+  ],
+  submissions: [graded(1, 8), graded(2, 5), graded(3, 6), graded(4, 88), graded(5, 75)],
+  courseStandards: [
+    {
+      id: 42,
+      title: 'Standard',
+      context_type: 'Course',
+      context_id: 1,
+      grading_scheme: GRADING_SCHEME,
+    },
+  ],
+}
+
+describe('explain_grade — Fixture A (weighted, drop_lowest + never_drop)', () => {
+  it('drops the lowest droppable score and pins the never_drop assignment', async () => {
+    const result = await run(FIXTURE_A)
+    const homework = findGroup(result, 1)
+    expect(findAssignment(homework, 2)).toMatchObject({ dropped: true, drop_reason: 'drop_lowest' })
+    expect(findAssignment(homework, 3)).toMatchObject({ dropped: false, drop_reason: null })
+    // Homework retained: HW1 (8) + HW3 (6) = 14/20 → 70%
+    expect(homework.current.earned_points).toBe(14)
+    expect(homework.current.possible_points).toBe(20)
+    expect(homework.current.percentage).toBeCloseTo(70, 5)
+    expect(homework.current.weighted_contribution).toBeCloseTo(21, 5)
+  })
+
+  it('computes the weighted overall percentage and maps the letter', async () => {
+    const result = await run(FIXTURE_A)
+    expect(result.course.weighted).toBe(true)
+    expect(result.totals.current.computed_percentage).toBeCloseTo(78.05, 2)
+    expect(result.totals.current.letter).toBe('C')
+  })
+})
+
+// ── Fixture B — unweighted, no drop rules ────────────────────────────────────
+
+describe('explain_grade — Fixture B (unweighted)', () => {
+  const fixture: MockOverrides = {
+    course: {
+      id: 1,
+      name: 'Math 200',
+      apply_assignment_group_weights: false,
+      grading_standard_id: null,
+    },
+    groups: [
+      {
+        id: 1,
+        name: 'Group A',
+        position: 1,
+        group_weight: 0,
+        assignments: [{ id: 1, name: 'A1', points_possible: 100, grading_type: 'points' }],
+      },
+      {
+        id: 2,
+        name: 'Group B',
+        position: 2,
+        group_weight: 0,
+        assignments: [{ id: 2, name: 'B1', points_possible: 50, grading_type: 'points' }],
+      },
+    ],
+    submissions: [graded(1, 90), graded(2, 40)],
+  }
+
+  it('reports weighted=false and null weighted_contribution', async () => {
+    const result = await run(fixture)
+    expect(result.course.weighted).toBe(false)
+    for (const group of result.groups) {
+      expect(group.current.weighted_contribution).toBeNull()
+      expect(group.final.weighted_contribution).toBeNull()
+    }
+  })
+
+  it('totals the raw points across groups regardless of weight', async () => {
+    const result = await run(fixture)
+    // 130 / 150 = 86.67%
+    expect(result.totals.current.computed_percentage).toBeCloseTo(86.67, 2)
+    expect(result.totals.current.letter).toBeNull()
+  })
+})
+
+// ── Fixture C — reconciliation: match vs discrepancy ─────────────────────────
+
+describe('explain_grade — Fixture C (reconciliation)', () => {
+  it('flags a match within the 0.5pp tolerance', async () => {
+    const result = await run({
+      ...FIXTURE_A,
+      enrollments: [
+        {
+          type: 'StudentEnrollment',
+          grades: { current_score: 78.1, current_grade: 'C', final_score: null, final_grade: null },
+        },
+      ],
+    })
+    expect(result.totals.current.canvas_posted_score).toBe(78.1)
+    expect(result.totals.current.discrepancy).toBeCloseTo(0.05, 2)
+    expect(result.totals.current.matches).toBe(true)
+    expect(result.totals.current.canvas_posted_letter).toBe('C')
+    expect(result.caveats.some((c) => c.includes('curve'))).toBe(false)
+  })
+
+  it('flags a discrepancy beyond tolerance and adds a curve caveat', async () => {
+    const result = await run({
+      ...FIXTURE_A,
+      enrollments: [
+        {
+          type: 'StudentEnrollment',
+          grades: { current_score: 81.0, current_grade: 'B', final_score: null, final_grade: null },
+        },
+      ],
+    })
+    expect(result.totals.current.discrepancy).toBeCloseTo(2.95, 2)
+    expect(result.totals.current.matches).toBe(false)
+    expect(result.caveats.some((c) => c.includes('curve') || c.includes('fudge'))).toBe(true)
+  })
+})
+
+// ── Fixture D — excused + missing + submitted/pending ────────────────────────
+
+describe('explain_grade — Fixture D (excused / missing / pending)', () => {
+  const fixture: MockOverrides = {
+    course: {
+      id: 1,
+      name: 'Hist 101',
+      apply_assignment_group_weights: false,
+      grading_standard_id: null,
+    },
+    groups: [
+      {
+        id: 1,
+        name: 'Work',
+        position: 1,
+        group_weight: 0,
+        assignments: [
+          { id: 1, name: 'A1', points_possible: 10, grading_type: 'points' },
+          { id: 2, name: 'A2', points_possible: 10, grading_type: 'points' },
+          { id: 3, name: 'A3', points_possible: 10, grading_type: 'points' },
+          { id: 4, name: 'A4', points_possible: 10, grading_type: 'points' },
+        ],
+      },
+    ],
+    submissions: [
+      graded(1, 8),
+      { assignment_id: 2, workflow_state: 'graded', score: null, excused: true },
+      { assignment_id: 3, workflow_state: 'unsubmitted', score: null, missing: true },
+      { assignment_id: 4, workflow_state: 'pending_review', score: null },
+    ],
+  }
+
+  it('classifies excused, missing, and pending_review correctly', async () => {
+    const group = findGroup(await run(fixture), 1)
+    expect(findAssignment(group, 2)).toMatchObject({ status: 'excused', dropped: false })
+    expect(findAssignment(group, 3).status).toBe('missing')
+    expect(findAssignment(group, 4).status).toBe('submitted')
+  })
+
+  it('counts only graded work in current mode, all non-excused in final mode', async () => {
+    const group = findGroup(await run(fixture), 1)
+    expect(group.current.earned_points).toBe(8)
+    expect(group.current.possible_points).toBe(10)
+    expect(group.final.earned_points).toBe(8)
+    expect(group.final.possible_points).toBe(30)
+  })
+})
+
+// ── Fixture E — drop_highest (bonus exclusion) ───────────────────────────────
+
+describe('explain_grade — Fixture E (drop_highest)', () => {
+  const fixture: MockOverrides = {
+    course: {
+      id: 1,
+      name: 'Phys 101',
+      apply_assignment_group_weights: false,
+      grading_standard_id: null,
+    },
+    groups: [
+      {
+        id: 1,
+        name: 'Quizzes',
+        position: 1,
+        group_weight: 0,
+        rules: { drop_highest: 1 },
+        assignments: [
+          { id: 1, name: 'Q1', points_possible: 10, grading_type: 'points' },
+          { id: 2, name: 'Q2', points_possible: 10, grading_type: 'points' },
+          { id: 3, name: 'Q3', points_possible: 10, grading_type: 'points' },
+          { id: 4, name: 'Q4', points_possible: 10, grading_type: 'points' },
+        ],
+      },
+    ],
+    submissions: [graded(1, 10), graded(2, 8), graded(3, 6), graded(4, 4)],
+  }
+
+  it('drops the highest-ratio assignment and recomputes', async () => {
+    const group = findGroup(await run(fixture), 1)
+    expect(findAssignment(group, 1)).toMatchObject({ dropped: true, drop_reason: 'drop_highest' })
+    // retained Q2+Q3+Q4 = 18/30 → 60%
+    expect(group.current.percentage).toBeCloseTo(60, 5)
+  })
+})
+
+// ── Fixture F — FERPA pseudonymization ───────────────────────────────────────
+
+describe('explain_grade — Fixture F (pseudonymization)', () => {
+  let tmpRoot: string
+  beforeEach(async () => {
+    tmpRoot = await mkdtemp(join(tmpdir(), 'grade-explain-'))
+  })
+  afterEach(async () => {
+    await rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('pseudonymizes a specified student but preserves the numeric id', async () => {
+    const ps = new Pseudonymizer({
+      baseUrl: 'https://school.instructure.com/api/v1',
+      rootDir: tmpRoot,
+      env: { CANVAS_PSEUDONYMIZE_STUDENTS: 'true' },
+    })
+    const result = await run(
+      {
+        course: {
+          id: 1,
+          name: 'Course',
+          apply_assignment_group_weights: false,
+          grading_standard_id: null,
+        },
+        groups: [],
+        user: { id: 1234, name: 'Alice Student' },
+        pseudonymizer: ps,
+      },
+      { course_id: 1, student_id: 1234 },
+    )
+    // Pseudonymizer replaces the real name with a stable "Student N" label
+    // (Canvas's pseudonym index starts at 1) but preserves the numeric id.
+    expect(result.student.name).toMatch(/^Student \d+$/)
+    expect(result.student.name).not.toBe('Alice Student')
+    expect(result.student.id).toBe(1234)
+  })
+
+  it('does not pseudonymize the authenticated user (self)', async () => {
+    const ps = new Pseudonymizer({
+      baseUrl: 'https://school.instructure.com/api/v1',
+      rootDir: tmpRoot,
+      env: { CANVAS_PSEUDONYMIZE_STUDENTS: 'true' },
+    })
+    const result = await run(
+      {
+        course: {
+          id: 1,
+          name: 'Course',
+          apply_assignment_group_weights: false,
+          grading_standard_id: null,
+        },
+        groups: [],
+        user: { id: 99, name: 'Real Name' },
+        pseudonymizer: ps,
+      },
+      { course_id: 1 },
+    )
+    expect(result.student.name).toBe('Real Name')
+  })
+})
+
+// ── Fixture G — missing enrollment ───────────────────────────────────────────
+
+describe('explain_grade — Fixture G (missing enrollment)', () => {
+  it('returns null posted scores, a caveat, and still computes the grade', async () => {
+    const result = await run({
+      course: {
+        id: 1,
+        name: 'Course',
+        apply_assignment_group_weights: false,
+        grading_standard_id: null,
+      },
+      groups: [
+        {
+          id: 1,
+          name: 'Work',
+          position: 1,
+          group_weight: 0,
+          assignments: [{ id: 1, name: 'A1', points_possible: 10, grading_type: 'points' }],
+        },
+      ],
+      submissions: [graded(1, 9)],
+      enrollments: [],
+    })
+    expect(result.totals.current.canvas_posted_score).toBeNull()
+    expect(result.totals.current.discrepancy).toBeNull()
+    expect(result.totals.current.matches).toBeNull()
+    expect(result.caveats.some((c) => c.includes('No student enrollment found'))).toBe(true)
+    expect(result.totals.current.computed_percentage).toBeCloseTo(90, 5)
+  })
+})
+
+// ── Fixture H — greedy fallback for pathologically large groups ──────────────
+
+describe('explain_grade — Fixture H (greedy cap)', () => {
+  it('falls back to a greedy drop and adds a caveat when combinations explode', async () => {
+    // 16 assignments, drop_lowest 8 → C(16,8) = 12_870 > 10_000 cap.
+    const assignments = Array.from({ length: 16 }, (_, i) => ({
+      id: i + 1,
+      name: `A${i + 1}`,
+      points_possible: 10,
+      grading_type: 'points',
+    }))
+    // Scores 0..15; greedy keeps the top 8 (scores 8..15), sum 92 / 80 = 115%? no:
+    // retained 8 highest scores = 8+9+10+11+12+13+14+15 = 92 over 80 possible.
+    const submissions = assignments.map((a, i) => graded(a.id, i))
+    const result = await run({
+      course: {
+        id: 1,
+        name: 'Big',
+        apply_assignment_group_weights: false,
+        grading_standard_id: null,
+      },
+      groups: [
+        {
+          id: 1,
+          name: 'Daily',
+          position: 1,
+          group_weight: 0,
+          rules: { drop_lowest: 8 },
+          assignments,
+        },
+      ],
+      submissions,
+    })
+    const group = findGroup(result, 1)
+    expect(group.current.possible_points).toBe(80)
+    expect(group.current.earned_points).toBe(92)
+    expect(result.caveats.some((c) => c.includes('greedy approximation'))).toBe(true)
+  })
+})
+
+// ── Tool metadata + error propagation ────────────────────────────────────────
+
+describe('explain_grade — tool metadata', () => {
+  it('exposes a single read-only, open-world tool', () => {
+    const tools = gradeExplanationTools(buildMockCanvas())
+    expect(tools).toHaveLength(1)
+    expect(tools[0].name).toBe('explain_grade')
+    expect(tools[0].annotations.readOnlyHint).toBe(true)
+    expect(tools[0].annotations.openWorldHint).toBe(true)
+    expect(tools[0].annotations.destructiveHint).toBe(false)
+  })
+
+  it('filters to a single assignment group and caveats the partial total', async () => {
+    const result = await run(FIXTURE_A, { course_id: 1, assignment_group_id: 2 })
+    expect(result.groups).toHaveLength(1)
+    expect(result.groups[0].group_id).toBe(2)
+    expect(result.caveats.some((c) => c.includes('filtered to assignment group'))).toBe(true)
+  })
+
+  it('does not swallow Canvas errors', async () => {
+    const canvas = buildMockCanvas(FIXTURE_A)
+    ;(canvas.courses.get as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new CanvasApiError('Not Found', 404, '/api/v1/courses/1'),
+    )
+    await expect(tool(canvas).handler({ course_id: 1 })).rejects.toThrow(CanvasApiError)
+  })
+})

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -189,7 +189,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 134 tools across all domains', () => {
+  it('returns all 135 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 
@@ -356,8 +356,10 @@ describe('getAllTools', () => {
     expect(names).toContain('set_student_assignment_dates')
     // Course Setup (1)
     expect(names).toContain('check_course_setup')
+    // Grade Explanation (1)
+    expect(names).toContain('explain_grade')
 
-    expect(tools).toHaveLength(134)
+    expect(tools).toHaveLength(135)
   })
 
   it('all tools have openWorldHint: true', () => {


### PR DESCRIPTION
## Summary

Implements the approved spec for #206 (`docs/superpowers/specs/2026-06-20-issue-206-explain-grade.md`).

> **User story:** As an instructor (or a student) using Claude, I want to recompute and *explain* a course grade — weighted assignment groups, dropped low/high scores, and the raw→weighted→letter path — so I can trust the number Canvas shows me instead of rebuilding it in a parallel spreadsheet, and quickly spot where a posted total diverges from what the rules imply.

Adds one read-only tool, **`explain_grade`**, that recomputes and explains a Canvas course grade for a single student and reconciles it against Canvas's posted scores.

## Approach

- **Drop rules** — brute-force combinatorial search honoring `never_drop`, choosing the drop set that maximises the retained percentage for `drop_lowest` and minimises it for `drop_highest` (Canvas's documented order: `drop_highest` first). A `binomial()` pre-check falls back to a greedy ranked drop past a 10 000-combination safety cap and emits a caveat.
- **current vs. final columns** — both are computed and exposed; `current` counts only graded work, `final` scores missing/pending as 0, excused and `not_graded` are excluded from both.
- **Letter mapping** via the course grading standard (account-scoped fallback), decimal-fraction cutoffs sorted descending.
- **Reconciliation** — ±0.5 pp tolerance → `matches`; a curve/fudge-points caveat is surfaced when the discrepancy exceeds tolerance (suppressed in single-group filter mode, where a large gap is expected).
- **Canvas-only** — composes existing `CanvasClient` facade methods (`courses.get`, `assignments.listGroups`, `submissions.listMy`/`listForStudents`, `enrollments.listForCourse`, `users.get`/new `getSelf`, `gradingStandards.list*`). No new endpoints, no new dependencies.
- **FERPA** — per-student output routes through `pseudonymizer.anonymizeUser` (skipped for `self`); `explain_grade` added to `PSEUDONYMIZER_WRAPPED_TOOLS`.

## Files

`src/tools/grade-explanation.ts` (new), `src/canvas/users.ts` (+`getSelf`), `src/tools/catalog.ts`, `src/pseudonym/coverage.ts`, `tests/tools/grade-explanation.test.ts` (new, fixtures A–H), plus tool-count bumps (134→135) in the registry/manifest tests and the regenerated `docs/generated/tool-manifest.json`.

## Deviations from the spec (followed code reality)

- Test file lives at `tests/tools/grade-explanation.test.ts` (repo convention), not `tests/grade-explanation.test.ts`.
- Pseudonym index starts at `Student 1`, not `Student 0` as the spec's Fixture F assumed — the test asserts the `Student N` pattern + preserved numeric id rather than a hard-coded index.

## Test evidence

`pnpm typecheck && pnpm lint && pnpm test && pnpm build` all green locally:

- Tests: **1204 passed | 1 skipped (89 files)** — includes 16 new `explain_grade` cases (weighted + drop_lowest/never_drop, unweighted, reconciliation match/discrepancy, excused/missing/pending, drop_highest, pseudonymization, missing enrollment, greedy cap, filter, error propagation).
- Build: success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
