### PR TITLE
feat(tools): add list_course_submission_files for bulk student-work archiving

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 135,
+  "toolCount": 136,
   "tools": [
     {
       "name": "health_check",
@@ -210,6 +210,18 @@
       "relatedWorkflows": [
         "educator-assignment-review"
       ]
+    },
+    {
+      "name": "list_course_submission_files",
+      "domain": "submission_files",
+      "description": "List every file attachment submitted by students across all assignments in a course. Returns a manifest — one entry per file — including the original filename, a file_id for re-fetching via download_file, content type, and size. Useful for bulk-archiving student work before a course expires or a Free-For-Teacher account is concluded. Outputs are bounded by max_files (default 500); when the limit is hit, truncated is true and truncation_note explains how to retrieve the rest. Download URLs are time-limited (typically 1 hour) — use the returned file_id with download_file to get a fresh URL at download time. When CANVAS_PSEUDONYMIZE_STUDENTS is enabled, user_name is a stable per-course pseudonym (e.g. \"Student 1\"); user_id (the raw numeric Canvas ID) is always returned and works as a stable per-student folder key.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
     },
     {
       "name": "list_rubrics",

--- a/src/pseudonym/coverage.ts
+++ b/src/pseudonym/coverage.ts
@@ -32,6 +32,9 @@ export const PSEUDONYMIZER_WRAPPED_TOOLS: readonly string[] = [
   'list_submissions',
   'get_submission',
 
+  // src/tools/submission-files.ts
+  'list_course_submission_files',
+
   // src/tools/conversations.ts
   'list_conversations',
   'get_conversation',

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -29,6 +29,7 @@ import { newQuizTools } from './new-quizzes'
 import { rubricTools } from './rubrics'
 import { studentTools } from './student'
 import { submissionTools } from './submissions'
+import { submissionFileTools } from './submission-files'
 import type { ToolAudience, ToolDefinition } from './types'
 import { userTools } from './users'
 
@@ -58,6 +59,11 @@ export const toolDomainCatalog: readonly ToolDomainRegistration[] = [
     domain: 'submissions',
     defaultPrimaryAudience: 'educator',
     getTools: submissionTools,
+  },
+  {
+    domain: 'submission_files',
+    defaultPrimaryAudience: 'educator',
+    getTools: submissionFileTools,
   },
   {
     domain: 'rubrics',

--- a/src/tools/submission-files.ts
+++ b/src/tools/submission-files.ts
@@ -1,0 +1,171 @@
+import { z } from 'zod'
+import type { CanvasClient } from '../canvas'
+import type { ListStudentSubmissionsOptions, SubmissionWorkflowState } from '../canvas/submissions'
+import type { Pseudonymizer } from '../pseudonym/pseudonymizer'
+import type { ToolDefinition } from './types'
+
+const WORKFLOW_STATE = ['submitted', 'graded', 'pending_review', 'unsubmitted'] as const
+
+const DEFAULT_MAX_FILES = 500
+const MAX_MAX_FILES = 2000
+
+const URL_EXPIRY_NOTE =
+  'Attachment download URLs are time-limited (typically 1 hour). Use file_id with the download_file tool to re-fetch a fresh URL.'
+
+interface SubmissionFileEntry {
+  assignment_id: number
+  assignment_name: string | null
+  user_id: number
+  user_name: string | null
+  original_filename: string
+  file_id: number
+  download_url: string
+  content_type: string
+  size: number
+  submitted_at: string | null
+  _warning?: string
+}
+
+/**
+ * `list_course_submission_files` — walk every assignment in a course and produce
+ * a flat manifest of every file attachment students have submitted. Read-only
+ * composition of `canvas.submissions.listForStudents`; no new Canvas endpoints.
+ */
+export function submissionFileTools(
+  canvas: CanvasClient,
+  pseudonymizer?: Pseudonymizer,
+): ToolDefinition[] {
+  return [
+    {
+      name: 'list_course_submission_files',
+      description:
+        'List every file attachment submitted by students across all assignments in a course. ' +
+        'Returns a manifest — one entry per file — including the original filename, a file_id for ' +
+        're-fetching via download_file, content type, and size. Useful for bulk-archiving student ' +
+        'work before a course expires or a Free-For-Teacher account is concluded. ' +
+        'Outputs are bounded by max_files (default 500); when the limit is hit, truncated is true ' +
+        'and truncation_note explains how to retrieve the rest. ' +
+        'Download URLs are time-limited (typically 1 hour) — use the returned file_id with ' +
+        'download_file to get a fresh URL at download time. ' +
+        'When CANVAS_PSEUDONYMIZE_STUDENTS is enabled, user_name is a stable per-course pseudonym ' +
+        '(e.g. "Student 1"); user_id (the raw numeric Canvas ID) is always returned and works as a ' +
+        'stable per-student folder key.',
+      inputSchema: {
+        course_id: z.number().int().positive().describe('Canvas course ID.'),
+        assignment_ids: z
+          .array(z.number().int().positive())
+          .optional()
+          .describe('Restrict to these assignment IDs. Omit to scan all assignments.'),
+        student_ids: z
+          .array(z.number().int().positive())
+          .optional()
+          .describe(
+            'Restrict to these student user IDs. Omit to include all students. When ' +
+              'CANVAS_PSEUDONYMIZE_STUDENTS is enabled, pass the real Canvas user_id after ' +
+              'resolving the pseudonym via resolve_pseudonym.',
+          ),
+        workflow_state: z
+          .enum(WORKFLOW_STATE)
+          .optional()
+          .describe('Only include submissions in this workflow state. Omit to include all states.'),
+        attachments_only: z
+          .boolean()
+          .default(true)
+          .describe(
+            'When true (default), skip submissions that have no file attachments. When false, ' +
+              'still only emit file entries but process every submission.',
+          ),
+        max_files: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_MAX_FILES)
+          .default(DEFAULT_MAX_FILES)
+          .describe(
+            `Maximum number of file entries to return (1–${MAX_MAX_FILES}). Default ${DEFAULT_MAX_FILES}. ` +
+              'When the limit is hit, truncated is set to true.',
+          ),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+        const maxFiles = (params.max_files as number | undefined) ?? DEFAULT_MAX_FILES
+        const attachmentsOnly = (params.attachments_only as boolean | undefined) ?? true
+
+        const listOpts: ListStudentSubmissionsOptions = {
+          student_ids: (params.student_ids as number[] | undefined) ?? (['all'] as const),
+          include: ['user', 'assignment'] as const,
+        }
+        if (params.assignment_ids !== undefined)
+          listOpts.assignment_ids = params.assignment_ids as number[]
+        if (params.workflow_state !== undefined)
+          listOpts.workflow_state = params.workflow_state as SubmissionWorkflowState
+
+        const submissions = await canvas.submissions.listForStudents(courseId, listOpts)
+
+        const files: SubmissionFileEntry[] = []
+        let submissionsScanned = 0
+        let truncated = false
+
+        for (const sub of submissions) {
+          submissionsScanned++
+
+          if (attachmentsOnly && (!sub.attachments || sub.attachments.length === 0)) {
+            continue
+          }
+
+          let userId = sub.user_id
+          let userName: string | null = null
+          let warning: string | undefined
+
+          if (sub.user) {
+            const resolvedUser = pseudonymizer?.isEnabled()
+              ? await pseudonymizer.anonymizeUser(courseId, sub.user)
+              : sub.user
+            userId = resolvedUser.id
+            userName = resolvedUser.name
+          } else {
+            warning = 'user data unavailable'
+          }
+
+          for (const att of sub.attachments ?? []) {
+            if (files.length >= maxFiles) {
+              truncated = true
+              break
+            }
+            files.push({
+              assignment_id: sub.assignment_id,
+              assignment_name: sub.assignment?.name ?? null,
+              user_id: userId,
+              user_name: userName,
+              original_filename: att.display_name,
+              file_id: att.id,
+              download_url: att.url,
+              content_type: att.content_type,
+              size: att.size,
+              submitted_at: sub.submitted_at,
+              ...(warning !== undefined ? { _warning: warning } : {}),
+            })
+          }
+
+          if (truncated) break
+        }
+
+        return {
+          course_id: courseId,
+          total_files: files.length,
+          total_submissions_scanned: submissionsScanned,
+          truncated,
+          truncation_note: truncated
+            ? `Results truncated at ${maxFiles} files. Re-run with assignment_ids or student_ids filters to retrieve the remaining files.`
+            : null,
+          url_expiry_note: URL_EXPIRY_NOTE,
+          files,
+        }
+      },
+    },
+  ]
+}

--- a/src/tools/submission-files.ts
+++ b/src/tools/submission-files.ts
@@ -119,7 +119,7 @@ export function submissionFileTools(
 
           let userId = sub.user_id
           let userName: string | null = null
-          let warning: string | undefined
+          let userWarning: string | undefined
 
           if (sub.user) {
             const resolvedUser = pseudonymizer?.isEnabled()
@@ -128,7 +128,7 @@ export function submissionFileTools(
             userId = resolvedUser.id
             userName = resolvedUser.name
           } else {
-            warning = 'user data unavailable'
+            userWarning = 'user data unavailable'
           }
 
           for (const att of sub.attachments ?? []) {
@@ -136,6 +136,14 @@ export function submissionFileTools(
               truncated = true
               break
             }
+            // Canvas can return an attachment whose signed URL is not yet ready
+            // (e.g. a file still processing). Flag it rather than emit a
+            // good-looking entry with a broken download_url; file_id still lets
+            // the caller re-fetch via download_file once it is ready.
+            const attWarning = att.url
+              ? undefined
+              : 'attachment url unavailable (file may still be processing) — retry download_file with file_id'
+            const warning = [userWarning, attWarning].filter(Boolean).join('; ') || undefined
             files.push({
               assignment_id: sub.assignment_id,
               assignment_name: sub.assignment?.name ?? null,
@@ -160,7 +168,7 @@ export function submissionFileTools(
           total_submissions_scanned: submissionsScanned,
           truncated,
           truncation_note: truncated
-            ? `Results truncated at ${maxFiles} files. Re-run with assignment_ids or student_ids filters to retrieve the remaining files.`
+            ? `Results truncated at ${maxFiles} files — the manifest is incomplete. To retrieve the rest, raise max_files (up to ${MAX_MAX_FILES}) and/or re-run scoped to a subset of assignment_ids or student_ids (iterate per assignment to fully cover a large course).`
             : null,
           url_expiry_note: URL_EXPIRY_NOTE,
           files,

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(135)
+    expect(manifest.tools).toHaveLength(136)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/pseudonym/coverage.test.ts
+++ b/tests/pseudonym/coverage.test.ts
@@ -18,6 +18,7 @@ const EXPECTED_PII_BEARING_TOOLS = new Set([
   'list_course_enrollments',
   'list_submissions',
   'get_submission',
+  'list_course_submission_files',
   'list_conversations',
   'get_conversation',
   'list_gradebook_history_submissions',

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -189,7 +189,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 135 tools across all domains', () => {
+  it('returns all 136 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 
@@ -213,6 +213,8 @@ describe('getAllTools', () => {
     expect(names).toContain('get_submission')
     expect(names).toContain('grade_submission')
     expect(names).toContain('comment_on_submission')
+    // Submission Files (1)
+    expect(names).toContain('list_course_submission_files')
     // Rubrics (5)
     expect(names).toContain('list_rubrics')
     expect(names).toContain('get_rubric')
@@ -359,7 +361,7 @@ describe('getAllTools', () => {
     // Grade Explanation (1)
     expect(names).toContain('explain_grade')
 
-    expect(tools).toHaveLength(135)
+    expect(tools).toHaveLength(136)
   })
 
   it('all tools have openWorldHint: true', () => {

--- a/tests/tools/submission-files.test.ts
+++ b/tests/tools/submission-files.test.ts
@@ -322,6 +322,22 @@ describe('submissionFileTools', () => {
       // file_id is still present so the caller can re-fetch once the file is ready.
       expect(result.files[0].file_id).toBe(800)
     })
+
+    it('combines the user and attachment warnings when both apply', async () => {
+      const submissions = [
+        sub({
+          id: 1,
+          assignment_id: 10,
+          user_id: 200,
+          user: undefined,
+          attachments: [att({ id: 801, display_name: 'processing.pdf', url: '' })],
+        }),
+      ]
+      const { canvas } = buildMockCanvas(submissions)
+      const result = (await getTool(canvas).handler({ course_id: 1 })) as Manifest
+      // Both clauses present, user-warning first, joined by '; '.
+      expect(result.files[0]._warning).toMatch(/user data unavailable; attachment url unavailable/)
+    })
   })
 
   // Fixture D — FERPA pseudonymization

--- a/tests/tools/submission-files.test.ts
+++ b/tests/tools/submission-files.test.ts
@@ -241,8 +241,86 @@ describe('submissionFileTools', () => {
       const result = (await getTool(canvas).handler({ course_id: 1, max_files: 3 })) as Manifest
       expect(result.total_files).toBe(3)
       expect(result.truncated).toBe(true)
-      expect(result.truncation_note).toMatch(/Re-run with assignment_ids or student_ids/)
+      // Pin the interpolated max_files in the note, plus the recovery guidance.
+      expect(result.truncation_note).toContain('truncated at 3 files')
+      expect(result.truncation_note).toMatch(/assignment_ids or student_ids/)
       expect(result.total_submissions_scanned).toBe(4)
+    })
+
+    it('cuts mid-submission when max_files falls between a submission’s attachments', async () => {
+      // Two submissions, three attachments each; cap at 4 → 3 from sub 1 plus the
+      // FIRST attachment of sub 2. Pins the inner-loop (mid-submission) cut point
+      // so a refactor to a submission-boundary check (which would overshoot to 6)
+      // is caught.
+      const submissions = [
+        sub({
+          id: 1,
+          assignment_id: 10,
+          user_id: 100,
+          user: { id: 100, name: 'Alice' },
+          attachments: [
+            att({ id: 1, display_name: 'a1.pdf' }),
+            att({ id: 2, display_name: 'a2.pdf' }),
+            att({ id: 3, display_name: 'a3.pdf' }),
+          ],
+        }),
+        sub({
+          id: 2,
+          assignment_id: 10,
+          user_id: 101,
+          user: { id: 101, name: 'Bob' },
+          attachments: [
+            att({ id: 4, display_name: 'b1.pdf' }),
+            att({ id: 5, display_name: 'b2.pdf' }),
+            att({ id: 6, display_name: 'b3.pdf' }),
+          ],
+        }),
+      ]
+      const { canvas } = buildMockCanvas(submissions)
+      const result = (await getTool(canvas).handler({ course_id: 1, max_files: 4 })) as Manifest
+      expect(result.total_files).toBe(4)
+      expect(result.truncated).toBe(true)
+      expect(result.files.map((f) => f.file_id)).toEqual([1, 2, 3, 4])
+      // files[3] is the first attachment of the second submission — the cut is mid-submission.
+      expect(result.files[3].file_id).toBe(4)
+    })
+
+    it('does not flag truncation when files exactly fill max_files', async () => {
+      const submissions = Array.from({ length: 3 }, (_, i) =>
+        sub({
+          id: i + 1,
+          assignment_id: 10,
+          user_id: 100 + i,
+          user: { id: 100 + i, name: `S${i}` },
+          attachments: [att({ id: 700 + i, display_name: `f${i}.pdf` })],
+        }),
+      )
+      const { canvas } = buildMockCanvas(submissions)
+      const result = (await getTool(canvas).handler({ course_id: 1, max_files: 3 })) as Manifest
+      expect(result.total_files).toBe(3)
+      expect(result.truncated).toBe(false)
+      expect(result.truncation_note).toBeNull()
+    })
+  })
+
+  // Attachment whose signed URL is not yet ready (e.g. still processing)
+  describe('missing attachment url', () => {
+    it('flags a warning instead of emitting a silently-broken download entry', async () => {
+      const submissions = [
+        sub({
+          id: 1,
+          assignment_id: 10,
+          user_id: 100,
+          user: { id: 100, name: 'Alice' },
+          attachments: [att({ id: 800, display_name: 'processing.pdf', url: '' })],
+        }),
+      ]
+      const { canvas } = buildMockCanvas(submissions)
+      const result = (await getTool(canvas).handler({ course_id: 1 })) as Manifest
+      expect(result.total_files).toBe(1)
+      expect(result.files[0]._warning).toContain('attachment url unavailable')
+      // file_id is still present so the caller can re-fetch once the file is ready.
+      expect(result.files[0].file_id).toBe(800)
     })
   })
 

--- a/tests/tools/submission-files.test.ts
+++ b/tests/tools/submission-files.test.ts
@@ -1,0 +1,410 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { CanvasClient } from '../../src/canvas'
+import type { CanvasAttachment, CanvasSubmission } from '../../src/canvas/types'
+import { Pseudonymizer } from '../../src/pseudonym/pseudonymizer'
+import { submissionFileTools } from '../../src/tools/submission-files'
+
+// All Canvas responses are mocked — no real Canvas instance is hit.
+
+function att(
+  overrides: Partial<CanvasAttachment> & Pick<CanvasAttachment, 'id' | 'display_name'>,
+): CanvasAttachment {
+  return {
+    filename: overrides.display_name,
+    url: `https://canvas.example.com/files/${overrides.id}/download`,
+    content_type: 'application/octet-stream',
+    size: 1024,
+    ...overrides,
+  }
+}
+
+function sub(overrides: Partial<CanvasSubmission>): CanvasSubmission {
+  return {
+    id: 1,
+    assignment_id: 0,
+    user_id: 0,
+    submitted_at: null,
+    score: null,
+    grade: null,
+    body: null,
+    url: null,
+    attempt: 1,
+    workflow_state: 'submitted',
+    ...overrides,
+  }
+}
+
+function buildMockCanvas(submissions: CanvasSubmission[]): {
+  canvas: CanvasClient
+  listForStudents: ReturnType<typeof vi.fn>
+} {
+  const listForStudents = vi.fn().mockResolvedValue(submissions)
+  const canvas = {
+    submissions: { listForStudents },
+  } as unknown as CanvasClient
+  return { canvas, listForStudents }
+}
+
+function getTool(canvas: CanvasClient, pseudonymizer?: Pseudonymizer) {
+  return submissionFileTools(canvas, pseudonymizer).find(
+    (t) => t.name === 'list_course_submission_files',
+  )!
+}
+
+type Manifest = {
+  course_id: number
+  total_files: number
+  total_submissions_scanned: number
+  truncated: boolean
+  truncation_note: string | null
+  url_expiry_note: string
+  files: Array<{
+    assignment_id: number
+    assignment_name: string | null
+    user_id: number
+    user_name: string | null
+    original_filename: string
+    file_id: number
+    download_url: string
+    content_type: string
+    size: number
+    submitted_at: string | null
+    _warning?: string
+  }>
+}
+
+// Fixture A — basic two-assignment, two-student course
+const FIXTURE_A: CanvasSubmission[] = [
+  sub({
+    id: 1,
+    assignment_id: 10,
+    assignment: {
+      id: 10,
+      name: 'Essay',
+      description: null,
+      due_at: null,
+      points_possible: 100,
+      grading_type: 'points',
+      submission_types: ['online_upload'],
+      course_id: 1,
+      allowed_attempts: -1,
+    },
+    user_id: 100,
+    user: { id: 100, name: 'Alice' },
+    submitted_at: '2026-01-10T12:00:00Z',
+    attachments: [
+      att({
+        id: 501,
+        display_name: 'essay.docx',
+        content_type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        size: 24576,
+      }),
+    ],
+  }),
+  sub({
+    id: 2,
+    assignment_id: 10,
+    assignment: {
+      id: 10,
+      name: 'Essay',
+      description: null,
+      due_at: null,
+      points_possible: 100,
+      grading_type: 'points',
+      submission_types: ['online_upload'],
+      course_id: 1,
+      allowed_attempts: -1,
+    },
+    user_id: 101,
+    user: { id: 101, name: 'Bob' },
+    submitted_at: '2026-01-11T09:30:00Z',
+    attachments: [
+      att({
+        id: 502,
+        display_name: 'essay_final.pdf',
+        content_type: 'application/pdf',
+        size: 98304,
+      }),
+    ],
+  }),
+  sub({
+    id: 3,
+    assignment_id: 20,
+    assignment: {
+      id: 20,
+      name: 'Project',
+      description: null,
+      due_at: null,
+      points_possible: 100,
+      grading_type: 'points',
+      submission_types: ['online_upload'],
+      course_id: 1,
+      allowed_attempts: -1,
+    },
+    user_id: 100,
+    user: { id: 100, name: 'Alice' },
+    submitted_at: '2026-02-01T15:00:00Z',
+    attachments: [
+      att({ id: 503, display_name: 'project.zip', content_type: 'application/zip', size: 204800 }),
+    ],
+  }),
+  sub({
+    id: 4,
+    assignment_id: 20,
+    assignment: {
+      id: 20,
+      name: 'Project',
+      description: null,
+      due_at: null,
+      points_possible: 100,
+      grading_type: 'points',
+      submission_types: ['online_upload'],
+      course_id: 1,
+      allowed_attempts: -1,
+    },
+    user_id: 101,
+    user: { id: 101, name: 'Bob' },
+    submitted_at: '2026-02-02T10:00:00Z',
+    attachments: [],
+  }),
+]
+
+describe('submissionFileTools', () => {
+  it('returns a single tool definition', () => {
+    const { canvas } = buildMockCanvas([])
+    expect(submissionFileTools(canvas)).toHaveLength(1)
+  })
+
+  it('exports list_course_submission_files', () => {
+    const { canvas } = buildMockCanvas([])
+    expect(submissionFileTools(canvas).map((t) => t.name)).toEqual(['list_course_submission_files'])
+  })
+
+  it('declares read-only annotations', () => {
+    const { canvas } = buildMockCanvas([])
+    expect(getTool(canvas).annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+  })
+
+  it('exposes course_id in the input schema', () => {
+    const { canvas } = buildMockCanvas([])
+    expect(getTool(canvas).inputSchema).toHaveProperty('course_id')
+  })
+
+  // Fixture A — basic walk, attachments_only default (true)
+  describe('basic two-assignment walk (Fixture A)', () => {
+    it('emits one entry per attachment and skips attachment-less submissions', async () => {
+      const { canvas } = buildMockCanvas(FIXTURE_A)
+      const result = (await getTool(canvas).handler({ course_id: 1 })) as Manifest
+      expect(result.total_files).toBe(3)
+      expect(result.total_submissions_scanned).toBe(4)
+      expect(result.truncated).toBe(false)
+      expect(result.truncation_note).toBeNull()
+      expect(result.files[0].original_filename).toBe('essay.docx')
+      expect(result.files[0].file_id).toBe(501)
+      expect(result.files[0].assignment_name).toBe('Essay')
+      expect(result.files[0].download_url).toBe('https://canvas.example.com/files/501/download')
+      expect(result.files[0].size).toBe(24576)
+      expect(result.url_expiry_note).toContain('file_id')
+      expect(result.course_id).toBe(1)
+    })
+  })
+
+  // Fixture B — attachments_only: false
+  describe('attachments_only false (Fixture B)', () => {
+    it('still emits only attachment-based entries and counts every submission', async () => {
+      const { canvas } = buildMockCanvas(FIXTURE_A)
+      const result = (await getTool(canvas).handler({
+        course_id: 1,
+        attachments_only: false,
+      })) as Manifest
+      expect(result.total_files).toBe(3)
+      expect(result.total_submissions_scanned).toBe(4)
+    })
+  })
+
+  // Fixture C — truncation at max_files
+  describe('truncation at max_files (Fixture C)', () => {
+    it('stops at max_files, flags truncated, and explains how to retrieve the rest', async () => {
+      const submissions = Array.from({ length: 6 }, (_, i) =>
+        sub({
+          id: i + 1,
+          assignment_id: 10,
+          user_id: 100 + i,
+          user: { id: 100 + i, name: `Student${i}` },
+          attachments: [att({ id: 600 + i, display_name: `file${i}.pdf` })],
+        }),
+      )
+      const { canvas } = buildMockCanvas(submissions)
+      const result = (await getTool(canvas).handler({ course_id: 1, max_files: 3 })) as Manifest
+      expect(result.total_files).toBe(3)
+      expect(result.truncated).toBe(true)
+      expect(result.truncation_note).toMatch(/Re-run with assignment_ids or student_ids/)
+      expect(result.total_submissions_scanned).toBe(4)
+    })
+  })
+
+  // Fixture D — FERPA pseudonymization
+  describe('pseudonymization (Fixture D)', () => {
+    let tmpDir: string
+    beforeEach(async () => {
+      tmpDir = await mkdtemp(join(tmpdir(), 'submission-files-'))
+    })
+    afterEach(async () => {
+      await rm(tmpDir, { recursive: true, force: true })
+    })
+
+    function makePseudonymizer(enabled = true) {
+      return new Pseudonymizer({
+        baseUrl: 'https://school.instructure.com/api/v1',
+        rootDir: tmpDir,
+        env: enabled ? { CANVAS_PSEUDONYMIZE_STUDENTS: 'true' } : {},
+      })
+    }
+
+    it('replaces user_name with a stable per-student pseudonym while keeping the raw user_id', async () => {
+      const { canvas } = buildMockCanvas(FIXTURE_A)
+      const result = (await getTool(canvas, makePseudonymizer()).handler({
+        course_id: 1,
+      })) as Manifest
+      // Names are pseudonymized...
+      expect(result.files[0].user_name).toMatch(/^Student \d+$/)
+      expect(result.files[1].user_name).toMatch(/^Student \d+$/)
+      // ...distinct students get distinct pseudonyms...
+      expect(result.files[0].user_name).not.toBe(result.files[1].user_name)
+      // ...the same student is stable across submissions (Alice appears twice)...
+      expect(result.files[2].user_name).toBe(result.files[0].user_name)
+      // ...and the numeric user_id is never altered (stable folder key).
+      expect(result.files[0].user_id).toBe(100)
+      expect(result.files[1].user_id).toBe(101)
+      expect(result.files[2].user_id).toBe(100)
+    })
+
+    it('passes through real names when pseudonymization is disabled', async () => {
+      const { canvas } = buildMockCanvas(FIXTURE_A)
+      const result = (await getTool(canvas, makePseudonymizer(false)).handler({
+        course_id: 1,
+      })) as Manifest
+      expect(result.files[0].user_name).toBe('Alice')
+      expect(result.files[1].user_name).toBe('Bob')
+    })
+  })
+
+  // Fixture E — missing user on submission
+  describe('missing user data (Fixture E)', () => {
+    it('falls back to user_id and flags a warning', async () => {
+      const submissions = [
+        sub({
+          id: 1,
+          assignment_id: 30,
+          user_id: 200,
+          user: undefined,
+          attachments: [att({ id: 601, display_name: 'hw.pdf' })],
+        }),
+      ]
+      const { canvas } = buildMockCanvas(submissions)
+      const result = (await getTool(canvas).handler({ course_id: 1 })) as Manifest
+      expect(result.files[0].user_id).toBe(200)
+      expect(result.files[0].user_name).toBeNull()
+      expect(result.files[0]._warning).toBe('user data unavailable')
+    })
+  })
+
+  // Fixture F — filters passed through to the Canvas API layer
+  describe('filter pass-through (Fixture F)', () => {
+    it('forwards assignment_ids', async () => {
+      const { canvas, listForStudents } = buildMockCanvas([])
+      await getTool(canvas).handler({ course_id: 1, assignment_ids: [10, 20] })
+      expect(listForStudents).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ assignment_ids: [10, 20] }),
+      )
+    })
+
+    it('forwards student_ids verbatim (not "all")', async () => {
+      const { canvas, listForStudents } = buildMockCanvas([])
+      await getTool(canvas).handler({ course_id: 1, student_ids: [100] })
+      expect(listForStudents).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ student_ids: [100] }),
+      )
+    })
+
+    it('defaults student_ids to ["all"] when none are provided', async () => {
+      const { canvas, listForStudents } = buildMockCanvas([])
+      await getTool(canvas).handler({ course_id: 1 })
+      expect(listForStudents).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ student_ids: ['all'] }),
+      )
+    })
+
+    it('always requests the user and assignment includes', async () => {
+      const { canvas, listForStudents } = buildMockCanvas([])
+      await getTool(canvas).handler({ course_id: 1 })
+      expect(listForStudents).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ include: ['user', 'assignment'] }),
+      )
+    })
+
+    it('forwards workflow_state when provided', async () => {
+      const { canvas, listForStudents } = buildMockCanvas([])
+      await getTool(canvas).handler({ course_id: 1, workflow_state: 'graded' })
+      expect(listForStudents).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ workflow_state: 'graded' }),
+      )
+    })
+  })
+
+  // Fixture G — empty course
+  describe('empty course (Fixture G)', () => {
+    it('returns an empty manifest with the expiry note still present', async () => {
+      const { canvas } = buildMockCanvas([])
+      const result = (await getTool(canvas).handler({ course_id: 1 })) as Manifest
+      expect(result.total_files).toBe(0)
+      expect(result.files).toEqual([])
+      expect(result.truncated).toBe(false)
+      expect(result.url_expiry_note).toBeTruthy()
+    })
+  })
+
+  // Fixture H — multiple attachments per submission
+  describe('multiple attachments per submission (Fixture H)', () => {
+    it('emits one entry per attachment sharing the submission metadata', async () => {
+      const submissions = [
+        sub({
+          id: 1,
+          assignment_id: 40,
+          assignment: {
+            id: 40,
+            name: 'Portfolio',
+            description: null,
+            due_at: null,
+            points_possible: 100,
+            grading_type: 'points',
+            submission_types: ['online_upload'],
+            course_id: 1,
+            allowed_attempts: -1,
+          },
+          user_id: 300,
+          user: { id: 300, name: 'Carol' },
+          attachments: [
+            att({ id: 701, display_name: 'a.pdf' }),
+            att({ id: 702, display_name: 'b.pdf' }),
+            att({ id: 703, display_name: 'c.pdf' }),
+          ],
+        }),
+      ]
+      const { canvas } = buildMockCanvas(submissions)
+      const result = (await getTool(canvas).handler({ course_id: 1 })) as Manifest
+      expect(result.total_files).toBe(3)
+      expect(result.files.map((f) => f.user_id)).toEqual([300, 300, 300])
+      expect(result.files.map((f) => f.assignment_id)).toEqual([40, 40, 40])
+      expect(result.files.map((f) => f.original_filename)).toEqual(['a.pdf', 'b.pdf', 'c.pdf'])
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Implements the merged spec for #210 (`docs/superpowers/specs/2026-06-22-issue-210-list-course-submission-files.md`).

> **User story:** As an instructor using Claude, when I'm about to lose access to a Canvas course (for example a Free-For-Teacher account being concluded), I want to pull every student's submitted files out in one pass — with their original filenames, organized per assignment and student — so I can archive years of work before it disappears, without hand-downloading hundreds of files.

Canvas's native course exports deliberately exclude student submission data, so there is no first-class way to bulk-retrieve submitted files. This adds one read-only tool, `list_course_submission_files`, that produces a flat, pseudonymizable manifest of every student file attachment in a course.

## Approach

- **New tool `list_course_submission_files`** (`src/tools/submission-files.ts`). Read-only composition of the existing `canvas.submissions.listForStudents` bulk endpoint (`GET /courses/:id/students/submissions` with `include[]=user,assignment`). **No new Canvas endpoints, no new canvas module, no new dependencies.**
- **One entry per attachment**: `{ assignment_id, assignment_name, user_id, user_name, original_filename, file_id, download_url, content_type, size, submitted_at }`.
- **Time-limited URLs surfaced honestly**: every response carries a top-level `url_expiry_note` and every entry carries `file_id` so callers re-fetch a fresh URL via the existing `download_file` tool.
- **Bounded, never silently truncated**: `max_files` (default 500, max 2000). When the cap is hit, `truncated: true` + a `truncation_note` explaining how to narrow with `assignment_ids`/`student_ids`. `total_submissions_scanned` reports coverage.
- **FERPA pseudonymization**: student identity routes through `pseudonymizer.anonymizeUser`; `user_name` becomes a stable per-course pseudonym while the raw numeric `user_id` is preserved as a stable per-student folder key. The tool is added to `PSEUDONYMIZER_WRAPPED_TOOLS` (and the coverage-test mirror).
- Annotations: `readOnlyHint: true`, `openWorldHint: true`. Domain `submission_files`, educator audience. Tool count 135 → 136; `pnpm generate:manifests` regenerated `docs/generated/tool-manifest.json`.

### Spec deviation (followed code reality)

The spec's Fixture D expected pseudonyms `Student 0`/`Student 1`, but `emptyCourseMap` initializes `next_pseudonym_index: 1`, so the first allocated pseudonym is `Student 1`. The tests assert the pseudonym shape (`/^Student \d+$/`), per-student stability, and distinctness rather than hard-coding the index — matching the existing pattern in `tests/tools/users.test.ts` and avoiding coupling to the index seed.

## Tests

New `tests/tools/submission-files.test.ts` covers fixtures A–H from the spec (mocked Canvas responses only): basic multi-assignment walk, `attachments_only` toggle, truncation at `max_files`, FERPA pseudonymization (enabled + disabled), missing-`user` fallback with `_warning`, filter pass-through (`assignment_ids`/`student_ids`/`workflow_state` + default `['all']`), empty course, and multiple attachments per submission.

Full gate green:

```
pnpm typecheck   ✓
pnpm lint        ✓  All matched files use Prettier code style!
pnpm test        ✓  Test Files 90 passed (90) | Tests 1234 passed | 1 skipped
pnpm build       ✓  Build success
```

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)
