### PR TITLE
feat(grading-policy): explain a course's grading automation policy

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 136,
+  "toolCount": 137,
   "tools": [
     {
       "name": "health_check",
@@ -1667,6 +1667,18 @@
       "name": "explain_grade",
       "domain": "grade_explanation",
       "description": "Recomputes and explains the weighted course grade for a student, including assignment-group weights, drop_lowest / drop_highest / never_drop rules, per-group breakdowns (earned points, dropped assignments, weighted contributions), the mapped letter grade (via the course grading standard when present), and a reconciliation check against Canvas's posted current_score / final_score.\n\nUse this when you need to verify that Canvas's displayed grade matches the rules, or to explain to a student or instructor how their grade was calculated.\n\nLimitations:\n- V1 computes one student per call. Omit student_id to compute for the authenticated user.\n- Instructor-applied curves and fudge points are not exposed via the Canvas REST API and cannot be reflected in the computation; a caveat is added when the discrepancy exceeds 0.5 pp.\n- When the course uses grading periods, reconciliation is against the overall (cross-period) grade.\n- When CANVAS_PSEUDONYMIZE_STUDENTS is enabled and you are passing a student_id, first call resolve_pseudonym to obtain the real Canvas user_id.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "explain_grading_policy",
+      "domain": "grading_policy",
+      "description": "Explains the grading automation rules configured for a Canvas course:\n- Missing-submission policy: whether blank/unsubmitted work is automatically scored 0 (or another deduction), or left unpenalised.\n- Late-submission policy: whether Canvas applies a per-day or per-hour percentage deduction to late submissions, and whether there is a floor below which the grade cannot fall.\n- Assignment-group weighting: whether the course uses weighted groups, and the weight of each group.\n- Grading scheme: whether a letter-grade scheme (A/B/C/F mapping) is applied to the final score.\n\nAlso returns a plain-language summary paragraph you can share with students or instructors.\n\nNote: the late/missing policy section requires instructor or admin permissions. Students receive the group-weighting and grading-scheme sections only, with a caveat noting what is unavailable. Use explain_grade to compute the actual weighted grade for a specific student.",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true

--- a/src/canvas/index.ts
+++ b/src/canvas/index.ts
@@ -23,6 +23,7 @@ import { GradebookHistoryModule } from './gradebook-history'
 import { NewQuizzesModule } from './new-quizzes'
 import { ContentExportsModule } from './content-exports'
 import { GradingStandardsModule } from './grading-standards'
+import { LatePolicyModule } from './late-policy'
 
 /**
  * Standalone Canvas REST API client. Composed of modular per-domain classes
@@ -61,6 +62,7 @@ export class CanvasClient {
   newQuizzes: NewQuizzesModule
   contentExports: ContentExportsModule
   gradingStandards: GradingStandardsModule
+  latePolicy: LatePolicyModule
 
   constructor(config: CanvasClientConfig) {
     this.client = new CanvasHttpClient(config)
@@ -87,6 +89,7 @@ export class CanvasClient {
     this.newQuizzes = new NewQuizzesModule(this.client)
     this.contentExports = new ContentExportsModule(this.client)
     this.gradingStandards = new GradingStandardsModule(this.client)
+    this.latePolicy = new LatePolicyModule(this.client)
   }
 }
 

--- a/src/canvas/late-policy.ts
+++ b/src/canvas/late-policy.ts
@@ -1,0 +1,21 @@
+import type { CanvasHttpClient } from './client'
+import type { CanvasLatePolicy } from './types'
+
+/**
+ * Canvas late/missing submission policy for a course.
+ *
+ * The response is an envelope — `{ "late_policy": { ... } }` — so `get` unwraps
+ * the inner object before returning it. Throws `CanvasApiError` on failure
+ * (notably 403 for student tokens and 404 when no policy row exists yet); the
+ * caller decides how to handle those statuses.
+ */
+export class LatePolicyModule {
+  constructor(private client: CanvasHttpClient) {}
+
+  async get(courseId: number): Promise<CanvasLatePolicy> {
+    const envelope = await this.client.request<{ late_policy: CanvasLatePolicy }>(
+      `/api/v1/courses/${courseId}/late_policy`,
+    )
+    return envelope.late_policy
+  }
+}

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -881,6 +881,30 @@ export interface CanvasGradingStandard {
   grading_scheme: CanvasGradingSchemeEntry[]
 }
 
+// --- Late policy ---
+
+/**
+ * A course's late/missing submission automation policy. Returned (wrapped in a
+ * `{ late_policy: ... }` envelope) by `GET /api/v1/courses/:id/late_policy`,
+ * which requires the `manage_grades` permission — student tokens receive 403.
+ * Canvas creates the underlying row lazily, so a course that has never had a
+ * policy saved returns 404.
+ */
+export interface CanvasLatePolicy {
+  id?: number
+  course_id?: number
+  late_submission_deduction_enabled: boolean
+  /** Percent deducted per interval (0–100; used as-is, no normalization). */
+  late_submission_deduction: number
+  late_submission_interval: 'hour' | 'day'
+  late_submission_minimum_percent_enabled: boolean
+  /** Floor: the grade cannot fall below this percent (0–100). */
+  late_submission_minimum_percent: number
+  missing_submission_deduction_enabled: boolean
+  /** Percent deducted for missing work (typically 100 for auto-zero). */
+  missing_submission_deduction: number
+}
+
 // --- Assignments (params) ---
 
 export interface CreateAssignmentParams {

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -16,6 +16,7 @@ import { enrollmentTools } from './enrollments'
 import { fileTools } from './files'
 import { gradebookHistoryTools } from './gradebook-history'
 import { gradeExplanationTools } from './grade-explanation'
+import { gradingPolicyTools } from './grading-policy'
 import { gradingStandardsTools } from './grading-standards'
 import { groupTools } from './groups'
 import { healthTools } from './health'
@@ -194,5 +195,10 @@ export const toolDomainCatalog: readonly ToolDomainRegistration[] = [
     domain: 'grade_explanation',
     defaultPrimaryAudience: 'shared',
     getTools: gradeExplanationTools,
+  },
+  {
+    domain: 'grading_policy',
+    defaultPrimaryAudience: 'shared',
+    getTools: gradingPolicyTools,
   },
 ]

--- a/src/tools/grading-policy.ts
+++ b/src/tools/grading-policy.ts
@@ -81,9 +81,15 @@ function buildSummary(
     }
   }
 
-  if (weighted) {
+  if (weighted && groups.length > 0) {
     const list = groups.map((g) => `${g.name} (${g.weight}%)`).join(', ')
     blocks.push(`Assignment groups are weighted: ${list}.`)
+  } else if (weighted) {
+    // Flagged for weighting but no groups configured yet — avoid emitting a
+    // malformed "weighted: ." with an empty list.
+    blocks.push(
+      'Assignment groups are set to be weighted, but no assignment groups are configured.',
+    )
   } else {
     blocks.push('Assignment groups are not weighted — all assignments contribute equally.')
   }
@@ -184,23 +190,36 @@ export function gradingPolicyTools(canvas: CanvasClient): ToolDefinition[] {
         // Call 4 (conditional): resolve the grading-standard title. The course
         // endpoint returns only course-owned standards, so fall back to the
         // account standard when the id is not found at the course level.
+        //
+        // The title is non-essential — a missing/unreadable standard degrades to
+        // a null title + caveat rather than failing the whole tool. So a
+        // CanvasApiError here (e.g. an instructor who can read the course but not
+        // the account-level standards list → 403) is caught and degraded, which
+        // keeps the allSettled partial-data contract intact. Non-Canvas errors
+        // still propagate.
         let standardTitle: string | null = null
         if (course.grading_standard_id != null) {
-          const courseStandards = await canvas.gradingStandards.listForCourse(courseId)
-          const found = courseStandards.find((s) => s.id === course.grading_standard_id)
-          if (found) {
-            standardTitle = found.title
-          } else if (course.account_id != null) {
-            const accountStandards = await canvas.gradingStandards.listForAccount(course.account_id)
-            const foundInAccount = accountStandards.find((s) => s.id === course.grading_standard_id)
-            if (foundInAccount) {
-              standardTitle = foundInAccount.title
-            } else {
-              caveats.push(
-                `Grading standard (id: ${course.grading_standard_id}) could not be retrieved.`,
+          try {
+            const courseStandards = await canvas.gradingStandards.listForCourse(courseId)
+            const found = courseStandards.find((s) => s.id === course.grading_standard_id)
+            if (found) {
+              standardTitle = found.title
+            } else if (course.account_id != null) {
+              const accountStandards = await canvas.gradingStandards.listForAccount(
+                course.account_id,
               )
+              const foundInAccount = accountStandards.find(
+                (s) => s.id === course.grading_standard_id,
+              )
+              if (foundInAccount) {
+                standardTitle = foundInAccount.title
+              }
             }
-          } else {
+          } catch (err) {
+            if (!(err instanceof CanvasApiError)) throw err
+            // Standard not retrievable (permission/transient) — degrade below.
+          }
+          if (standardTitle === null) {
             caveats.push(
               `Grading standard (id: ${course.grading_standard_id}) could not be retrieved.`,
             )

--- a/src/tools/grading-policy.ts
+++ b/src/tools/grading-policy.ts
@@ -1,0 +1,263 @@
+import { z } from 'zod'
+import type { CanvasClient } from '../canvas'
+import { CanvasApiError } from '../canvas/client'
+import type { CanvasLatePolicy } from '../canvas/types'
+import type { ToolDefinition } from './types'
+
+/**
+ * Synthetic policy used when Canvas returns 404 for `late_policy` — i.e. the
+ * course has never had a late policy saved, so no automation is in effect.
+ */
+const DEFAULT_LATE_POLICY: CanvasLatePolicy = {
+  late_submission_deduction_enabled: false,
+  late_submission_deduction: 0,
+  late_submission_interval: 'day',
+  late_submission_minimum_percent_enabled: false,
+  late_submission_minimum_percent: 0,
+  missing_submission_deduction_enabled: false,
+  missing_submission_deduction: 0,
+}
+
+type PolicySource = 'api' | 'default'
+
+interface MissingPolicyOut {
+  source: PolicySource
+  enabled: boolean
+  deduction_percent: number
+}
+
+interface LatePolicyOut {
+  source: PolicySource
+  enabled: boolean
+  deduction_percent: number
+  interval: 'hour' | 'day'
+  minimum_percent_enabled: boolean
+  minimum_percent: number
+}
+
+interface GroupWeightOut {
+  id: number
+  name: string
+  weight: number
+}
+
+/** Assemble the plain-language summary paragraph from the structured policy. */
+function buildSummary(
+  missing: MissingPolicyOut | null,
+  late: LatePolicyOut | null,
+  weighted: boolean,
+  groups: ReadonlyArray<GroupWeightOut>,
+  schemeApplied: boolean,
+  schemeTitle: string | null,
+  policyUnavailable: boolean,
+): string {
+  const blocks: string[] = []
+
+  if (missing !== null) {
+    if (missing.enabled) {
+      if (missing.deduction_percent === 100) {
+        blocks.push('Missing work is automatically scored 0% (auto-zero).')
+      } else if (missing.deduction_percent === 0) {
+        blocks.push('Missing work policy is enabled with no deduction (0%).')
+      } else {
+        blocks.push(
+          `Missing work loses ${missing.deduction_percent}% of possible points automatically.`,
+        )
+      }
+    } else {
+      blocks.push('No automatic missing-work penalty.')
+    }
+  }
+
+  if (late !== null) {
+    if (late.enabled) {
+      let sentence = `Late submissions lose ${late.deduction_percent}% per ${late.interval}.`
+      if (late.minimum_percent_enabled) {
+        sentence += ` Grade cannot fall below ${late.minimum_percent}%.`
+      }
+      blocks.push(sentence)
+    } else {
+      blocks.push('No automatic late penalty.')
+    }
+  }
+
+  if (weighted) {
+    const list = groups.map((g) => `${g.name} (${g.weight}%)`).join(', ')
+    blocks.push(`Assignment groups are weighted: ${list}.`)
+  } else {
+    blocks.push('Assignment groups are not weighted — all assignments contribute equally.')
+  }
+
+  if (schemeApplied && schemeTitle !== null) {
+    blocks.push(`A letter-grade scheme is applied ("${schemeTitle}").`)
+  } else if (schemeApplied && schemeTitle === null) {
+    blocks.push('A letter-grade scheme is applied (title unavailable).')
+  } else {
+    blocks.push('No letter-grade scheme is applied.')
+  }
+
+  let summary = blocks.join(' ')
+  if (policyUnavailable) {
+    summary += ' Late/missing penalty details require instructor permissions and are not available.'
+  }
+  return summary
+}
+
+export function gradingPolicyTools(canvas: CanvasClient): ToolDefinition[] {
+  return [
+    {
+      name: 'explain_grading_policy',
+      description:
+        'Explains the grading automation rules configured for a Canvas course:\n' +
+        '- Missing-submission policy: whether blank/unsubmitted work is automatically scored 0 (or ' +
+        'another deduction), or left unpenalised.\n' +
+        '- Late-submission policy: whether Canvas applies a per-day or per-hour percentage deduction ' +
+        'to late submissions, and whether there is a floor below which the grade cannot fall.\n' +
+        '- Assignment-group weighting: whether the course uses weighted groups, and the weight of ' +
+        'each group.\n' +
+        '- Grading scheme: whether a letter-grade scheme (A/B/C/F mapping) is applied to the final ' +
+        'score.\n\n' +
+        'Also returns a plain-language summary paragraph you can share with students or instructors.\n\n' +
+        'Note: the late/missing policy section requires instructor or admin permissions. Students ' +
+        'receive the group-weighting and grading-scheme sections only, with a caveat noting what is ' +
+        'unavailable. Use explain_grade to compute the actual weighted grade for a specific student.',
+      inputSchema: {
+        course_id: z
+          .number()
+          .int()
+          .positive()
+          .describe('Canvas course ID to explain the grading policy for.'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+
+        // Calls 1–3 are independent. allSettled (not all) lets a 403/404 on the
+        // late-policy call leave the course + groups results intact.
+        const [latePolicyResult, courseResult, groupsResult] = await Promise.allSettled([
+          canvas.latePolicy.get(courseId),
+          canvas.courses.get(courseId),
+          canvas.assignments.listGroups(courseId),
+        ])
+
+        // Course + assignment groups are required — the tool cannot produce
+        // meaningful output without them. Re-throw so buildHandler() (in
+        // src/tools/index.ts) maps the CanvasApiError via formatError().
+        if (courseResult.status === 'rejected') throw courseResult.reason
+        if (groupsResult.status === 'rejected') throw groupsResult.reason
+        const course = courseResult.value
+        const groups = groupsResult.value
+
+        const caveats: string[] = []
+
+        // Call 1: late policy — only 403 (no permission) and 404 (no policy row
+        // yet) are handled gracefully; any other error propagates.
+        let latePolicySource: PolicySource = 'default'
+        let rawLatePolicy: CanvasLatePolicy = DEFAULT_LATE_POLICY
+        let policyUnavailable = false
+
+        if (latePolicyResult.status === 'fulfilled') {
+          rawLatePolicy = latePolicyResult.value
+          latePolicySource = 'api'
+        } else {
+          const err = latePolicyResult.reason
+          if (err instanceof CanvasApiError && err.status === 403) {
+            policyUnavailable = true
+          } else if (err instanceof CanvasApiError && err.status === 404) {
+            latePolicySource = 'default'
+          } else {
+            throw err
+          }
+        }
+
+        if (policyUnavailable) {
+          caveats.push(
+            'Late/missing submission policy requires instructor or admin permissions — policy ' +
+              'details are not accessible with this token.',
+          )
+        }
+
+        // Call 4 (conditional): resolve the grading-standard title. The course
+        // endpoint returns only course-owned standards, so fall back to the
+        // account standard when the id is not found at the course level.
+        let standardTitle: string | null = null
+        if (course.grading_standard_id != null) {
+          const courseStandards = await canvas.gradingStandards.listForCourse(courseId)
+          const found = courseStandards.find((s) => s.id === course.grading_standard_id)
+          if (found) {
+            standardTitle = found.title
+          } else if (course.account_id != null) {
+            const accountStandards = await canvas.gradingStandards.listForAccount(course.account_id)
+            const foundInAccount = accountStandards.find((s) => s.id === course.grading_standard_id)
+            if (foundInAccount) {
+              standardTitle = foundInAccount.title
+            } else {
+              caveats.push(
+                `Grading standard (id: ${course.grading_standard_id}) could not be retrieved.`,
+              )
+            }
+          } else {
+            caveats.push(
+              `Grading standard (id: ${course.grading_standard_id}) could not be retrieved.`,
+            )
+          }
+        }
+
+        const missingPolicy: MissingPolicyOut | null = policyUnavailable
+          ? null
+          : {
+              source: latePolicySource,
+              enabled: rawLatePolicy.missing_submission_deduction_enabled,
+              deduction_percent: rawLatePolicy.missing_submission_deduction,
+            }
+
+        const latePolicy: LatePolicyOut | null = policyUnavailable
+          ? null
+          : {
+              source: latePolicySource,
+              enabled: rawLatePolicy.late_submission_deduction_enabled,
+              deduction_percent: rawLatePolicy.late_submission_deduction,
+              interval: rawLatePolicy.late_submission_interval,
+              minimum_percent_enabled: rawLatePolicy.late_submission_minimum_percent_enabled,
+              minimum_percent: rawLatePolicy.late_submission_minimum_percent,
+            }
+
+        const weighted = course.apply_assignment_group_weights ?? false
+        const groupWeighting: GroupWeightOut[] = groups.map((g) => ({
+          id: g.id,
+          name: g.name,
+          weight: g.group_weight,
+        }))
+
+        const schemeApplied = course.grading_standard_id != null
+        const summary = buildSummary(
+          missingPolicy,
+          latePolicy,
+          weighted,
+          groupWeighting,
+          schemeApplied,
+          standardTitle,
+          policyUnavailable,
+        )
+
+        return {
+          course: { id: course.id, name: course.name },
+          missing_submission_policy: missingPolicy,
+          late_submission_policy: latePolicy,
+          group_weighting: { weighted, groups: groupWeighting },
+          grading_scheme: {
+            applied: schemeApplied,
+            standard_id: course.grading_standard_id ?? null,
+            standard_title: standardTitle,
+          },
+          summary,
+          caveats,
+        }
+      },
+    },
+  ]
+}

--- a/src/tools/grading-policy.ts
+++ b/src/tools/grading-policy.ts
@@ -217,7 +217,13 @@ export function gradingPolicyTools(canvas: CanvasClient): ToolDefinition[] {
             }
           } catch (err) {
             if (!(err instanceof CanvasApiError)) throw err
-            // Standard not retrievable (permission/transient) — degrade below.
+            // Only "not retrievable for a non-error reason" degrades to a caveat:
+            // 403 (no permission to read the account standards list) and 404
+            // (the referenced standard is gone). Transient/actionable failures
+            // (5xx, 429, 401) propagate to formatError() with their specific
+            // message — mirroring the late-policy handling above, so a retryable
+            // error is never masked as a permanent "could not be retrieved".
+            if (err.status !== 403 && err.status !== 404) throw err
           }
           if (standardTitle === null) {
             caveats.push(

--- a/tests/canvas/late-policy.test.ts
+++ b/tests/canvas/late-policy.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { LatePolicyModule } from '../../src/canvas/late-policy'
+import { CanvasHttpClient, CanvasApiError } from '../../src/canvas/client'
+
+const mockLatePolicy = {
+  id: 7,
+  course_id: 100,
+  missing_submission_deduction_enabled: true,
+  missing_submission_deduction: 100,
+  late_submission_deduction_enabled: true,
+  late_submission_deduction: 10,
+  late_submission_interval: 'day' as const,
+  late_submission_minimum_percent_enabled: true,
+  late_submission_minimum_percent: 50,
+}
+
+describe('LatePolicyModule', () => {
+  let client: CanvasHttpClient
+  let module: LatePolicyModule
+
+  beforeEach(() => {
+    client = new CanvasHttpClient({
+      token: 'test-token',
+      baseUrl: 'https://canvas.example.com',
+    })
+    module = new LatePolicyModule(client)
+  })
+
+  it('unwraps the late_policy envelope and hits the course late_policy endpoint', async () => {
+    const requestSpy = vi
+      .spyOn(client, 'request')
+      .mockResolvedValueOnce({ late_policy: mockLatePolicy })
+    const result = await module.get(100)
+    expect(result).toEqual(mockLatePolicy)
+    expect(requestSpy).toHaveBeenCalledWith('/api/v1/courses/100/late_policy')
+  })
+
+  it('propagates a 403 CanvasApiError (student tokens lack manage_grades)', async () => {
+    vi.spyOn(client, 'request').mockRejectedValueOnce(
+      new CanvasApiError('Forbidden', 403, '/api/v1/courses/100/late_policy'),
+    )
+    await expect(module.get(100)).rejects.toThrow(CanvasApiError)
+  })
+
+  it('propagates a 404 CanvasApiError (no late policy row exists yet)', async () => {
+    vi.spyOn(client, 'request').mockRejectedValueOnce(
+      new CanvasApiError('Not Found', 404, '/api/v1/courses/100/late_policy'),
+    )
+    await expect(module.get(100)).rejects.toMatchObject({ status: 404 })
+  })
+})

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(136)
+    expect(manifest.tools).toHaveLength(137)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/tools/grading-policy.test.ts
+++ b/tests/tools/grading-policy.test.ts
@@ -1,0 +1,359 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { CanvasClient } from '../../src/canvas'
+import { CanvasApiError } from '../../src/canvas/client'
+import type { CanvasLatePolicy } from '../../src/canvas/types'
+import { gradingPolicyTools } from '../../src/tools/grading-policy'
+
+// ── Output shape (mirrors the tool contract; partial for assertion typing) ───
+
+interface PolicyBlock {
+  source: 'api' | 'default'
+  enabled: boolean
+  deduction_percent: number
+}
+
+interface LateBlock extends PolicyBlock {
+  interval: 'hour' | 'day'
+  minimum_percent_enabled: boolean
+  minimum_percent: number
+}
+
+interface GradingPolicyOut {
+  course: { id: number; name: string }
+  missing_submission_policy: PolicyBlock | null
+  late_submission_policy: LateBlock | null
+  group_weighting: {
+    weighted: boolean
+    groups: Array<{ id: number; name: string; weight: number }>
+  }
+  grading_scheme: { applied: boolean; standard_id: number | null; standard_title: string | null }
+  summary: string
+  caveats: string[]
+}
+
+// ── Fixtures helpers ─────────────────────────────────────────────────────────
+
+function latePolicy(p: Partial<CanvasLatePolicy> = {}): CanvasLatePolicy {
+  return {
+    late_submission_deduction_enabled: false,
+    late_submission_deduction: 0,
+    late_submission_interval: 'day',
+    late_submission_minimum_percent_enabled: false,
+    late_submission_minimum_percent: 0,
+    missing_submission_deduction_enabled: false,
+    missing_submission_deduction: 0,
+    ...p,
+  }
+}
+
+interface MockOverrides {
+  /** Resolved late-policy value. Ignored when `latePolicyError` is set. */
+  latePolicy?: CanvasLatePolicy
+  /** When set, `canvas.latePolicy.get` rejects with this error. */
+  latePolicyError?: unknown
+  course?: unknown
+  groups?: unknown[]
+  courseStandards?: unknown[]
+  accountStandards?: unknown[]
+}
+
+function buildMockCanvas(o: MockOverrides = {}): CanvasClient {
+  const latePolicyGet =
+    o.latePolicyError !== undefined
+      ? vi.fn().mockRejectedValue(o.latePolicyError)
+      : vi.fn().mockResolvedValue(o.latePolicy ?? latePolicy())
+  return {
+    latePolicy: { get: latePolicyGet },
+    courses: {
+      get: vi.fn().mockResolvedValue(o.course ?? { id: 1, name: 'Course' }),
+    },
+    assignments: {
+      listGroups: vi.fn().mockResolvedValue(o.groups ?? []),
+    },
+    gradingStandards: {
+      listForCourse: vi.fn().mockResolvedValue(o.courseStandards ?? []),
+      listForAccount: vi.fn().mockResolvedValue(o.accountStandards ?? []),
+    },
+  } as unknown as CanvasClient
+}
+
+async function run(
+  overrides: MockOverrides,
+  params: Record<string, unknown> = { course_id: 1 },
+): Promise<{ result: GradingPolicyOut; canvas: CanvasClient }> {
+  const canvas = buildMockCanvas(overrides)
+  const result = (await gradingPolicyTools(canvas)[0].handler(params)) as GradingPolicyOut
+  return { result, canvas }
+}
+
+// ── Tool metadata ────────────────────────────────────────────────────────────
+
+describe('explain_grading_policy — metadata', () => {
+  it('is a read-only, open-world tool with the expected name', () => {
+    const tool = gradingPolicyTools(buildMockCanvas())[0]
+    expect(tool.name).toBe('explain_grading_policy')
+    expect(tool.annotations).toMatchObject({
+      readOnlyHint: true,
+      destructiveHint: false,
+      openWorldHint: true,
+    })
+  })
+})
+
+// ── Fixture A — full instructor view ─────────────────────────────────────────
+
+describe('explain_grading_policy — Fixture A (auto-zero + late penalty + weighted + scheme)', () => {
+  const overrides: MockOverrides = {
+    course: {
+      id: 1,
+      name: 'Physics 101',
+      apply_assignment_group_weights: true,
+      grading_standard_id: 42,
+      account_id: 10,
+    },
+    latePolicy: latePolicy({
+      missing_submission_deduction_enabled: true,
+      missing_submission_deduction: 100,
+      late_submission_deduction_enabled: true,
+      late_submission_deduction: 10,
+      late_submission_interval: 'day',
+      late_submission_minimum_percent_enabled: true,
+      late_submission_minimum_percent: 50,
+    }),
+    groups: [
+      { id: 1, name: 'Exams', group_weight: 60 },
+      { id: 2, name: 'Homework', group_weight: 40 },
+    ],
+    courseStandards: [{ id: 42, title: 'Default Grading Scale', grading_scheme: [] }],
+  }
+
+  it('surfaces the full policy with an instructor-facing summary', async () => {
+    const { result } = await run(overrides)
+    expect(result.missing_submission_policy).toEqual({
+      source: 'api',
+      enabled: true,
+      deduction_percent: 100,
+    })
+    expect(result.late_submission_policy).toEqual({
+      source: 'api',
+      enabled: true,
+      deduction_percent: 10,
+      interval: 'day',
+      minimum_percent_enabled: true,
+      minimum_percent: 50,
+    })
+    expect(result.group_weighting.weighted).toBe(true)
+    expect(result.group_weighting.groups).toEqual([
+      { id: 1, name: 'Exams', weight: 60 },
+      { id: 2, name: 'Homework', weight: 40 },
+    ])
+    expect(result.grading_scheme.applied).toBe(true)
+    expect(result.grading_scheme.standard_title).toBe('Default Grading Scale')
+    for (const fragment of ['auto-zero', '10%', 'day', '50%', 'Exams', 'Homework']) {
+      expect(result.summary).toContain(fragment)
+    }
+    expect(result.caveats).toEqual([])
+  })
+})
+
+// ── Fixture B — no policy configured (404) ───────────────────────────────────
+
+describe('explain_grading_policy — Fixture B (late_policy 404)', () => {
+  const overrides: MockOverrides = {
+    course: {
+      id: 1,
+      name: 'Course',
+      apply_assignment_group_weights: false,
+      grading_standard_id: null,
+    },
+    latePolicyError: new CanvasApiError('Not Found', 404, '/api/v1/courses/1/late_policy'),
+    groups: [{ id: 1, name: 'Assignments', group_weight: 0 }],
+  }
+
+  it('normalises a 404 to defaults (source: default), no caveat', async () => {
+    const { result } = await run(overrides)
+    expect(result.missing_submission_policy).not.toBeNull()
+    expect(result.missing_submission_policy?.enabled).toBe(false)
+    expect(result.missing_submission_policy?.source).toBe('default')
+    expect(result.late_submission_policy?.enabled).toBe(false)
+    expect(result.late_submission_policy?.source).toBe('default')
+    expect(result.group_weighting.weighted).toBe(false)
+    expect(result.grading_scheme.applied).toBe(false)
+    expect(result.grading_scheme.standard_id).toBeNull()
+    for (const fragment of ['No automatic', 'not weighted', 'No letter-grade']) {
+      expect(result.summary).toContain(fragment)
+    }
+    expect(result.caveats).toEqual([])
+  })
+})
+
+// ── Fixture C — student token (403) ──────────────────────────────────────────
+
+describe('explain_grading_policy — Fixture C (late_policy 403)', () => {
+  const overrides: MockOverrides = {
+    course: {
+      id: 1,
+      name: 'Course',
+      apply_assignment_group_weights: true,
+      grading_standard_id: null,
+    },
+    latePolicyError: new CanvasApiError('Forbidden', 403, '/api/v1/courses/1/late_policy'),
+    groups: [{ id: 1, name: 'Exams', group_weight: 100 }],
+  }
+
+  it('returns null policy blocks and exactly one permission caveat', async () => {
+    const { result } = await run(overrides)
+    expect(result.missing_submission_policy).toBeNull()
+    expect(result.late_submission_policy).toBeNull()
+    expect(result.group_weighting.weighted).toBe(true)
+    expect(result.group_weighting.groups[0]?.weight).toBe(100)
+    expect(result.caveats).toHaveLength(1)
+    expect(result.caveats[0]).toContain('instructor or admin permissions')
+    for (const fragment of ['Exams', '100%', 'instructor permissions']) {
+      expect(result.summary).toContain(fragment)
+    }
+  })
+})
+
+// ── Fixture D — account-scoped grading standard (two-level fallback) ──────────
+
+describe('explain_grading_policy — Fixture D (account-scoped standard)', () => {
+  const overrides: MockOverrides = {
+    course: {
+      id: 1,
+      name: 'Course',
+      apply_assignment_group_weights: false,
+      grading_standard_id: 42,
+      account_id: 10,
+    },
+    latePolicy: latePolicy(),
+    courseStandards: [],
+    accountStandards: [{ id: 42, title: 'Institutional Scale', grading_scheme: [] }],
+    groups: [{ id: 1, name: 'Assignments', group_weight: 0 }],
+  }
+
+  it('falls back to the account standard and records both lookups', async () => {
+    const { result, canvas } = await run(overrides)
+    expect(result.grading_scheme.applied).toBe(true)
+    expect(result.grading_scheme.standard_title).toBe('Institutional Scale')
+    expect(canvas.gradingStandards.listForCourse).toHaveBeenCalledWith(1)
+    expect(canvas.gradingStandards.listForAccount).toHaveBeenCalledWith(10)
+    expect(result.caveats).toEqual([])
+  })
+})
+
+// ── Fixture E — grading standard not retrievable at either level ──────────────
+
+describe('explain_grading_policy — Fixture E (standard unretrievable)', () => {
+  const overrides: MockOverrides = {
+    course: {
+      id: 1,
+      name: 'Course',
+      apply_assignment_group_weights: false,
+      grading_standard_id: 99,
+      account_id: 10,
+    },
+    latePolicy: latePolicy(),
+    courseStandards: [{ id: 1, title: 'Other', grading_scheme: [] }],
+    accountStandards: [],
+    groups: [{ id: 1, name: 'Assignments', group_weight: 0 }],
+  }
+
+  it('reports applied but with a null title and a retrieval caveat', async () => {
+    const { result } = await run(overrides)
+    expect(result.grading_scheme.applied).toBe(true)
+    expect(result.grading_scheme.standard_id).toBe(99)
+    expect(result.grading_scheme.standard_title).toBeNull()
+    expect(
+      result.caveats.some((c) => c.includes('Grading standard (id: 99) could not be retrieved')),
+    ).toBe(true)
+  })
+})
+
+// ── Fixture F — late penalty with no floor ───────────────────────────────────
+
+describe('explain_grading_policy — Fixture F (late penalty, no floor)', () => {
+  const overrides: MockOverrides = {
+    course: {
+      id: 1,
+      name: 'Course',
+      apply_assignment_group_weights: false,
+      grading_standard_id: null,
+    },
+    latePolicy: latePolicy({
+      late_submission_deduction_enabled: true,
+      late_submission_deduction: 5,
+      late_submission_interval: 'hour',
+      late_submission_minimum_percent_enabled: false,
+      late_submission_minimum_percent: 0,
+    }),
+    groups: [{ id: 1, name: 'Assignments', group_weight: 0 }],
+  }
+
+  it('omits the floor sentence when no minimum is configured', async () => {
+    const { result } = await run(overrides)
+    expect(result.late_submission_policy?.minimum_percent_enabled).toBe(false)
+    expect(result.late_submission_policy?.minimum_percent).toBe(0)
+    expect(result.summary).toContain('5%')
+    expect(result.summary).toContain('hour')
+    expect(result.summary).not.toContain('floor')
+    expect(result.summary).not.toContain('minimum')
+    expect(result.summary).not.toContain('below')
+  })
+})
+
+// ── Fixture G — deduction 0 with policy enabled (edge case) ───────────────────
+
+describe('explain_grading_policy — Fixture G (enabled, 0% deduction)', () => {
+  const overrides: MockOverrides = {
+    course: {
+      id: 1,
+      name: 'Course',
+      apply_assignment_group_weights: false,
+      grading_standard_id: null,
+    },
+    latePolicy: latePolicy({
+      missing_submission_deduction_enabled: true,
+      missing_submission_deduction: 0,
+    }),
+    groups: [{ id: 1, name: 'Assignments', group_weight: 0 }],
+  }
+
+  it('says "no deduction (0%)" rather than inferring 100%', async () => {
+    const { result } = await run(overrides)
+    expect(result.summary).toContain('no deduction (0%)')
+    expect(result.summary).not.toContain('100%')
+  })
+})
+
+// ── Error propagation — required calls ───────────────────────────────────────
+
+describe('explain_grading_policy — required-call failures propagate', () => {
+  it('propagates a non-403/404 error from the late_policy call', async () => {
+    const canvas = buildMockCanvas({
+      course: { id: 1, name: 'Course', grading_standard_id: null },
+      latePolicyError: new CanvasApiError('Server Error', 500, '/api/v1/courses/1/late_policy'),
+      groups: [{ id: 1, name: 'Assignments', group_weight: 0 }],
+    })
+    await expect(gradingPolicyTools(canvas)[0].handler({ course_id: 1 })).rejects.toThrow(
+      CanvasApiError,
+    )
+  })
+
+  it('propagates a failure from the required course call', async () => {
+    const canvas = {
+      latePolicy: { get: vi.fn().mockResolvedValue(latePolicy()) },
+      courses: {
+        get: vi.fn().mockRejectedValue(new CanvasApiError('Not Found', 404, '/api/v1/courses/1')),
+      },
+      assignments: { listGroups: vi.fn().mockResolvedValue([]) },
+      gradingStandards: {
+        listForCourse: vi.fn().mockResolvedValue([]),
+        listForAccount: vi.fn().mockResolvedValue([]),
+      },
+    } as unknown as CanvasClient
+    await expect(gradingPolicyTools(canvas)[0].handler({ course_id: 1 })).rejects.toThrow(
+      CanvasApiError,
+    )
+  })
+})

--- a/tests/tools/grading-policy.test.ts
+++ b/tests/tools/grading-policy.test.ts
@@ -148,6 +148,7 @@ describe('explain_grading_policy — Fixture A (auto-zero + late penalty + weigh
       { id: 2, name: 'Homework', weight: 40 },
     ])
     expect(result.grading_scheme.applied).toBe(true)
+    expect(result.grading_scheme.standard_id).toBe(42)
     expect(result.grading_scheme.standard_title).toBe('Default Grading Scale')
     for (const fragment of ['auto-zero', '10%', 'day', '50%', 'Exams', 'Homework']) {
       expect(result.summary).toContain(fragment)
@@ -323,6 +324,151 @@ describe('explain_grading_policy — Fixture G (enabled, 0% deduction)', () => {
     const { result } = await run(overrides)
     expect(result.summary).toContain('no deduction (0%)')
     expect(result.summary).not.toContain('100%')
+  })
+})
+
+// ── Fixture H — mid-range missing deduction (partial, neither 0 nor 100) ─────
+
+describe('explain_grading_policy — Fixture H (partial missing deduction)', () => {
+  const overrides: MockOverrides = {
+    course: {
+      id: 1,
+      name: 'Course',
+      apply_assignment_group_weights: false,
+      grading_standard_id: null,
+    },
+    latePolicy: latePolicy({
+      missing_submission_deduction_enabled: true,
+      missing_submission_deduction: 25,
+    }),
+    groups: [{ id: 1, name: 'Assignments', group_weight: 0 }],
+  }
+
+  it('describes a partial missing-work deduction without auto-zero/0% wording', async () => {
+    const { result } = await run(overrides)
+    expect(result.missing_submission_policy?.deduction_percent).toBe(25)
+    expect(result.summary).toContain('Missing work loses 25%')
+    expect(result.summary).not.toContain('auto-zero')
+    expect(result.summary).not.toContain('no deduction')
+  })
+})
+
+// ── Fixture I — grading standard set, course has no account_id ────────────────
+
+describe('explain_grading_policy — Fixture I (standard set, no account_id)', () => {
+  const overrides: MockOverrides = {
+    course: {
+      id: 1,
+      name: 'Course',
+      apply_assignment_group_weights: false,
+      grading_standard_id: 99,
+      // account_id intentionally omitted
+    },
+    latePolicy: latePolicy(),
+    courseStandards: [{ id: 1, title: 'Other', grading_scheme: [] }],
+    groups: [{ id: 1, name: 'Assignments', group_weight: 0 }],
+  }
+
+  it('caveats without an account fallback and never calls listForAccount', async () => {
+    const { result, canvas } = await run(overrides)
+    expect(result.grading_scheme.applied).toBe(true)
+    expect(result.grading_scheme.standard_id).toBe(99)
+    expect(result.grading_scheme.standard_title).toBeNull()
+    expect(canvas.gradingStandards.listForAccount).not.toHaveBeenCalled()
+    expect(
+      result.caveats.some((c) => c.includes('Grading standard (id: 99) could not be retrieved')),
+    ).toBe(true)
+  })
+})
+
+// ── Fixture J — weighted course with no assignment groups configured ──────────
+
+describe('explain_grading_policy — Fixture J (weighted, empty groups)', () => {
+  const overrides: MockOverrides = {
+    course: {
+      id: 1,
+      name: 'Course',
+      apply_assignment_group_weights: true,
+      grading_standard_id: null,
+    },
+    latePolicy: latePolicy(),
+    groups: [],
+  }
+
+  it('reflects the weighted flag without emitting a malformed empty group list', async () => {
+    const { result } = await run(overrides)
+    expect(result.group_weighting.weighted).toBe(true)
+    expect(result.group_weighting.groups).toEqual([])
+    expect(result.summary).not.toContain('weighted: .')
+    expect(result.summary).toContain('no assignment groups are configured')
+  })
+})
+
+// ── Fixture K — grading-standard lookup throws (degrades, does not abort) ──────
+
+describe('explain_grading_policy — Fixture K (call-4 CanvasApiError degrades)', () => {
+  it('degrades a 403 on the account standard lookup to a caveat instead of failing', async () => {
+    const canvas = {
+      latePolicy: { get: vi.fn().mockResolvedValue(latePolicy()) },
+      courses: {
+        get: vi.fn().mockResolvedValue({
+          id: 1,
+          name: 'Course',
+          apply_assignment_group_weights: false,
+          grading_standard_id: 42,
+          account_id: 10,
+        }),
+      },
+      assignments: {
+        listGroups: vi.fn().mockResolvedValue([{ id: 1, name: 'Assignments', group_weight: 0 }]),
+      },
+      gradingStandards: {
+        listForCourse: vi.fn().mockResolvedValue([]),
+        listForAccount: vi
+          .fn()
+          .mockRejectedValue(
+            new CanvasApiError('Forbidden', 403, '/api/v1/accounts/10/grading_standards'),
+          ),
+      },
+    } as unknown as CanvasClient
+
+    const result = (await gradingPolicyTools(canvas)[0].handler({
+      course_id: 1,
+    })) as GradingPolicyOut
+    expect(result.grading_scheme.applied).toBe(true)
+    expect(result.grading_scheme.standard_title).toBeNull()
+    expect(
+      result.caveats.some((c) => c.includes('Grading standard (id: 42) could not be retrieved')),
+    ).toBe(true)
+    // The rest of the policy still came through — partial-data contract intact.
+    expect(result.missing_submission_policy).not.toBeNull()
+  })
+})
+
+// ── Fixture L — multiple caveats coexist (403 policy + unretrievable standard) ─
+
+describe('explain_grading_policy — Fixture L (coexisting caveats)', () => {
+  const overrides: MockOverrides = {
+    course: {
+      id: 1,
+      name: 'Course',
+      apply_assignment_group_weights: true,
+      grading_standard_id: 99,
+      account_id: 10,
+    },
+    latePolicyError: new CanvasApiError('Forbidden', 403, '/api/v1/courses/1/late_policy'),
+    courseStandards: [],
+    accountStandards: [],
+    groups: [{ id: 1, name: 'Exams', group_weight: 100 }],
+  }
+
+  it('emits both the permission and the standard-retrieval caveats', async () => {
+    const { result } = await run(overrides)
+    expect(result.caveats).toHaveLength(2)
+    expect(result.caveats.some((c) => c.includes('instructor or admin permissions'))).toBe(true)
+    expect(
+      result.caveats.some((c) => c.includes('Grading standard (id: 99) could not be retrieved')),
+    ).toBe(true)
   })
 })
 

--- a/tests/tools/grading-policy.test.ts
+++ b/tests/tools/grading-policy.test.ts
@@ -153,6 +153,8 @@ describe('explain_grading_policy — Fixture A (auto-zero + late penalty + weigh
     for (const fragment of ['auto-zero', '10%', 'day', '50%', 'Exams', 'Homework']) {
       expect(result.summary).toContain(fragment)
     }
+    // Pin the weighted-groups sentence directly (lead-in + per-group rendering).
+    expect(result.summary).toContain('Assignment groups are weighted: Exams (60%), Homework (40%).')
     expect(result.caveats).toEqual([])
   })
 })
@@ -266,6 +268,8 @@ describe('explain_grading_policy — Fixture E (standard unretrievable)', () => 
     expect(result.grading_scheme.applied).toBe(true)
     expect(result.grading_scheme.standard_id).toBe(99)
     expect(result.grading_scheme.standard_title).toBeNull()
+    // Applied-but-title-unknown must read differently from "no scheme applied".
+    expect(result.summary).toContain('A letter-grade scheme is applied (title unavailable)')
     expect(
       result.caveats.some((c) => c.includes('Grading standard (id: 99) could not be retrieved')),
     ).toBe(true)

--- a/tests/tools/grading-policy.test.ts
+++ b/tests/tools/grading-policy.test.ts
@@ -164,7 +164,8 @@ describe('explain_grading_policy — Fixture B (late_policy 404)', () => {
     course: {
       id: 1,
       name: 'Course',
-      apply_assignment_group_weights: false,
+      // apply_assignment_group_weights intentionally omitted — exercises the
+      // `?? false` coalescing for the realistic Canvas shape where it is absent.
       grading_standard_id: null,
     },
     latePolicyError: new CanvasApiError('Not Found', 404, '/api/v1/courses/1/late_policy'),
@@ -472,6 +473,66 @@ describe('explain_grading_policy — Fixture L (coexisting caveats)', () => {
   })
 })
 
+// ── Fixture M — call-4 non-Canvas error propagates (not degraded) ─────────────
+
+describe('explain_grading_policy — Fixture M (call-4 non-Canvas error propagates)', () => {
+  it('re-throws a non-CanvasApiError from the grading-standard lookup', async () => {
+    const canvas = {
+      latePolicy: { get: vi.fn().mockResolvedValue(latePolicy()) },
+      courses: {
+        get: vi.fn().mockResolvedValue({
+          id: 1,
+          name: 'Course',
+          apply_assignment_group_weights: false,
+          grading_standard_id: 42,
+          account_id: 10,
+        }),
+      },
+      assignments: {
+        listGroups: vi.fn().mockResolvedValue([{ id: 1, name: 'Assignments', group_weight: 0 }]),
+      },
+      gradingStandards: {
+        listForCourse: vi.fn().mockRejectedValue(new TypeError('boom')),
+        listForAccount: vi.fn().mockResolvedValue([]),
+      },
+    } as unknown as CanvasClient
+    await expect(gradingPolicyTools(canvas)[0].handler({ course_id: 1 })).rejects.toThrow(TypeError)
+  })
+})
+
+// ── Fixture N — call-4 transient (5xx) CanvasApiError propagates (not degraded) ─
+
+describe('explain_grading_policy — Fixture N (call-4 5xx propagates)', () => {
+  it('re-throws a non-403/404 CanvasApiError instead of masking it as a caveat', async () => {
+    const canvas = {
+      latePolicy: { get: vi.fn().mockResolvedValue(latePolicy()) },
+      courses: {
+        get: vi.fn().mockResolvedValue({
+          id: 1,
+          name: 'Course',
+          apply_assignment_group_weights: false,
+          grading_standard_id: 42,
+          account_id: 10,
+        }),
+      },
+      assignments: {
+        listGroups: vi.fn().mockResolvedValue([{ id: 1, name: 'Assignments', group_weight: 0 }]),
+      },
+      gradingStandards: {
+        listForCourse: vi.fn().mockResolvedValue([]),
+        listForAccount: vi
+          .fn()
+          .mockRejectedValue(
+            new CanvasApiError('Server Error', 503, '/api/v1/accounts/10/grading_standards'),
+          ),
+      },
+    } as unknown as CanvasClient
+    await expect(gradingPolicyTools(canvas)[0].handler({ course_id: 1 })).rejects.toMatchObject({
+      status: 503,
+    })
+  })
+})
+
 // ── Error propagation — required calls ───────────────────────────────────────
 
 describe('explain_grading_policy — required-call failures propagate', () => {
@@ -493,6 +554,29 @@ describe('explain_grading_policy — required-call failures propagate', () => {
         get: vi.fn().mockRejectedValue(new CanvasApiError('Not Found', 404, '/api/v1/courses/1')),
       },
       assignments: { listGroups: vi.fn().mockResolvedValue([]) },
+      gradingStandards: {
+        listForCourse: vi.fn().mockResolvedValue([]),
+        listForAccount: vi.fn().mockResolvedValue([]),
+      },
+    } as unknown as CanvasClient
+    await expect(gradingPolicyTools(canvas)[0].handler({ course_id: 1 })).rejects.toThrow(
+      CanvasApiError,
+    )
+  })
+
+  it('propagates a failure from the required assignment-groups call', async () => {
+    const canvas = {
+      latePolicy: { get: vi.fn().mockResolvedValue(latePolicy()) },
+      courses: {
+        get: vi.fn().mockResolvedValue({ id: 1, name: 'Course', grading_standard_id: null }),
+      },
+      assignments: {
+        listGroups: vi
+          .fn()
+          .mockRejectedValue(
+            new CanvasApiError('Forbidden', 403, '/api/v1/courses/1/assignment_groups'),
+          ),
+      },
       gradingStandards: {
         listForCourse: vi.fn().mockResolvedValue([]),
         listForAccount: vi.fn().mockResolvedValue([]),

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -189,7 +189,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 136 tools across all domains', () => {
+  it('returns all 137 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 
@@ -360,8 +360,10 @@ describe('getAllTools', () => {
     expect(names).toContain('check_course_setup')
     // Grade Explanation (1)
     expect(names).toContain('explain_grade')
+    // Grading Policy (1)
+    expect(names).toContain('explain_grading_policy')
 
-    expect(tools).toHaveLength(136)
+    expect(tools).toHaveLength(137)
   })
 
   it('all tools have openWorldHint: true', () => {


### PR DESCRIPTION
## What & why

Implements the design-first spec merged in #214 (`docs/superpowers/specs/2026-06-23-issue-213-explain-grading-policy.md`).

> **User story** — As an instructor (or student) using Claude, I want to ask "how is grading set up in this course — will missing work automatically become a zero, are late submissions penalized, and are the assignment groups weighted?" and get a plain-language answer, instead of hunting through Canvas settings screens or guessing.

This is complementary to `explain_grade` (which recomputes the *numeric* grade): `explain_grading_policy` answers the prior question — *what rules will Canvas apply automatically?*

## Approach

A new read-only tool `explain_grading_policy` (input: `course_id`) composes four Canvas reads:

1. `GET /courses/:id/late_policy` via a new `LatePolicyModule` (unwraps the `{ late_policy }` envelope).
2. `GET /courses/:id` for `apply_assignment_group_weights`, `grading_standard_id`, `account_id`.
3. `GET /courses/:id/assignment_groups` for group names + weights.
4. (conditional) grading-standard lookup with course→account fallback for the scheme title.

Calls 1–3 run via `Promise.allSettled`, so a student **403** on `late_policy` (no `manage_grades`) degrades gracefully — both policy blocks become `null` with one permission caveat — instead of failing the whole call. A **404** (no policy row yet) normalises to "no automation configured" (`source: 'default'`). Course/groups failures and any non-403/404 late-policy error propagate to the framework's error formatter. The response carries no student PII (course-level config only), so per the spec it is **not** pseudonymizer-wrapped.

## Deviations from the spec (followed code reality, per the worker rules)

- **Error handling:** the spec's pseudocode used `return formatError(...)` inside the handler. In this codebase `formatError` lives in `src/tools/errors.ts`, returns a string, and `buildHandler` (`src/tools/index.ts`) already catches thrown `CanvasApiError`. So the handler **throws** required-call failures (matching `grade-explanation.ts`) rather than calling `formatError` itself.
- **Tool signature:** dropped the unused `pseudonymizer?` parameter — `noUnusedParameters` is on and the catalog's `getTools` type accepts a unary `(canvas) => ToolDefinition[]` (same as `courseTools`).
- **Test locations:** `tests/tools/grading-policy.test.ts` + `tests/canvas/late-policy.test.ts` (the repo splits tool- and canvas-layer tests), rather than the spec's single `tests/grading-policy.test.ts`.
- **Manifest/count gate:** bumped the hard-coded tool count 136 → 137 in `tests/tools/registry.test.ts` and `tests/discovery/manifests.test.ts`, and regenerated `docs/generated/tool-manifest.json` (`pnpm generate:manifests`). Also fixed the spec's internal duplicate-caveat inconsistency by pushing the permission caveat exactly once (Fixture C requires `caveats.length === 1`).

## Tests

Fixtures A–G from the spec (auto-zero + late penalty + weighted + scheme; 404 default; 403 student; account-scoped standard fallback; unretrievable standard; late penalty with no floor; enabled-but-0% deduction edge case), plus canvas-layer envelope-unwrap / 403 / 404 tests and required-call error propagation.

```
pnpm typecheck   ✓
pnpm lint        ✓  (eslint + prettier)
pnpm test        ✓  92 files, 1251 passed | 1 skipped
pnpm build       ✓
```

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)
