### PR TITLE
docs(spec): explain_grading_policy tool — late/missing policy + group weights (spec for #213)

### DIFF
--- a/docs/superpowers/specs/2026-06-23-issue-213-explain-grading-policy.md
+++ b/docs/superpowers/specs/2026-06-23-issue-213-explain-grading-policy.md
@@ -1,0 +1,507 @@
+---
+issue: 213
+---
+
+# Grading Automation Policy Tool — `explain_grading_policy` MCP Tool Design
+
+**Date**: 2026-06-23
+**Issue**: [bruchris/canvas-lms-mcp#213](https://github.com/bruchris/canvas-lms-mcp/issues/213)
+**Status**: Design — awaiting CTO review
+
+---
+
+## Purpose
+
+Add a single read-only tool, `explain_grading_policy`, that surfaces the **grading automation rules**
+configured for a Canvas course in one structured response — the missing-submission policy (auto-zero
+or custom deduction), the late-submission penalty (percent per day/hour, floor), the assignment-group
+weights (are groups weighted? what weight does each carry?), and whether a grading standard
+(letter-grade scheme) is applied. The output includes a plain-language `summary` that Claude can
+read to students or instructors directly.
+
+This is **complementary to, not overlapping with, `explain_grade`**. `explain_grade` recomputes
+the *numeric grade* given current scores. This tool answers the prior question: *what are the rules
+that Canvas will apply automatically?* — "will a blank become a 0?", "is there a late penalty?",
+"does the Exams group count more than Homework?"
+
+---
+
+## Design unknowns (retired)
+
+### 1. Permission / persona: who can read `GET /courses/:id/late_policy`?
+
+**Decision: instructor/admin primary; student best-effort with a graceful fallback.**
+
+The Canvas REST API requires the `manage_grades` permission (i.e. teacher or admin role) to read
+`GET /api/v1/courses/:course_id/late_policy`. A student token typically receives a `403 Forbidden`.
+
+Handling:
+
+- The tool issues the late-policy call in parallel with the course + assignment-groups calls.
+- If a `CanvasApiError` with `status === 403` is thrown by the late-policy call, the tool returns
+  `null` for both `missing_submission_policy` and `late_submission_policy` and appends a caveat:
+  `"Late/missing submission policy requires instructor or admin permissions — policy details are
+  not accessible with this token."` The group-weighting and grading-scheme sections, which come
+  from the course object and assignment groups (both student-readable), are still returned normally.
+- Any other `CanvasApiError` on the late-policy call (e.g. 404 — course has no late policy record
+  yet) is treated the same as a policy-not-configured response (all flags false, all values 0).
+  A `404` on the late_policy endpoint means Canvas has not yet created a `LatePolicy` row for this
+  course — semantically equivalent to "no policy configured".
+- Non-403, non-404 errors (5xx, network) propagate normally via `formatError()`.
+
+Documented persona in tool description: **instructor or admin** for full output; students receive
+the group-weighting and grading-scheme sections only.
+
+### 2. When no late policy is configured (Canvas returns 404 or all-false flags)
+
+**Decision: surface as "not configured / off" rather than "unknown".**
+
+Canvas creates a `LatePolicy` row lazily — only when the instructor first saves a late-policy
+change in the UI. Before that, a GET returns 404. When the policy exists but all flags are `false`,
+no automatic deductions are in effect.
+
+Both situations (404 and all-flags-false) should be expressed to the user as
+"No automatic missing/late penalty is configured for this course" rather than "policy unknown" or
+"not retrievable", since the _effect_ is the same: no automation will fire. The tool normalises
+both to `enabled: false` / `deduction_percent: 0`.
+
+To distinguish the two states in the raw output, the tool exposes a
+`missing_submission_policy.source` field:
+- `'api'` — a 200 response was received from the late_policy endpoint.
+- `'default'` — a 404 was received; defaults (no automation) are assumed.
+- `'unavailable'` — a 403 was received; values should be treated as unknown.
+
+Same pattern for `late_submission_policy.source`.
+
+### 3. Scope: include group weighting and grading-scheme presence in this tool?
+
+**Decision: yes — all three facets in a single tool.**
+
+The user story asks for one answer to "how is grading set up in this course?" Splitting the grading
+automation rules across two or three tools would force the caller (Claude or a user) to issue
+multiple requests and synthesise the answer manually. Combining them:
+
+- Late/missing policy (from `late_policy` endpoint)
+- Group weighting (from `course.apply_assignment_group_weights` + `assignment_groups`)
+- Grading standard presence (from `course.grading_standard_id`)
+
+into one tool is idiomatic Canvas — they are all properties of the same conceptual object
+("how this course grades") — and the Canvas endpoints needed for groups and the course record are
+called anyway to fill out the answer.
+
+The `explain_grade` tool already fetches groups (with full assignment lists) for its own math;
+this tool fetches groups **without** `include[]=assignments` (lighter call, group metadata only).
+There is no data overlap that would require deduplication between the two tools — they are called
+independently.
+
+---
+
+## Canvas API calls
+
+| # | Endpoint | Purpose | Method |
+|---|----------|---------|--------|
+| 1 | `GET /api/v1/courses/:id/late_policy` | Missing/late deduction flags and values | `canvas.latePolicy.get(courseId)` (new) |
+| 2 | `GET /api/v1/courses/:id` | `apply_assignment_group_weights`, `grading_standard_id`, `account_id`, course name | `canvas.courses.get(courseId)` (existing) |
+| 3 | `GET /api/v1/courses/:id/assignment_groups` | Group names and weights | `canvas.assignments.listGroups(courseId)` (existing, no extra includes) |
+| 4 _(conditional)_ | `GET /api/v1/courses/:id/grading_standards` (then account fallback) | Confirm the grading standard exists and retrieve its title | `canvas.gradingStandards.listForCourse()` / `listForAccount()` (existing) |
+
+Calls 1, 2, and 3 are independent — issue them as `Promise.allSettled([call1, call2, call3])` so
+that a 403 on call 1 does not abort calls 2 and 3. Call 4 is conditional on
+`course.grading_standard_id !== null && course.grading_standard_id !== undefined`.
+
+**Why `Promise.allSettled` (not `Promise.all`):** call 1 may throw a 403 `CanvasApiError` for
+student tokens while calls 2 and 3 succeed. `allSettled` lets the tool inspect each result
+independently and return partial data rather than failing entirely.
+
+---
+
+## New canvas module: `src/canvas/late-policy.ts`
+
+A minimal module following the established canvas-layer pattern: receives `CanvasHttpClient` via
+constructor, throws `CanvasApiError`, no MCP dependency.
+
+```ts
+import type { CanvasHttpClient } from './client'
+import type { CanvasLatePolicy } from './types'
+
+export class LatePolicyModule {
+  constructor(private client: CanvasHttpClient) {}
+
+  async get(courseId: number): Promise<CanvasLatePolicy> {
+    const envelope = await this.client.request<{ late_policy: CanvasLatePolicy }>(
+      `/api/v1/courses/${courseId}/late_policy`,
+    )
+    return envelope.late_policy
+  }
+}
+```
+
+The response shape from Canvas is `{ "late_policy": { ... } }` — an envelope. The module unwraps
+it and returns the inner `CanvasLatePolicy` object directly.
+
+**Register in `src/canvas/index.ts`:**
+
+```ts
+import { LatePolicyModule } from './late-policy'
+// in CanvasClient constructor:
+this.latePolicy = new LatePolicyModule(this.client)
+// and as a property:
+latePolicy: LatePolicyModule
+```
+
+---
+
+## New Canvas types (`src/canvas/types.ts`)
+
+Append these two interfaces:
+
+```ts
+export interface CanvasLatePolicy {
+  id?: number
+  course_id?: number
+  late_submission_deduction_enabled: boolean
+  // Percent deducted per interval (0–100). Canvas stores as a decimal fraction
+  // in older API versions and as an integer in newer; always treat as 0–100 range.
+  late_submission_deduction: number
+  late_submission_interval: 'hour' | 'day'
+  late_submission_minimum_percent_enabled: boolean
+  late_submission_minimum_percent: number  // floor: grade cannot fall below this (0–100)
+  missing_submission_deduction_enabled: boolean
+  missing_submission_deduction: number     // typically 100 for auto-zero
+}
+```
+
+---
+
+## Tool contract (`src/tools/grading-policy.ts`)
+
+### Export signature
+
+```ts
+export function gradingPolicyTools(canvas: CanvasClient): ToolDefinition[]
+```
+
+No `pseudonymizer` parameter — this tool returns no student PII (see FERPA section below).
+
+### Tool name
+
+`explain_grading_policy`
+
+### Zod input schema
+
+```ts
+z.object({
+  course_id: z.number().int().positive().describe(
+    'Canvas course ID to explain the grading policy for.'
+  ),
+})
+```
+
+### Annotations
+
+```ts
+{
+  readOnlyHint: true,
+  destructiveHint: false,
+  openWorldHint: true,
+}
+```
+
+### Output shape
+
+```ts
+{
+  course: {
+    id: number,
+    name: string,
+  },
+  missing_submission_policy: {
+    // 'api' = 200 received; 'default' = 404 (no policy row, defaults assumed);
+    // 'unavailable' = 403 (student token)
+    source: 'api' | 'default' | 'unavailable',
+    enabled: boolean,             // true iff missing_submission_deduction_enabled
+    deduction_percent: number,    // 0-100; 100 means auto-zero
+  } | null,   // null only when source === 'unavailable'
+  late_submission_policy: {
+    source: 'api' | 'default' | 'unavailable',
+    enabled: boolean,
+    deduction_percent: number,    // percent deducted per interval
+    interval: 'hour' | 'day',
+    minimum_percent_enabled: boolean,
+    minimum_percent: number,      // 0 if minimum_percent_enabled is false
+  } | null,   // null only when source === 'unavailable'
+  group_weighting: {
+    weighted: boolean,            // course.apply_assignment_group_weights ?? false
+    groups: Array<{
+      id: number,
+      name: string,
+      weight: number,             // group_weight from Canvas (0-100)
+    }>,
+  },
+  grading_scheme: {
+    applied: boolean,             // true iff grading_standard_id is set
+    standard_id: number | null,
+    standard_title: string | null,  // fetched if applied; null if unavailable or not set
+  },
+  summary: string,               // plain-language paragraph
+  caveats: string[],
+}
+```
+
+**When `source === 'unavailable'`**, both `missing_submission_policy` and `late_submission_policy`
+are set to `null` (not an object with `enabled: false`), signalling that the values are
+**unknown**, not **off**. The summary and caveats reflect this.
+
+### Summary generation
+
+The `summary` field is assembled from the structured data in priority order. Examples:
+
+**Full instructor view (auto-zero + late penalty + weighted groups + grading scheme):**
+> "Missing work is automatically scored 0%. Late submissions lose 10% per day, with a floor of
+> 50%. Assignment groups are weighted: Exams (60%), Homework (30%), Participation (10%). A
+> letter-grade scheme is applied to the final score."
+
+**Student view (403 on late_policy):**
+> "Assignment groups are weighted: Exams (60%), Homework (40%). A letter-grade scheme is applied.
+> Late/missing penalty details require instructor permissions and are not available."
+
+**No automation (policy-off or 404):**
+> "No automatic missing-work or late-submission penalty is configured for this course. Assignment
+> groups are not weighted — all assignments contribute equally to the course grade. No letter-grade
+> scheme is applied."
+
+### Summary assembly rules
+
+```
+missing_block:
+  if source === 'unavailable':  skip
+  elif enabled:  "Missing work is automatically scored <(100 - deduction_percent)>%."
+                 (if deduction_percent === 100: "Missing work is automatically scored 0% (auto-zero).")
+  else:          "No automatic penalty for missing work."
+
+late_block:
+  if source === 'unavailable':  skip
+  elif enabled:
+    base = "Late submissions lose <deduction_percent>% per <interval>."
+    if minimum_percent_enabled: append " Grade cannot fall below <minimum_percent>%."
+  else: "No automatic late penalty."
+
+weighting_block:
+  if weighted:
+    group_list = groups.map(g => "<name> (<weight>%)").join(", ")
+    "Assignment groups are weighted: <group_list>."
+  else:
+    "Assignment groups are not weighted — all assignments contribute equally."
+
+scheme_block:
+  if applied:  "A letter-grade scheme is applied (\"<standard_title>\")."
+  else:        "No letter-grade scheme is applied."
+
+if source === 'unavailable' (for both policy fields):
+  append to caveats: "Late/missing penalty details require instructor permissions and are
+  not available with this token."
+
+summary = [missing_block, late_block, weighting_block, scheme_block]
+  .filter(Boolean).join(" ")
+```
+
+---
+
+## Catalog registration (`src/tools/catalog.ts`)
+
+Add import and catalog entry:
+
+```ts
+import { gradingPolicyTools } from './grading-policy'
+
+// In toolDomainCatalog (append after 'grade_explanation'):
+{
+  domain: 'grading_policy',
+  defaultPrimaryAudience: 'shared',
+  getTools: gradingPolicyTools,
+},
+```
+
+---
+
+## FERPA / pseudonymization
+
+`explain_grading_policy` returns **no student PII**. The response contains only:
+- Course ID and name (course-level metadata)
+- Late/missing policy flags and numeric values (course-level configuration)
+- Assignment group names and weights (course-level configuration)
+- Grading standard title (course-level configuration)
+
+No `CanvasUser`, no `user_name`, no `participants` array, no enrollment data with user fields.
+
+**Pseudonymizer integration: not required.** Do NOT add `'explain_grading_policy'` to
+`PSEUDONYMIZER_WRAPPED_TOOLS`. CI's `coverage.test.ts` checks only that tools in that list are
+actually wrapped — adding a non-PII tool to the list would fail that check.
+
+---
+
+## Error handling
+
+| Scenario | Handling |
+|----------|----------|
+| 403 on `late_policy` call | Catch in tool; set both policy sections to `null` (source `'unavailable'`); add caveat; continue |
+| 404 on `late_policy` call | Treat as default (all-false policy, source `'default'`); no caveat needed |
+| 403/404 on course or assignment_groups | Propagate via `formatError()` — tool cannot function without course data |
+| `grading_standard_id` set but standard not fetchable (404 on standards list) | `standard_title: null`; add caveat `"Grading standard (id: <n>) could not be retrieved."` |
+| Network failure on any call | Propagate via `formatError()` "Failed to connect to Canvas — check your base URL" |
+
+---
+
+## Test plan (`tests/grading-policy.test.ts`)
+
+All tests use mocked Canvas responses — no real Canvas instance is hit.
+
+### Fixture A — Full instructor view: auto-zero + late penalty + weighted groups + grading scheme
+
+**Course mock**: `id: 1`, `name: 'Physics 101'`, `apply_assignment_group_weights: true`,
+`grading_standard_id: 42`, `account_id: 10`
+
+**Late policy mock** (200):
+```json
+{
+  "late_policy": {
+    "missing_submission_deduction_enabled": true,
+    "missing_submission_deduction": 100,
+    "late_submission_deduction_enabled": true,
+    "late_submission_deduction": 10,
+    "late_submission_interval": "day",
+    "late_submission_minimum_percent_enabled": true,
+    "late_submission_minimum_percent": 50
+  }
+}
+```
+
+**Assignment groups mock** (two groups):
+```json
+[
+  { "id": 1, "name": "Exams", "group_weight": 60 },
+  { "id": 2, "name": "Homework", "group_weight": 40 }
+]
+```
+
+**Grading standards mock** (course-level, id 42, title `'Default Grading Scale'`).
+
+**Assertions**:
+1. `result.missing_submission_policy.enabled === true`
+2. `result.missing_submission_policy.deduction_percent === 100`
+3. `result.missing_submission_policy.source === 'api'`
+4. `result.late_submission_policy.enabled === true`
+5. `result.late_submission_policy.deduction_percent === 10`
+6. `result.late_submission_policy.interval === 'day'`
+7. `result.late_submission_policy.minimum_percent_enabled === true`
+8. `result.late_submission_policy.minimum_percent === 50`
+9. `result.group_weighting.weighted === true`
+10. `result.group_weighting.groups` has two entries: Exams (60) and Homework (40)
+11. `result.grading_scheme.applied === true`
+12. `result.grading_scheme.standard_title === 'Default Grading Scale'`
+13. `result.summary` contains "auto-zero" (or "0%") and "10% per day" and "floor of 50%" and
+    "weighted" and the group names
+14. `result.caveats` is empty
+
+### Fixture B — No policy configured (late_policy returns 404)
+
+**Course mock**: `apply_assignment_group_weights: false`, `grading_standard_id: null`
+
+**Late policy call**: throws `CanvasApiError` with `status: 404`.
+
+**Assignment groups mock**: single group `{ id: 1, name: 'Assignments', group_weight: 0 }`.
+
+**Assertions**:
+1. `result.missing_submission_policy.enabled === false`
+2. `result.missing_submission_policy.source === 'default'`
+3. `result.late_submission_policy.enabled === false`
+4. `result.late_submission_policy.source === 'default'`
+5. `result.group_weighting.weighted === false`
+6. `result.grading_scheme.applied === false`
+7. `result.grading_scheme.standard_id === null`
+8. `result.summary` contains "No automatic" and "not weighted" and "No letter-grade scheme"
+9. `result.caveats` is empty (404 is not a caveat — it is the expected default state)
+
+### Fixture C — Student token (403 on late_policy)
+
+**Late policy call**: throws `CanvasApiError` with `status: 403`.
+
+**Course and assignment_groups**: return normally (weighted course, one group).
+
+**Assertions**:
+1. `result.missing_submission_policy === null`
+2. `result.late_submission_policy === null`
+3. `result.group_weighting.weighted === true` (group data still returned)
+4. `result.caveats` includes the "instructor permissions" string
+5. `result.summary` includes the permissions caveat mention and group weighting info
+
+### Fixture D — Grading standard in the standard list (course-level)
+
+Same as Fixture A but the grading-standards **course list** returns an empty array (standard is
+account-scoped). The tool then calls `listForAccount(course.account_id)` and finds it there.
+
+**Assertions**:
+1. `result.grading_scheme.applied === true`
+2. `result.grading_scheme.standard_title` matches the account-level mock title
+3. Exactly two grading-standard API calls were made (one course-level, one account-level)
+
+### Fixture E — Grading standard set but not retrievable
+
+`grading_standard_id: 99` on course; both `listForCourse` and `listForAccount` return arrays that
+do not contain id 99.
+
+**Assertions**:
+1. `result.grading_scheme.applied === true`
+2. `result.grading_scheme.standard_title === null`
+3. `result.caveats` includes `"Grading standard (id: 99) could not be retrieved."`
+
+### Fixture F — Late penalty with no floor (minimum_percent_enabled: false)
+
+**Late policy mock**: `late_submission_deduction_enabled: true`, `late_submission_deduction: 5`,
+`late_submission_interval: 'hour'`, `late_submission_minimum_percent_enabled: false`,
+`late_submission_minimum_percent: 0`.
+
+**Assertions**:
+1. `result.late_submission_policy.minimum_percent_enabled === false`
+2. `result.summary` contains "5% per hour" but NOT the word "floor" or "minimum"
+
+---
+
+## Tool description (MCP `tool.description`)
+
+```
+Explains the grading automation rules configured for a Canvas course:
+- Missing-submission policy: whether blank/unsubmitted work is automatically scored 0 (or another
+  deduction), or left unpenalised.
+- Late-submission policy: whether Canvas applies a per-day or per-hour percentage deduction to
+  late submissions, and whether there is a floor below which the grade cannot fall.
+- Assignment-group weighting: whether the course uses weighted groups, and the weight of each group.
+- Grading scheme: whether a letter-grade scheme (A/B/C/F mapping) is applied to the final score.
+
+Also returns a plain-language summary paragraph you can share with students or instructors.
+
+Note: the late/missing policy section requires instructor or admin permissions. Students receive
+the group-weighting and grading-scheme sections only, with a caveat noting what is unavailable.
+Use explain_grade to compute the actual weighted grade for a specific student.
+```
+
+---
+
+## File changes summary
+
+| File | Change |
+|------|--------|
+| `src/canvas/types.ts` | Add `CanvasLatePolicy` interface |
+| `src/canvas/late-policy.ts` | **New** — `LatePolicyModule` with `get(courseId)` |
+| `src/canvas/index.ts` | Import `LatePolicyModule`; add `latePolicy: LatePolicyModule` property and constructor assignment |
+| `src/tools/grading-policy.ts` | **New** — `gradingPolicyTools()` with `explain_grading_policy` ToolDefinition, all Canvas calls, and summary generation |
+| `src/tools/catalog.ts` | Import `gradingPolicyTools`; add `grading_policy` domain entry |
+| `tests/grading-policy.test.ts` | **New** — Fixtures A–F with mocked Canvas responses |
+
+**6 files total. No new package dependencies. No student PII (pseudonymizer not required).**
+
+---
+
+## Open questions for CTO review
+
+None — all design unknowns are retired above. The spec is implementation-ready.

--- a/docs/superpowers/specs/2026-06-23-issue-213-explain-grading-policy.md
+++ b/docs/superpowers/specs/2026-06-23-issue-213-explain-grading-policy.md
@@ -21,8 +21,8 @@ read to students or instructors directly.
 
 This is **complementary to, not overlapping with, `explain_grade`**. `explain_grade` recomputes
 the *numeric grade* given current scores. This tool answers the prior question: *what are the rules
-that Canvas will apply automatically?* — "will a blank become a 0?", "is there a late penalty?",
-"does the Exams group count more than Homework?"
+that Canvas will apply automatically?* — “will a blank become a 0?”, “is there a late penalty?”,
+“does the Exams group count more than Homework?”
 
 ---
 
@@ -37,47 +37,50 @@ The Canvas REST API requires the `manage_grades` permission (i.e. teacher or adm
 
 Handling:
 
-- The tool issues the late-policy call in parallel with the course + assignment-groups calls.
-- If a `CanvasApiError` with `status === 403` is thrown by the late-policy call, the tool returns
-  `null` for both `missing_submission_policy` and `late_submission_policy` and appends a caveat:
-  `"Late/missing submission policy requires instructor or admin permissions — policy details are
-  not accessible with this token."` The group-weighting and grading-scheme sections, which come
-  from the course object and assignment groups (both student-readable), are still returned normally.
-- Any other `CanvasApiError` on the late-policy call (e.g. 404 — course has no late policy record
-  yet) is treated the same as a policy-not-configured response (all flags false, all values 0).
-  A `404` on the late_policy endpoint means Canvas has not yet created a `LatePolicy` row for this
-  course — semantically equivalent to "no policy configured".
-- Non-403, non-404 errors (5xx, network) propagate normally via `formatError()`.
+- The tool issues the late-policy call in parallel with the course + assignment-groups calls via
+  `Promise.allSettled` (see Canvas API calls section for unwrapping pseudocode).
+- If the late-policy result is rejected with a `CanvasApiError` where `status === 403`, the tool
+  returns `null` for both `missing_submission_policy` and `late_submission_policy` and appends a
+  caveat: `"Late/missing submission policy requires instructor or admin permissions — policy details
+  are not accessible with this token."`
+- If the late-policy result is rejected with `status === 404` (Canvas has not created a `LatePolicy`
+  row for this course yet), it is treated as policy-not-configured: all flags false, all values 0,
+  `source: 'default'`. No caveat is added (this is the normal state for new courses).
+- If the late-policy result is rejected with any **other** error (5xx, network error), the tool
+  propagates it via `formatError()` and returns a tool-level error response. The partial data from
+  calls 2 and 3 is discarded in this case.
+- Non-403, non-404 errors on calls 2 (course) or 3 (assignment groups) propagate unconditionally
+  via `formatError()` — the tool cannot produce meaningful output without course-level data.
 
 Documented persona in tool description: **instructor or admin** for full output; students receive
-the group-weighting and grading-scheme sections only.
+the group-weighting and grading-scheme sections only, with a caveat noting what is unavailable.
 
 ### 2. When no late policy is configured (Canvas returns 404 or all-false flags)
 
-**Decision: surface as "not configured / off" rather than "unknown".**
+**Decision: surface as “not configured / off” rather than “unknown”.**
 
 Canvas creates a `LatePolicy` row lazily — only when the instructor first saves a late-policy
 change in the UI. Before that, a GET returns 404. When the policy exists but all flags are `false`,
 no automatic deductions are in effect.
 
 Both situations (404 and all-flags-false) should be expressed to the user as
-"No automatic missing/late penalty is configured for this course" rather than "policy unknown" or
-"not retrievable", since the _effect_ is the same: no automation will fire. The tool normalises
+“No automatic missing/late penalty is configured for this course” rather than “policy unknown” or
+“not retrievable”, since the _effect_ is the same: no automation will fire. The tool normalises
 both to `enabled: false` / `deduction_percent: 0`.
 
 To distinguish the two states in the raw output, the tool exposes a
 `missing_submission_policy.source` field:
 - `'api'` — a 200 response was received from the late_policy endpoint.
 - `'default'` — a 404 was received; defaults (no automation) are assumed.
-- `'unavailable'` — a 403 was received; values should be treated as unknown.
 
-Same pattern for `late_submission_policy.source`.
+Same pattern for `late_submission_policy.source`. When the field is `null` (403 case), neither
+status is applicable — the caller should treat the absence of the field as "unknown, not off".
 
 ### 3. Scope: include group weighting and grading-scheme presence in this tool?
 
 **Decision: yes — all three facets in a single tool.**
 
-The user story asks for one answer to "how is grading set up in this course?" Splitting the grading
+The user story asks for one answer to “how is grading set up in this course?” Splitting the grading
 automation rules across two or three tools would force the caller (Claude or a user) to issue
 multiple requests and synthesise the answer manually. Combining them:
 
@@ -86,7 +89,7 @@ multiple requests and synthesise the answer manually. Combining them:
 - Grading standard presence (from `course.grading_standard_id`)
 
 into one tool is idiomatic Canvas — they are all properties of the same conceptual object
-("how this course grades") — and the Canvas endpoints needed for groups and the course record are
+(“how this course grades”) — and the Canvas endpoints needed for groups and the course record are
 called anyway to fill out the answer.
 
 The `explain_grade` tool already fetches groups (with full assignment lists) for its own math;
@@ -112,6 +115,44 @@ that a 403 on call 1 does not abort calls 2 and 3. Call 4 is conditional on
 **Why `Promise.allSettled` (not `Promise.all`):** call 1 may throw a 403 `CanvasApiError` for
 student tokens while calls 2 and 3 succeed. `allSettled` lets the tool inspect each result
 independently and return partial data rather than failing entirely.
+
+**Unwrapping `Promise.allSettled` results (required reading for implementers):**
+
+```ts
+const [latePolicyResult, courseResult, groupsResult] = await Promise.allSettled([
+  canvas.latePolicy.get(courseId),
+  canvas.courses.get(courseId),
+  canvas.assignments.listGroups(courseId),
+])
+
+// Calls 2 and 3 are required — propagate any error immediately
+if (courseResult.status === 'rejected') return formatError(courseResult.reason)
+if (groupsResult.status === 'rejected') return formatError(groupsResult.reason)
+const course = courseResult.value
+const groups = groupsResult.value
+
+// Call 1: late policy — only 403 and 404 are handled gracefully
+let latePolicySource: 'api' | 'default' = 'default'
+let rawLatePolicy: CanvasLatePolicy | null = null
+let policyUnavailable = false
+
+if (latePolicyResult.status === 'fulfilled') {
+  rawLatePolicy = latePolicyResult.value
+  latePolicySource = 'api'
+} else {
+  const err = latePolicyResult.reason
+  if (err instanceof CanvasApiError && err.status === 403) {
+    policyUnavailable = true  // both policy output fields become null
+  } else if (err instanceof CanvasApiError && err.status === 404) {
+    latePolicySource = 'default'  // no policy row yet; defaults (disabled) apply
+  } else {
+    return formatError(err)  // 5xx, network error — propagate
+  }
+}
+```
+
+Note: `canvas.assignments.listGroups(courseId)` is called without `include: ['assignments']`
+(the default call omits assignments) to avoid fetching unnecessary data.
 
 ---
 
@@ -139,29 +180,30 @@ export class LatePolicyModule {
 The response shape from Canvas is `{ "late_policy": { ... } }` — an envelope. The module unwraps
 it and returns the inner `CanvasLatePolicy` object directly.
 
-**Register in `src/canvas/index.ts`:**
+**Register in `src/canvas/index.ts`** (following the pattern of all existing modules):
 
 ```ts
 import { LatePolicyModule } from './late-policy'
-// in CanvasClient constructor:
-this.latePolicy = new LatePolicyModule(this.client)
-// and as a property:
+
+// 1. Declare as a class property (in the class body, alongside existing properties):
 latePolicy: LatePolicyModule
+
+// 2. Assign in the constructor:
+this.latePolicy = new LatePolicyModule(this.client)
 ```
 
 ---
 
 ## New Canvas types (`src/canvas/types.ts`)
 
-Append these two interfaces:
+Append this interface:
 
 ```ts
 export interface CanvasLatePolicy {
   id?: number
   course_id?: number
   late_submission_deduction_enabled: boolean
-  // Percent deducted per interval (0–100). Canvas stores as a decimal fraction
-  // in older API versions and as an integer in newer; always treat as 0–100 range.
+  // Percent deducted per interval (0–100 integer; no normalization required)
   late_submission_deduction: number
   late_submission_interval: 'hour' | 'day'
   late_submission_minimum_percent_enabled: boolean
@@ -178,10 +220,15 @@ export interface CanvasLatePolicy {
 ### Export signature
 
 ```ts
-export function gradingPolicyTools(canvas: CanvasClient): ToolDefinition[]
+export function gradingPolicyTools(
+  canvas: CanvasClient,
+  pseudonymizer?: Pseudonymizer,
+): ToolDefinition[]
 ```
 
-No `pseudonymizer` parameter — this tool returns no student PII (see FERPA section below).
+The `pseudonymizer` parameter is accepted to satisfy the `ToolDomainRegistration` interface
+(which declares `getTools: (canvas: CanvasClient, pseudonymizer?: Pseudonymizer) => ToolDefinition[]`)
+but is **not used** — this tool returns no student PII.
 
 ### Tool name
 
@@ -215,21 +262,21 @@ z.object({
     id: number,
     name: string,
   },
+  // null when the late_policy endpoint returned 403 (student token).
+  // Non-null for both 200 (source: 'api') and 404 (source: 'default') responses.
   missing_submission_policy: {
-    // 'api' = 200 received; 'default' = 404 (no policy row, defaults assumed);
-    // 'unavailable' = 403 (student token)
-    source: 'api' | 'default' | 'unavailable',
+    source: 'api' | 'default',  // 'api' = Canvas returned data; 'default' = no policy row (404)
     enabled: boolean,             // true iff missing_submission_deduction_enabled
-    deduction_percent: number,    // 0-100; 100 means auto-zero
-  } | null,   // null only when source === 'unavailable'
+    deduction_percent: number,    // 0-100; 100 means auto-zero; 0 when source is 'default'
+  } | null,
   late_submission_policy: {
-    source: 'api' | 'default' | 'unavailable',
+    source: 'api' | 'default',
     enabled: boolean,
-    deduction_percent: number,    // percent deducted per interval
+    deduction_percent: number,    // percent deducted per interval; 0 when source is 'default'
     interval: 'hour' | 'day',
     minimum_percent_enabled: boolean,
     minimum_percent: number,      // 0 if minimum_percent_enabled is false
-  } | null,   // null only when source === 'unavailable'
+  } | null,
   group_weighting: {
     weighted: boolean,            // course.apply_assignment_group_weights ?? false
     groups: Array<{
@@ -239,48 +286,49 @@ z.object({
     }>,
   },
   grading_scheme: {
-    applied: boolean,             // true iff grading_standard_id is set
+    applied: boolean,             // true iff grading_standard_id is non-null
     standard_id: number | null,
-    standard_title: string | null,  // fetched if applied; null if unavailable or not set
+    standard_title: string | null,  // populated if applied; null if unretrievable or not set
   },
   summary: string,               // plain-language paragraph
   caveats: string[],
 }
 ```
 
-**When `source === 'unavailable'`**, both `missing_submission_policy` and `late_submission_policy`
-are set to `null` (not an object with `enabled: false`), signalling that the values are
-**unknown**, not **off**. The summary and caveats reflect this.
+**When `missing_submission_policy === null` (and likewise for `late_submission_policy`)**, the
+caller should treat the values as **unknown, not off** — the policy exists but cannot be read
+with the current token. The `caveats` array will contain an explanation.
 
 ### Summary generation
 
-The `summary` field is assembled from the structured data in priority order. Examples:
+The `summary` field is assembled from the structured data. Examples:
 
 **Full instructor view (auto-zero + late penalty + weighted groups + grading scheme):**
-> "Missing work is automatically scored 0%. Late submissions lose 10% per day, with a floor of
-> 50%. Assignment groups are weighted: Exams (60%), Homework (30%), Participation (10%). A
-> letter-grade scheme is applied to the final score."
+> “Missing work is automatically scored 0% (auto-zero). Late submissions lose 10% per day, with a
+> floor of 50%. Assignment groups are weighted: Exams (60%), Homework (40%). A letter-grade scheme
+> is applied.”
 
 **Student view (403 on late_policy):**
-> "Assignment groups are weighted: Exams (60%), Homework (40%). A letter-grade scheme is applied.
-> Late/missing penalty details require instructor permissions and are not available."
+> “Assignment groups are weighted: Exams (60%), Homework (40%). A letter-grade scheme is applied.
+> Late/missing penalty details require instructor permissions and are not available.”
 
 **No automation (policy-off or 404):**
-> "No automatic missing-work or late-submission penalty is configured for this course. Assignment
-> groups are not weighted — all assignments contribute equally to the course grade. No letter-grade
-> scheme is applied."
+> “No automatic missing-work penalty. No automatic late penalty. Assignment groups are not weighted
+> — all assignments contribute equally. No letter-grade scheme is applied.”
 
 ### Summary assembly rules
 
 ```
 missing_block:
-  if source === 'unavailable':  skip
-  elif enabled:  "Missing work is automatically scored <(100 - deduction_percent)>%."
-                 (if deduction_percent === 100: "Missing work is automatically scored 0% (auto-zero).")
-  else:          "No automatic penalty for missing work."
+  if missing_submission_policy === null:  skip (permission caveat added separately)
+  elif enabled:
+    if deduction_percent === 100: "Missing work is automatically scored 0% (auto-zero)."
+    elif deduction_percent === 0:  "Missing work policy is enabled with no deduction (0%)."
+    else: "Missing work loses <deduction_percent>% of the possible points automatically."
+  else: "No automatic missing-work penalty."
 
 late_block:
-  if source === 'unavailable':  skip
+  if late_submission_policy === null:  skip (permission caveat added separately)
   elif enabled:
     base = "Late submissions lose <deduction_percent>% per <interval>."
     if minimum_percent_enabled: append " Grade cannot fall below <minimum_percent>%."
@@ -294,15 +342,22 @@ weighting_block:
     "Assignment groups are not weighted — all assignments contribute equally."
 
 scheme_block:
-  if applied:  "A letter-grade scheme is applied (\"<standard_title>\")."
-  else:        "No letter-grade scheme is applied."
+  if applied and standard_title is not null:
+    "A letter-grade scheme is applied (\"<standard_title>\")."
+  elif applied and standard_title is null:
+    "A letter-grade scheme is applied (title unavailable)."
+  else:
+    "No letter-grade scheme is applied."
 
-if source === 'unavailable' (for both policy fields):
-  append to caveats: "Late/missing penalty details require instructor permissions and are
-  not available with this token."
+permission_caveat (added when missing_submission_policy === null):
+  append to caveats: "Late/missing penalty details require instructor or admin permissions
+  and are not available with this token."
+  append to summary: "Late/missing penalty details require instructor permissions and are
+  not available."
 
 summary = [missing_block, late_block, weighting_block, scheme_block]
   .filter(Boolean).join(" ")
+  (permission note appended at the end when policy is null)
 ```
 
 ---
@@ -314,7 +369,7 @@ Add import and catalog entry:
 ```ts
 import { gradingPolicyTools } from './grading-policy'
 
-// In toolDomainCatalog (append after 'grade_explanation'):
+// In toolDomainCatalog (append after the 'grade_explanation' entry):
 {
   domain: 'grading_policy',
   defaultPrimaryAudience: 'shared',
@@ -338,16 +393,22 @@ No `CanvasUser`, no `user_name`, no `participants` array, no enrollment data wit
 `PSEUDONYMIZER_WRAPPED_TOOLS`. CI's `coverage.test.ts` checks only that tools in that list are
 actually wrapped — adding a non-PII tool to the list would fail that check.
 
+Note: if Canvas adds user-identity fields (e.g. `created_by`) to the `late_policy` or
+`grading_standards` responses in future API versions, this tool must be re-evaluated for
+PII exposure.
+
 ---
 
 ## Error handling
 
 | Scenario | Handling |
 |----------|----------|
-| 403 on `late_policy` call | Catch in tool; set both policy sections to `null` (source `'unavailable'`); add caveat; continue |
-| 404 on `late_policy` call | Treat as default (all-false policy, source `'default'`); no caveat needed |
-| 403/404 on course or assignment_groups | Propagate via `formatError()` — tool cannot function without course data |
-| `grading_standard_id` set but standard not fetchable (404 on standards list) | `standard_title: null`; add caveat `"Grading standard (id: <n>) could not be retrieved."` |
+| 403 on `late_policy` call | Set both policy fields to `null`; add caveat; continue with course/groups data |
+| 404 on `late_policy` call | Treat as default (all-false policy, `source: 'default'`); no caveat |
+| 5xx or network error on `late_policy` call | Propagate via `formatError()`; discard partial data |
+| 403 or 404 on course or assignment_groups | Propagate via `formatError()` — tool cannot function without course data |
+| `grading_standard_id` set but standard not in course-level list | Try account-level list via `listForAccount(course.account_id)` |
+| Standard not found in either course or account list | `standard_title: null`; add caveat `"Grading standard (id: <n>) could not be retrieved."` |
 | Network failure on any call | Propagate via `formatError()` "Failed to connect to Canvas — check your base URL" |
 
 ---
@@ -361,7 +422,7 @@ All tests use mocked Canvas responses — no real Canvas instance is hit.
 **Course mock**: `id: 1`, `name: 'Physics 101'`, `apply_assignment_group_weights: true`,
 `grading_standard_id: 42`, `account_id: 10`
 
-**Late policy mock** (200):
+**Late policy mock** (200 with envelope `{ late_policy: { ... } }`):
 ```json
 {
   "late_policy": {
@@ -376,7 +437,7 @@ All tests use mocked Canvas responses — no real Canvas instance is hit.
 }
 ```
 
-**Assignment groups mock** (two groups):
+**Assignment groups mock** (two groups, no `include[]=assignments`):
 ```json
 [
   { "id": 1, "name": "Exams", "group_weight": 60 },
@@ -384,7 +445,7 @@ All tests use mocked Canvas responses — no real Canvas instance is hit.
 ]
 ```
 
-**Grading standards mock** (course-level, id 42, title `'Default Grading Scale'`).
+**Grading standards mock** (course-level list returns `[{ id: 42, title: 'Default Grading Scale', ... }]`).
 
 **Assertions**:
 1. `result.missing_submission_policy.enabled === true`
@@ -396,74 +457,93 @@ All tests use mocked Canvas responses — no real Canvas instance is hit.
 7. `result.late_submission_policy.minimum_percent_enabled === true`
 8. `result.late_submission_policy.minimum_percent === 50`
 9. `result.group_weighting.weighted === true`
-10. `result.group_weighting.groups` has two entries: Exams (60) and Homework (40)
+10. `result.group_weighting.groups` has two entries: Exams (weight 60) and Homework (weight 40)
 11. `result.grading_scheme.applied === true`
 12. `result.grading_scheme.standard_title === 'Default Grading Scale'`
-13. `result.summary` contains "auto-zero" (or "0%") and "10% per day" and "floor of 50%" and
-    "weighted" and the group names
+13. `result.summary` contains "auto-zero" and "10%" and "day" and "50%" and group names
 14. `result.caveats` is empty
 
 ### Fixture B — No policy configured (late_policy returns 404)
 
 **Course mock**: `apply_assignment_group_weights: false`, `grading_standard_id: null`
 
-**Late policy call**: throws `CanvasApiError` with `status: 404`.
+**Late policy call**: `canvas.latePolicy.get` throws `CanvasApiError` with `status: 404`.
 
 **Assignment groups mock**: single group `{ id: 1, name: 'Assignments', group_weight: 0 }`.
 
 **Assertions**:
-1. `result.missing_submission_policy.enabled === false`
-2. `result.missing_submission_policy.source === 'default'`
-3. `result.late_submission_policy.enabled === false`
-4. `result.late_submission_policy.source === 'default'`
-5. `result.group_weighting.weighted === false`
-6. `result.grading_scheme.applied === false`
-7. `result.grading_scheme.standard_id === null`
-8. `result.summary` contains "No automatic" and "not weighted" and "No letter-grade scheme"
-9. `result.caveats` is empty (404 is not a caveat — it is the expected default state)
+1. `result.missing_submission_policy` is non-null
+2. `result.missing_submission_policy.enabled === false`
+3. `result.missing_submission_policy.source === 'default'`
+4. `result.late_submission_policy.enabled === false`
+5. `result.late_submission_policy.source === 'default'`
+6. `result.group_weighting.weighted === false`
+7. `result.grading_scheme.applied === false`
+8. `result.grading_scheme.standard_id === null`
+9. `result.summary` contains "No automatic" and "not weighted" and "No letter-grade"
+10. `result.caveats` is empty
 
 ### Fixture C — Student token (403 on late_policy)
 
-**Late policy call**: throws `CanvasApiError` with `status: 403`.
+**Late policy call**: `canvas.latePolicy.get` throws `CanvasApiError` with `status: 403`.
 
-**Course and assignment_groups**: return normally (weighted course, one group).
+**Course mock**: `apply_assignment_group_weights: true`, `grading_standard_id: null`
+
+**Assignment groups mock**: single group `{ id: 1, name: 'Exams', group_weight: 100 }`.
 
 **Assertions**:
 1. `result.missing_submission_policy === null`
 2. `result.late_submission_policy === null`
 3. `result.group_weighting.weighted === true` (group data still returned)
-4. `result.caveats` includes the "instructor permissions" string
-5. `result.summary` includes the permissions caveat mention and group weighting info
+4. `result.caveats` has exactly one entry containing "instructor or admin permissions"
+5. `result.summary` contains group name and weight, and ends with the permissions note
 
-### Fixture D — Grading standard in the standard list (course-level)
+### Fixture D — Grading standard is account-scoped (two-level fallback)
 
-Same as Fixture A but the grading-standards **course list** returns an empty array (standard is
-account-scoped). The tool then calls `listForAccount(course.account_id)` and finds it there.
+**Course mock**: `grading_standard_id: 42`, `account_id: 10`
+
+**Course-level grading standards mock**: `listForCourse(1)` returns `[]` (standard is
+account-scoped; `/courses/:id/grading_standards` returns only course-owned standards).
+
+**Account-level grading standards mock**: `listForAccount(10)` returns
+`[{ id: 42, title: 'Institutional Scale', grading_scheme: [...] }]`.
 
 **Assertions**:
 1. `result.grading_scheme.applied === true`
-2. `result.grading_scheme.standard_title` matches the account-level mock title
-3. Exactly two grading-standard API calls were made (one course-level, one account-level)
+2. `result.grading_scheme.standard_title === 'Institutional Scale'`
+3. Both `listForCourse` AND `listForAccount` mocks were called (verify via spy)
 
 ### Fixture E — Grading standard set but not retrievable
 
-`grading_standard_id: 99` on course; both `listForCourse` and `listForAccount` return arrays that
-do not contain id 99.
+**Course mock**: `grading_standard_id: 99`, `account_id: 10`
+
+**Both `listForCourse(1)` and `listForAccount(10)`** return arrays that do not include id 99.
 
 **Assertions**:
 1. `result.grading_scheme.applied === true`
-2. `result.grading_scheme.standard_title === null`
-3. `result.caveats` includes `"Grading standard (id: 99) could not be retrieved."`
+2. `result.grading_scheme.standard_id === 99`
+3. `result.grading_scheme.standard_title === null`
+4. `result.caveats` contains a string matching "Grading standard (id: 99) could not be retrieved"
 
-### Fixture F — Late penalty with no floor (minimum_percent_enabled: false)
+### Fixture F — Late penalty with no floor (`minimum_percent_enabled: false`)
 
-**Late policy mock**: `late_submission_deduction_enabled: true`, `late_submission_deduction: 5`,
-`late_submission_interval: 'hour'`, `late_submission_minimum_percent_enabled: false`,
-`late_submission_minimum_percent: 0`.
+**Late policy mock** (200): `late_submission_deduction_enabled: true`,
+`late_submission_deduction: 5`, `late_submission_interval: 'hour'`,
+`late_submission_minimum_percent_enabled: false`, `late_submission_minimum_percent: 0`.
 
 **Assertions**:
 1. `result.late_submission_policy.minimum_percent_enabled === false`
-2. `result.summary` contains "5% per hour" but NOT the word "floor" or "minimum"
+2. `result.late_submission_policy.minimum_percent === 0`
+3. `result.summary` contains "5%" and "hour" but does NOT contain "floor" or "minimum" or "below"
+
+### Fixture G — `deduction_percent === 0` with policy enabled (edge case)
+
+**Late policy mock** (200): `missing_submission_deduction_enabled: true`,
+`missing_submission_deduction: 0` (policy enabled but deduction is 0%).
+
+**Assertion**:
+1. `result.summary` contains "no deduction (0%)" or equivalent — does NOT say "100%"
+   (i.e. the `(100 - 0) = 100%` formula is NOT applied)
 
 ---
 
@@ -493,12 +573,18 @@ Use explain_grade to compute the actual weighted grade for a specific student.
 |------|--------|
 | `src/canvas/types.ts` | Add `CanvasLatePolicy` interface |
 | `src/canvas/late-policy.ts` | **New** — `LatePolicyModule` with `get(courseId)` |
-| `src/canvas/index.ts` | Import `LatePolicyModule`; add `latePolicy: LatePolicyModule` property and constructor assignment |
-| `src/tools/grading-policy.ts` | **New** — `gradingPolicyTools()` with `explain_grading_policy` ToolDefinition, all Canvas calls, and summary generation |
-| `src/tools/catalog.ts` | Import `gradingPolicyTools`; add `grading_policy` domain entry |
-| `tests/grading-policy.test.ts` | **New** — Fixtures A–F with mocked Canvas responses |
+| `src/canvas/index.ts` | Import `LatePolicyModule`; declare `latePolicy: LatePolicyModule` property; assign in constructor |
+| `src/tools/grading-policy.ts` | **New** — `gradingPolicyTools(canvas, pseudonymizer?)` with `explain_grading_policy` ToolDefinition, `Promise.allSettled` calls, and summary generation |
+| `src/tools/catalog.ts` | Import `gradingPolicyTools`; add `grading_policy` domain entry after `grade_explanation` |
+| `tests/grading-policy.test.ts` | **New** — Fixtures A–G with mocked Canvas responses |
 
-**6 files total. No new package dependencies. No student PII (pseudonymizer not required).**
+**6 files total. No new package dependencies. No student PII (pseudonymizer accepted but unused).**
+
+Existing modules used without modification:
+- `src/canvas/courses.ts` — `CoursesModule.get(courseId)` (already exists)
+- `src/canvas/assignments.ts` — `AssignmentsModule.listGroups(courseId)` (already exists)
+- `src/canvas/grading-standards.ts` — `GradingStandardsModule.listForCourse()` /
+  `listForAccount()` (already exists and registered on `CanvasClient` as `canvas.gradingStandards`)
 
 ---
 

--- a/docs/superpowers/specs/2026-06-23-issue-213-explain-grading-policy.md
+++ b/docs/superpowers/specs/2026-06-23-issue-213-explain-grading-policy.md
@@ -73,8 +73,22 @@ To distinguish the two states in the raw output, the tool exposes a
 - `'api'` — a 200 response was received from the late_policy endpoint.
 - `'default'` — a 404 was received; defaults (no automation) are assumed.
 
-Same pattern for `late_submission_policy.source`. When the field is `null` (403 case), neither
-status is applicable — the caller should treat the absence of the field as "unknown, not off".
+Same pattern for `late_submission_policy.source`. When either field is `null` (403 case), the
+state is unknown — callers must NOT infer "policy is off" from a null field.
+
+The **synthetic default object** used when Canvas returns 404 is:
+
+```ts
+const DEFAULT_LATE_POLICY = {
+  late_submission_deduction_enabled: false,
+  late_submission_deduction: 0,
+  late_submission_interval: 'day' as const,
+  late_submission_minimum_percent_enabled: false,
+  late_submission_minimum_percent: 0,
+  missing_submission_deduction_enabled: false,
+  missing_submission_deduction: 0,
+}
+```
 
 ### 3. Scope: include group weighting and grading-scheme presence in this tool?
 
@@ -105,7 +119,7 @@ independently.
 |---|----------|---------|--------|
 | 1 | `GET /api/v1/courses/:id/late_policy` | Missing/late deduction flags and values | `canvas.latePolicy.get(courseId)` (new) |
 | 2 | `GET /api/v1/courses/:id` | `apply_assignment_group_weights`, `grading_standard_id`, `account_id`, course name | `canvas.courses.get(courseId)` (existing) |
-| 3 | `GET /api/v1/courses/:id/assignment_groups` | Group names and weights | `canvas.assignments.listGroups(courseId)` (existing, no extra includes) |
+| 3 | `GET /api/v1/courses/:id/assignment_groups` | Group names and weights | `canvas.assignments.listGroups(courseId)` (existing; omit `include` opts to skip assignments) |
 | 4 _(conditional)_ | `GET /api/v1/courses/:id/grading_standards` (then account fallback) | Confirm the grading standard exists and retrieve its title | `canvas.gradingStandards.listForCourse()` / `listForAccount()` (existing) |
 
 Calls 1, 2, and 3 are independent — issue them as `Promise.allSettled([call1, call2, call3])` so
@@ -133,7 +147,7 @@ const groups = groupsResult.value
 
 // Call 1: late policy — only 403 and 404 are handled gracefully
 let latePolicySource: 'api' | 'default' = 'default'
-let rawLatePolicy: CanvasLatePolicy | null = null
+let rawLatePolicy: CanvasLatePolicy = DEFAULT_LATE_POLICY
 let policyUnavailable = false
 
 if (latePolicyResult.status === 'fulfilled') {
@@ -144,15 +158,49 @@ if (latePolicyResult.status === 'fulfilled') {
   if (err instanceof CanvasApiError && err.status === 403) {
     policyUnavailable = true  // both policy output fields become null
   } else if (err instanceof CanvasApiError && err.status === 404) {
-    latePolicySource = 'default'  // no policy row yet; defaults (disabled) apply
+    latePolicySource = 'default'  // rawLatePolicy stays as DEFAULT_LATE_POLICY
   } else {
     return formatError(err)  // 5xx, network error — propagate
   }
 }
+
+// Initialize caveats (always starts as empty array)
+const caveats: string[] = []
+if (policyUnavailable) {
+  caveats.push(
+    'Late/missing submission policy requires instructor or admin permissions '
+    + '— policy details are not accessible with this token.',
+  )
+}
 ```
 
-Note: `canvas.assignments.listGroups(courseId)` is called without `include: ['assignments']`
-(the default call omits assignments) to avoid fetching unnecessary data.
+Note: `canvas.assignments.listGroups(courseId)` is called without options (the second parameter
+defaults to `{}`), so `include[]=assignments` is NOT sent and only group metadata is returned.
+
+**Grading standard lookup (call 4):**
+
+```ts
+let standardTitle: string | null = null
+if (course.grading_standard_id != null) {
+  // Canvas /courses/:id/grading_standards returns ONLY course-owned standards;
+  // account-inherited standards are NOT included, so an account-level fallback is needed.
+  const courseStandards = await canvas.gradingStandards.listForCourse(courseId)
+  const found = courseStandards.find(s => s.id === course.grading_standard_id)
+  if (found) {
+    standardTitle = found.title
+  } else if (course.account_id != null) {
+    const accountStandards = await canvas.gradingStandards.listForAccount(course.account_id)
+    const foundInAccount = accountStandards.find(s => s.id === course.grading_standard_id)
+    if (foundInAccount) {
+      standardTitle = foundInAccount.title
+    } else {
+      caveats.push(`Grading standard (id: ${course.grading_standard_id}) could not be retrieved.`)
+    }
+  } else {
+    caveats.push(`Grading standard (id: ${course.grading_standard_id}) could not be retrieved.`)
+  }
+}
+```
 
 ---
 
@@ -180,15 +228,16 @@ export class LatePolicyModule {
 The response shape from Canvas is `{ "late_policy": { ... } }` — an envelope. The module unwraps
 it and returns the inner `CanvasLatePolicy` object directly.
 
-**Register in `src/canvas/index.ts`** (following the pattern of all existing modules):
+**Register in `src/canvas/index.ts`** (following the exact pattern of all existing modules):
 
 ```ts
+// 1. Add import alongside existing module imports:
 import { LatePolicyModule } from './late-policy'
 
-// 1. Declare as a class property (in the class body, alongside existing properties):
+// 2. Declare as a class property in the class body, alongside e.g. `courses: CoursesModule`:
 latePolicy: LatePolicyModule
 
-// 2. Assign in the constructor:
+// 3. Assign in the constructor body, alongside e.g. `this.courses = new CoursesModule(...)`:
 this.latePolicy = new LatePolicyModule(this.client)
 ```
 
@@ -213,6 +262,9 @@ export interface CanvasLatePolicy {
 }
 ```
 
+Note: `grading_standard_id?: number | null` and `account_id?: number` are already present on
+`CanvasCourse` in `types.ts` — no additional type changes needed for those fields.
+
 ---
 
 ## Tool contract (`src/tools/grading-policy.ts`)
@@ -234,14 +286,17 @@ but is **not used** — this tool returns no student PII.
 
 `explain_grading_policy`
 
-### Zod input schema
+### Input schema
+
+Following the `ToolDefinition.inputSchema` shape used by all other tools (a `Record<string, ZodTypeAny>`,
+not a `z.object()` wrapper):
 
 ```ts
-z.object({
+inputSchema: {
   course_id: z.number().int().positive().describe(
     'Canvas course ID to explain the grading policy for.'
   ),
-})
+}
 ```
 
 ### Annotations
@@ -263,41 +318,59 @@ z.object({
     name: string,
   },
   // null when the late_policy endpoint returned 403 (student token).
-  // Non-null for both 200 (source: 'api') and 404 (source: 'default') responses.
+  // Non-null for both 200 (source: 'api') and 404/default (source: 'default') responses.
+  // When null, treat values as UNKNOWN — not as "no penalty".
   missing_submission_policy: {
     source: 'api' | 'default',  // 'api' = Canvas returned data; 'default' = no policy row (404)
-    enabled: boolean,             // true iff missing_submission_deduction_enabled
-    deduction_percent: number,    // 0-100; 100 means auto-zero; 0 when source is 'default'
+    enabled: boolean,             // mirrors missing_submission_deduction_enabled
+    deduction_percent: number,    // mirrors missing_submission_deduction (0-100)
   } | null,
   late_submission_policy: {
     source: 'api' | 'default',
     enabled: boolean,
-    deduction_percent: number,    // percent deducted per interval; 0 when source is 'default'
-    interval: 'hour' | 'day',
+    deduction_percent: number,    // mirrors late_submission_deduction
+    interval: 'hour' | 'day',    // mirrors late_submission_interval
     minimum_percent_enabled: boolean,
-    minimum_percent: number,      // 0 if minimum_percent_enabled is false
+    minimum_percent: number,      // mirrors late_submission_minimum_percent
   } | null,
   group_weighting: {
-    weighted: boolean,            // course.apply_assignment_group_weights ?? false
-    groups: Array<{
-      id: number,
-      name: string,
-      weight: number,             // group_weight from Canvas (0-100)
-    }>,
+    weighted: boolean,
+    // Each group: { id, name, weight } where weight maps from CanvasAssignmentGroup.group_weight
+    groups: Array<{ id: number; name: string; weight: number }>,
   },
   grading_scheme: {
     applied: boolean,             // true iff grading_standard_id is non-null
     standard_id: number | null,
     standard_title: string | null,  // populated if applied; null if unretrievable or not set
   },
-  summary: string,               // plain-language paragraph
-  caveats: string[],
+  summary: string,
+  caveats: string[],             // initialised as []; strings appended as issues arise
 }
 ```
 
-**When `missing_submission_policy === null` (and likewise for `late_submission_policy`)**, the
-caller should treat the values as **unknown, not off** — the policy exists but cannot be read
-with the current token. The `caveats` array will contain an explanation.
+**Field mapping from Canvas types to output:**
+
+```ts
+// group_weighting.groups is built by mapping CanvasAssignmentGroup[]:
+groups: assignmentGroups.map(g => ({ id: g.id, name: g.name, weight: g.group_weight }))
+
+// missing_submission_policy (when non-null):
+{
+  source: latePolicySource,
+  enabled: rawLatePolicy.missing_submission_deduction_enabled,
+  deduction_percent: rawLatePolicy.missing_submission_deduction,
+}
+
+// late_submission_policy (when non-null):
+{
+  source: latePolicySource,
+  enabled: rawLatePolicy.late_submission_deduction_enabled,
+  deduction_percent: rawLatePolicy.late_submission_deduction,
+  interval: rawLatePolicy.late_submission_interval,
+  minimum_percent_enabled: rawLatePolicy.late_submission_minimum_percent_enabled,
+  minimum_percent: rawLatePolicy.late_submission_minimum_percent,
+}
+```
 
 ### Summary generation
 
@@ -318,17 +391,20 @@ The `summary` field is assembled from the structured data. Examples:
 
 ### Summary assembly rules
 
+`caveats` starts as `[]`; strings are pushed as issues are encountered. The summary is
+built by joining non-empty blocks with a space.
+
 ```
 missing_block:
-  if missing_submission_policy === null:  skip (permission caveat added separately)
+  if missing_submission_policy === null:  skip  // permission caveat added below
   elif enabled:
     if deduction_percent === 100: "Missing work is automatically scored 0% (auto-zero)."
     elif deduction_percent === 0:  "Missing work policy is enabled with no deduction (0%)."
-    else: "Missing work loses <deduction_percent>% of the possible points automatically."
+    else: "Missing work loses <deduction_percent>% of possible points automatically."
   else: "No automatic missing-work penalty."
 
 late_block:
-  if late_submission_policy === null:  skip (permission caveat added separately)
+  if late_submission_policy === null:  skip
   elif enabled:
     base = "Late submissions lose <deduction_percent>% per <interval>."
     if minimum_percent_enabled: append " Grade cannot fall below <minimum_percent>%."
@@ -349,15 +425,15 @@ scheme_block:
   else:
     "No letter-grade scheme is applied."
 
-permission_caveat (added when missing_submission_policy === null):
-  append to caveats: "Late/missing penalty details require instructor or admin permissions
-  and are not available with this token."
-  append to summary: "Late/missing penalty details require instructor permissions and are
-  not available."
+permission note (appended when missing_submission_policy === null):
+  // one caveat entry covers both policy fields (single 403 caused both to be null):
+  caveats.push('Late/missing penalty details require instructor or admin permissions — not available with this token.')
+  // append to summary after scheme_block:
+  + " Late/missing penalty details require instructor permissions and are not available."
 
 summary = [missing_block, late_block, weighting_block, scheme_block]
   .filter(Boolean).join(" ")
-  (permission note appended at the end when policy is null)
+  (permission note text appended to summary when policyUnavailable)
 ```
 
 ---
@@ -393,9 +469,8 @@ No `CanvasUser`, no `user_name`, no `participants` array, no enrollment data wit
 `PSEUDONYMIZER_WRAPPED_TOOLS`. CI's `coverage.test.ts` checks only that tools in that list are
 actually wrapped — adding a non-PII tool to the list would fail that check.
 
-Note: if Canvas adds user-identity fields (e.g. `created_by`) to the `late_policy` or
-`grading_standards` responses in future API versions, this tool must be re-evaluated for
-PII exposure.
+Note: if Canvas adds user-identity fields (e.g. `created_by`) to `late_policy` or
+`grading_standards` responses in future API versions, this tool must be re-evaluated for PII exposure.
 
 ---
 
@@ -403,13 +478,14 @@ PII exposure.
 
 | Scenario | Handling |
 |----------|----------|
-| 403 on `late_policy` call | Set both policy fields to `null`; add caveat; continue with course/groups data |
-| 404 on `late_policy` call | Treat as default (all-false policy, `source: 'default'`); no caveat |
+| 403 on `late_policy` call | Set `policyUnavailable = true`; both policy fields become `null`; push one caveat entry; continue |
+| 404 on `late_policy` call | Use `DEFAULT_LATE_POLICY`, `source: 'default'`; no caveat |
 | 5xx or network error on `late_policy` call | Propagate via `formatError()`; discard partial data |
 | 403 or 404 on course or assignment_groups | Propagate via `formatError()` — tool cannot function without course data |
-| `grading_standard_id` set but standard not in course-level list | Try account-level list via `listForAccount(course.account_id)` |
-| Standard not found in either course or account list | `standard_title: null`; add caveat `"Grading standard (id: <n>) could not be retrieved."` |
-| Network failure on any call | Propagate via `formatError()` "Failed to connect to Canvas — check your base URL" |
+| `grading_standard_id` set, not in course-level list | Try `listForAccount(course.account_id)` |
+| Standard not found in either course or account list | `standard_title: null`; push caveat |
+| `account_id` is null/undefined and standard not in course list | `standard_title: null`; push caveat |
+| Network failure on any call | Propagate via `formatError()` |
 
 ---
 
@@ -437,7 +513,7 @@ All tests use mocked Canvas responses — no real Canvas instance is hit.
 }
 ```
 
-**Assignment groups mock** (two groups, no `include[]=assignments`):
+**Assignment groups mock** (no `include[]=assignments`):
 ```json
 [
   { "id": 1, "name": "Exams", "group_weight": 60 },
@@ -445,7 +521,7 @@ All tests use mocked Canvas responses — no real Canvas instance is hit.
 ]
 ```
 
-**Grading standards mock** (course-level list returns `[{ id: 42, title: 'Default Grading Scale', ... }]`).
+**Grading standards mock**: `listForCourse(1)` returns `[{ id: 42, title: 'Default Grading Scale', grading_scheme: [] }]`.
 
 **Assertions**:
 1. `result.missing_submission_policy.enabled === true`
@@ -457,22 +533,22 @@ All tests use mocked Canvas responses — no real Canvas instance is hit.
 7. `result.late_submission_policy.minimum_percent_enabled === true`
 8. `result.late_submission_policy.minimum_percent === 50`
 9. `result.group_weighting.weighted === true`
-10. `result.group_weighting.groups` has two entries: Exams (weight 60) and Homework (weight 40)
+10. `result.group_weighting.groups` is `[{ id: 1, name: 'Exams', weight: 60 }, { id: 2, name: 'Homework', weight: 40 }]`
 11. `result.grading_scheme.applied === true`
 12. `result.grading_scheme.standard_title === 'Default Grading Scale'`
-13. `result.summary` contains "auto-zero" and "10%" and "day" and "50%" and group names
-14. `result.caveats` is empty
+13. `result.summary` contains "auto-zero" and "10%" and "day" and "50%" and "Exams" and "Homework"
+14. `result.caveats` is `[]`
 
 ### Fixture B — No policy configured (late_policy returns 404)
 
 **Course mock**: `apply_assignment_group_weights: false`, `grading_standard_id: null`
 
-**Late policy call**: `canvas.latePolicy.get` throws `CanvasApiError` with `status: 404`.
+**Late policy call**: throws `CanvasApiError` with `status: 404`.
 
-**Assignment groups mock**: single group `{ id: 1, name: 'Assignments', group_weight: 0 }`.
+**Assignment groups mock**: `[{ id: 1, name: 'Assignments', group_weight: 0 }]`.
 
 **Assertions**:
-1. `result.missing_submission_policy` is non-null
+1. `result.missing_submission_policy` is not null
 2. `result.missing_submission_policy.enabled === false`
 3. `result.missing_submission_policy.source === 'default'`
 4. `result.late_submission_policy.enabled === false`
@@ -481,43 +557,47 @@ All tests use mocked Canvas responses — no real Canvas instance is hit.
 7. `result.grading_scheme.applied === false`
 8. `result.grading_scheme.standard_id === null`
 9. `result.summary` contains "No automatic" and "not weighted" and "No letter-grade"
-10. `result.caveats` is empty
+10. `result.caveats` is `[]`
 
 ### Fixture C — Student token (403 on late_policy)
 
-**Late policy call**: `canvas.latePolicy.get` throws `CanvasApiError` with `status: 403`.
+**Late policy call**: throws `CanvasApiError` with `status: 403`.
 
 **Course mock**: `apply_assignment_group_weights: true`, `grading_standard_id: null`
 
-**Assignment groups mock**: single group `{ id: 1, name: 'Exams', group_weight: 100 }`.
+**Assignment groups mock**: `[{ id: 1, name: 'Exams', group_weight: 100 }]`.
 
 **Assertions**:
 1. `result.missing_submission_policy === null`
 2. `result.late_submission_policy === null`
-3. `result.group_weighting.weighted === true` (group data still returned)
-4. `result.caveats` has exactly one entry containing "instructor or admin permissions"
-5. `result.summary` contains group name and weight, and ends with the permissions note
+3. `result.group_weighting.weighted === true`
+4. `result.group_weighting.groups[0].weight === 100` (mapping from `group_weight`)
+5. `result.caveats.length === 1` (exactly one caveat for both policy fields)
+6. `result.caveats[0]` contains "instructor or admin permissions"
+7. `result.summary` contains "Exams" and "100%" and "instructor permissions"
 
 ### Fixture D — Grading standard is account-scoped (two-level fallback)
 
 **Course mock**: `grading_standard_id: 42`, `account_id: 10`
 
-**Course-level grading standards mock**: `listForCourse(1)` returns `[]` (standard is
-account-scoped; `/courses/:id/grading_standards` returns only course-owned standards).
+**`listForCourse(1)` mock**: returns `[]` (standard is account-scoped; this endpoint returns
+only course-owned standards, not inherited ones).
 
-**Account-level grading standards mock**: `listForAccount(10)` returns
-`[{ id: 42, title: 'Institutional Scale', grading_scheme: [...] }]`.
+**`listForAccount(10)` mock**: returns `[{ id: 42, title: 'Institutional Scale', grading_scheme: [] }]`.
 
 **Assertions**:
 1. `result.grading_scheme.applied === true`
 2. `result.grading_scheme.standard_title === 'Institutional Scale'`
-3. Both `listForCourse` AND `listForAccount` mocks were called (verify via spy)
+3. Spy confirms both `listForCourse` and `listForAccount` were called
+4. `result.caveats` is `[]`
 
-### Fixture E — Grading standard set but not retrievable
+### Fixture E — Grading standard set but not retrievable at either level
 
 **Course mock**: `grading_standard_id: 99`, `account_id: 10`
 
-**Both `listForCourse(1)` and `listForAccount(10)`** return arrays that do not include id 99.
+**`listForCourse(1)` mock**: returns `[{ id: 1, title: 'Other', grading_scheme: [] }]` (id 99 not present).
+
+**`listForAccount(10)` mock**: returns `[]`.
 
 **Assertions**:
 1. `result.grading_scheme.applied === true`
@@ -539,11 +619,11 @@ account-scoped; `/courses/:id/grading_standards` returns only course-owned stand
 ### Fixture G — `deduction_percent === 0` with policy enabled (edge case)
 
 **Late policy mock** (200): `missing_submission_deduction_enabled: true`,
-`missing_submission_deduction: 0` (policy enabled but deduction is 0%).
+`missing_submission_deduction: 0`.
 
 **Assertion**:
-1. `result.summary` contains "no deduction (0%)" or equivalent — does NOT say "100%"
-   (i.e. the `(100 - 0) = 100%` formula is NOT applied)
+1. `result.summary` contains "no deduction (0%)" — does NOT say "100%"
+   (the `(100 - 0)` formula must NOT be applied for this case)
 
 ---
 
@@ -573,18 +653,17 @@ Use explain_grade to compute the actual weighted grade for a specific student.
 |------|--------|
 | `src/canvas/types.ts` | Add `CanvasLatePolicy` interface |
 | `src/canvas/late-policy.ts` | **New** — `LatePolicyModule` with `get(courseId)` |
-| `src/canvas/index.ts` | Import `LatePolicyModule`; declare `latePolicy: LatePolicyModule` property; assign in constructor |
-| `src/tools/grading-policy.ts` | **New** — `gradingPolicyTools(canvas, pseudonymizer?)` with `explain_grading_policy` ToolDefinition, `Promise.allSettled` calls, and summary generation |
+| `src/canvas/index.ts` | Import `LatePolicyModule`; declare property; assign in constructor |
+| `src/tools/grading-policy.ts` | **New** — `gradingPolicyTools(canvas, pseudonymizer?)` with `explain_grading_policy` ToolDefinition, `Promise.allSettled` orchestration, `DEFAULT_LATE_POLICY` constant, and summary generation |
 | `src/tools/catalog.ts` | Import `gradingPolicyTools`; add `grading_policy` domain entry after `grade_explanation` |
 | `tests/grading-policy.test.ts` | **New** — Fixtures A–G with mocked Canvas responses |
 
 **6 files total. No new package dependencies. No student PII (pseudonymizer accepted but unused).**
 
 Existing modules used without modification:
-- `src/canvas/courses.ts` — `CoursesModule.get(courseId)` (already exists)
-- `src/canvas/assignments.ts` — `AssignmentsModule.listGroups(courseId)` (already exists)
-- `src/canvas/grading-standards.ts` — `GradingStandardsModule.listForCourse()` /
-  `listForAccount()` (already exists and registered on `CanvasClient` as `canvas.gradingStandards`)
+- `src/canvas/courses.ts` — `CoursesModule.get(courseId)` ✅
+- `src/canvas/assignments.ts` — `AssignmentsModule.listGroups(courseId)` (second param omitted; defaults to `{}`) ✅
+- `src/canvas/grading-standards.ts` — `GradingStandardsModule.listForCourse()` / `listForAccount()` (registered on `CanvasClient` as `canvas.gradingStandards`) ✅
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds design spec for the `explain_grading_policy` MCP tool (issue #213, design-first flag)
- Retires all three design unknowns: permission/persona handling, empty-policy semantics, and scope decision
- Single new file: `docs/superpowers/specs/2026-06-23-issue-213-explain-grading-policy.md`

## What the spec decides

**Unknown 1 — Permissions:** `GET /courses/:id/late_policy` requires manage-grades. Student tokens receive a 403. The tool uses `Promise.allSettled` so a 403 on the late-policy call doesn't abort course/group fetches. Policy sections are set to `null` (source `'unavailable'`) with a caveat; group-weighting and grading-scheme sections still return normally.

**Unknown 2 — No policy configured:** Canvas returns 404 when no `LatePolicy` row exists yet. Both 404 and all-flags-false are normalised to `enabled: false` (source `'default'`), since the effect is identical. A `source` discriminant field lets callers distinguish `'api'` / `'default'` / `'unavailable'` without ambiguity.

**Unknown 3 — Scope:** All three facets (late/missing policy, group weighting, grading scheme) are combined into one tool. The user story asks \"how is grading set up in this course?\" — splitting across multiple tools would require the caller to synthesise the answer manually.

## Approach

- 6-file implementation plan: new `src/canvas/late-policy.ts` module (wraps single endpoint), new `CanvasLatePolicy` type, new `src/tools/grading-policy.ts` tool, catalog entry, and test file (Fixtures A–F covering full policy, 404 default, 403 student, account-scoped standard, unretrievable standard, no-floor late penalty)
- No student PII — pseudonymizer not required
- No new package dependencies

## Test evidence

Spec only — no code changes in this PR. Fixtures A–F in the spec provide the complete mocked-response test plan for the implementation pass.

Refs #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011LRpjCvin7ECp24By5fhDH)_