### PR TITLE
feat(link-audit): detect broken and cross-course links in course content

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 137,
+  "toolCount": 138,
   "tools": [
     {
       "name": "health_check",
@@ -1685,6 +1685,18 @@
       },
       "access": "read",
       "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "audit_course_links",
+      "domain": "link_audit",
+      "description": "Scan a course's content (pages, assignments, syllabus, announcements) for broken or outdated links and images. Returns structured findings: cross-course references (links that still point at a previous copy of the course — the canonical stale-copy failure after a course import) and empty/malformed URLs. Structural checks only — no outbound HTTP requests. Requires instructor permissions in the course.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
       "relatedWorkflows": []
     }
   ]

--- a/src/canvas/pages.ts
+++ b/src/canvas/pages.ts
@@ -14,6 +14,18 @@ export class PagesModule {
     )
   }
 
+  /**
+   * List every page in a course with its full HTML `body`. The paginated list
+   * endpoint returns page stubs without `body`, so this fans out a `get()` per
+   * page (mirroring the `listWithItems` pattern in `modules.ts`). Used by the
+   * link-audit tool to scan page content. `CanvasApiError` from either the list
+   * or any individual fetch propagates unchanged.
+   */
+  async listWithBodies(courseId: number): Promise<CanvasPage[]> {
+    const stubs = await this.client.paginate<CanvasPage>(`/api/v1/courses/${courseId}/pages`)
+    return Promise.all(stubs.map((stub) => this.get(courseId, stub.url)))
+  }
+
   async create(
     courseId: number,
     params: { title: string; body?: string; published?: boolean; editing_roles?: string },

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -33,6 +33,7 @@ import { submissionTools } from './submissions'
 import { submissionFileTools } from './submission-files'
 import type { ToolAudience, ToolDefinition } from './types'
 import { userTools } from './users'
+import { linkAuditTools } from './link-audit'
 
 export interface ToolDomainRegistration {
   domain: string
@@ -200,5 +201,10 @@ export const toolDomainCatalog: readonly ToolDomainRegistration[] = [
     domain: 'grading_policy',
     defaultPrimaryAudience: 'shared',
     getTools: gradingPolicyTools,
+  },
+  {
+    domain: 'link_audit',
+    defaultPrimaryAudience: 'educator',
+    getTools: linkAuditTools,
   },
 ]

--- a/src/tools/link-audit.ts
+++ b/src/tools/link-audit.ts
@@ -1,0 +1,189 @@
+import { z } from 'zod'
+import type { CanvasClient } from '../canvas'
+import type { ToolDefinition } from './types'
+
+const CONTENT_SOURCES = ['pages', 'assignments', 'syllabus', 'announcements'] as const
+type ContentSource = (typeof CONTENT_SOURCES)[number]
+type LinkKind = 'link' | 'image' | 'video'
+type FindingReason = 'cross_course_reference' | 'empty_or_malformed'
+
+interface ContentLocation {
+  type: ContentSource
+  id: number
+  title: string
+}
+
+interface LinkFinding {
+  location: ContentLocation
+  kind: LinkKind
+  href: string
+  reason: FindingReason
+  cross_course_id?: number
+}
+
+// Canvas generates predictably structured HTML with double-quoted attributes, so
+// regex extraction is accurate here without pulling in a DOM parser. Single-quoted
+// attributes are a known v1 limitation (see PR / spec notes).
+const HREF_RE = /<a\b[^>]*\bhref="([^"]*)"[^>]*>/gi
+const IMG_SRC_RE = /<img\b[^>]*\bsrc="([^"]*)"[^>]*>/gi
+const EMBED_SRC_RE = /<(?:iframe|embed|video|source)\b[^>]*\bsrc="([^"]*)"[^>]*>/gi
+
+function extractUrls(html: string | null | undefined): Array<{ kind: LinkKind; raw: string }> {
+  if (!html) return []
+  const results: Array<{ kind: LinkKind; raw: string }> = []
+  let m: RegExpExecArray | null
+  // Each regex carries the `g` flag and maintains `lastIndex` across calls; reset
+  // before scanning a new HTML string so prior state cannot skip the first match.
+  // The capture group `([^"]*)` always matches (possibly empty) when the overall
+  // pattern matches, so `m[1]` is never undefined at runtime; `?? ''` satisfies
+  // the compiler's `noUncheckedIndexedAccess` without changing behaviour.
+  HREF_RE.lastIndex = 0
+  while ((m = HREF_RE.exec(html)) !== null) results.push({ kind: 'link', raw: m[1] ?? '' })
+  IMG_SRC_RE.lastIndex = 0
+  while ((m = IMG_SRC_RE.exec(html)) !== null) results.push({ kind: 'image', raw: m[1] ?? '' })
+  EMBED_SRC_RE.lastIndex = 0
+  while ((m = EMBED_SRC_RE.exec(html)) !== null) results.push({ kind: 'video', raw: m[1] ?? '' })
+  return results
+}
+
+function decodeHtmlEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+}
+
+function classifyUrl(
+  raw: string,
+  courseId: number,
+): { reason: FindingReason; crossCourseId?: number } | null {
+  const href = decodeHtmlEntities(raw).trim()
+  if (!href || href === '#' || href.startsWith('javascript:')) {
+    return { reason: 'empty_or_malformed' }
+  }
+  const crossCourseId = href.match(/\/courses\/(\d+)\//)?.[1]
+  if (crossCourseId) {
+    const refId = parseInt(crossCourseId, 10)
+    if (refId !== courseId) {
+      return { reason: 'cross_course_reference', crossCourseId: refId }
+    }
+  }
+  return null
+}
+
+function scanHtml(
+  html: string | null | undefined,
+  courseId: number,
+  location: ContentLocation,
+): LinkFinding[] {
+  const findings: LinkFinding[] = []
+  for (const { kind, raw } of extractUrls(html)) {
+    const result = classifyUrl(raw, courseId)
+    if (!result) continue
+    const finding: LinkFinding = { location, kind, href: raw, reason: result.reason }
+    if (result.crossCourseId !== undefined) finding.cross_course_id = result.crossCourseId
+    findings.push(finding)
+  }
+  return findings
+}
+
+export function linkAuditTools(canvas: CanvasClient): ToolDefinition[] {
+  return [
+    {
+      name: 'audit_course_links',
+      description:
+        "Scan a course's content (pages, assignments, syllabus, announcements) for broken or " +
+        'outdated links and images. Returns structured findings: cross-course references (links ' +
+        'that still point at a previous copy of the course — the canonical stale-copy failure ' +
+        'after a course import) and empty/malformed URLs. Structural checks only — no outbound ' +
+        'HTTP requests. Requires instructor permissions in the course.',
+      inputSchema: {
+        course_id: z.number().int().positive().describe('Canvas course ID'),
+        include: z
+          .array(z.enum(['pages', 'assignments', 'syllabus', 'announcements']))
+          .optional()
+          .describe(
+            'Content sources to scan. Omit to scan all four. ' +
+              'Valid values: pages, assignments, syllabus, announcements.',
+          ),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+        const activeInclude = new Set<ContentSource>(
+          (params.include as ContentSource[] | undefined) ?? [...CONTENT_SOURCES],
+        )
+
+        const [pages, assignments, syllabus, announcements] = await Promise.all([
+          activeInclude.has('pages') ? canvas.pages.listWithBodies(courseId) : Promise.resolve([]),
+          activeInclude.has('assignments')
+            ? canvas.assignments.list(courseId)
+            : Promise.resolve([]),
+          activeInclude.has('syllabus')
+            ? canvas.courses.getSyllabus(courseId)
+            : Promise.resolve(null),
+          activeInclude.has('announcements')
+            ? canvas.discussions.listAnnouncements(courseId)
+            : Promise.resolve([]),
+        ])
+
+        const findings: LinkFinding[] = []
+
+        if (activeInclude.has('pages')) {
+          for (const page of pages) {
+            findings.push(
+              ...scanHtml(page.body, courseId, {
+                type: 'pages',
+                id: page.page_id,
+                title: page.title,
+              }),
+            )
+          }
+        }
+
+        if (activeInclude.has('assignments')) {
+          for (const a of assignments) {
+            findings.push(
+              ...scanHtml(a.description, courseId, {
+                type: 'assignments',
+                id: a.id,
+                title: a.name,
+              }),
+            )
+          }
+        }
+
+        if (activeInclude.has('syllabus') && syllabus) {
+          findings.push(
+            ...scanHtml(syllabus, courseId, { type: 'syllabus', id: courseId, title: 'Syllabus' }),
+          )
+        }
+
+        if (activeInclude.has('announcements')) {
+          for (const ann of announcements) {
+            findings.push(
+              ...scanHtml(ann.message, courseId, {
+                type: 'announcements',
+                id: ann.id,
+                title: ann.title,
+              }),
+            )
+          }
+        }
+
+        return {
+          summary: {
+            course_id: courseId,
+            sources_scanned: CONTENT_SOURCES.filter((s) => activeInclude.has(s)),
+            total_findings: findings.length,
+          },
+          findings,
+        }
+      },
+    },
+  ]
+}

--- a/tests/canvas/pages.test.ts
+++ b/tests/canvas/pages.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { PagesModule } from '../../src/canvas/pages'
-import { CanvasHttpClient } from '../../src/canvas/client'
+import { CanvasHttpClient, CanvasApiError } from '../../src/canvas/client'
 
 describe('PagesModule', () => {
   let client: CanvasHttpClient
@@ -81,6 +81,61 @@ describe('PagesModule', () => {
     await pages.delete(100, 'old-page')
     expect(client.request).toHaveBeenCalledWith('/api/v1/courses/100/pages/old-page', {
       method: 'DELETE',
+    })
+  })
+
+  describe('listWithBodies', () => {
+    it('fans out to fetch each page body', async () => {
+      vi.spyOn(client, 'paginate').mockResolvedValueOnce([
+        { page_id: 1, url: 'introduction', title: 'Introduction', published: true, updated_at: '' },
+        { page_id: 2, url: 'week-1', title: 'Week 1', published: true, updated_at: '' },
+      ])
+      vi.spyOn(client, 'request').mockResolvedValue({
+        page_id: 1,
+        url: 'introduction',
+        title: 'Introduction',
+        body: '<p>Hello</p>',
+        published: true,
+        updated_at: '',
+      })
+
+      const result = await pages.listWithBodies(42)
+
+      expect(result).toHaveLength(2)
+      expect(result.every((p) => p.body != null)).toBe(true)
+      expect(client.paginate).toHaveBeenCalledWith('/api/v1/courses/42/pages')
+      expect(client.request).toHaveBeenCalledTimes(2)
+      expect(client.request).toHaveBeenCalledWith('/api/v1/courses/42/pages/introduction')
+      expect(client.request).toHaveBeenCalledWith('/api/v1/courses/42/pages/week-1')
+    })
+
+    it('returns an empty array without fetching bodies for a course with no pages', async () => {
+      vi.spyOn(client, 'paginate').mockResolvedValueOnce([])
+      const requestSpy = vi.spyOn(client, 'request')
+
+      const result = await pages.listWithBodies(42)
+
+      expect(result).toEqual([])
+      expect(requestSpy).not.toHaveBeenCalled()
+    })
+
+    it('propagates a CanvasApiError thrown by paginate', async () => {
+      vi.spyOn(client, 'paginate').mockRejectedValueOnce(
+        new CanvasApiError('Not Found', 404, '/api/v1/courses/42/pages'),
+      )
+
+      await expect(pages.listWithBodies(42)).rejects.toBeInstanceOf(CanvasApiError)
+    })
+
+    it('propagates a CanvasApiError thrown while fetching a page body', async () => {
+      vi.spyOn(client, 'paginate').mockResolvedValueOnce([
+        { page_id: 1, url: 'introduction', title: 'Introduction', published: true, updated_at: '' },
+      ])
+      vi.spyOn(client, 'request').mockRejectedValueOnce(
+        new CanvasApiError('Forbidden', 403, '/api/v1/courses/42/pages/introduction'),
+      )
+
+      await expect(pages.listWithBodies(42)).rejects.toBeInstanceOf(CanvasApiError)
     })
   })
 })

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(137)
+    expect(manifest.tools).toHaveLength(138)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/tools/link-audit.test.ts
+++ b/tests/tools/link-audit.test.ts
@@ -296,6 +296,9 @@ describe('linkAuditTools', () => {
         reason: 'cross_course_reference',
         cross_course_id: 999,
       })
+      // href reports the RAW, un-decoded attribute value; decoding is applied only
+      // to the value used for classification, not to what is surfaced.
+      expect(result.findings[0].href).toBe('/courses/999/pages/foo?a=1&amp;b=2')
     })
 
     it('classifies an iframe src as a video kind', async () => {
@@ -319,6 +322,30 @@ describe('linkAuditTools', () => {
         course_id: 100,
         include: ['assignments'],
       })) as AuditResult
+
+      expect(result.findings).toHaveLength(1)
+      expect(result.findings[0]).toMatchObject({
+        kind: 'video',
+        reason: 'cross_course_reference',
+        cross_course_id: 999,
+      })
+    })
+
+    it('classifies a <source> inside a <video> as a video kind', async () => {
+      const canvas = makeCanvas({
+        pages: [
+          {
+            page_id: 1,
+            url: 'p',
+            title: 'P',
+            published: true,
+            updated_at: '',
+            body: '<video controls><source src="/courses/999/media_objects/m2"></video>',
+          },
+        ],
+      })
+      const [tool] = linkAuditTools(canvas)
+      const result = (await tool.handler({ course_id: 100, include: ['pages'] })) as AuditResult
 
       expect(result.findings).toHaveLength(1)
       expect(result.findings[0]).toMatchObject({

--- a/tests/tools/link-audit.test.ts
+++ b/tests/tools/link-audit.test.ts
@@ -174,6 +174,16 @@ describe('linkAuditTools', () => {
       expect(result.summary.total_findings).toBe(result.findings.length)
     })
 
+    it('emits exactly the three expected findings (no over- or under-counting)', async () => {
+      // page 2 cross-course image + syllabus cross-course link + announcement empty img.
+      // The same-course page/assignment links and the null assignment description
+      // must NOT contribute, so this absolute count guards against a dropped source
+      // loop, double-counting, or accidental same-course findings.
+      const result = await runFullScan()
+      expect(result.findings).toHaveLength(3)
+      expect(result.summary.total_findings).toBe(3)
+    })
+
     it('lists all four sources in stable order', async () => {
       const result = await runFullScan()
       expect(result.summary.sources_scanned).toEqual([
@@ -362,6 +372,87 @@ describe('linkAuditTools', () => {
       const [tool] = linkAuditTools(canvas)
       const result = (await tool.handler({ course_id: 100, include: ['pages'] })) as AuditResult
 
+      expect(result.findings).toHaveLength(0)
+    })
+
+    it('emits a finding per flaggable URL when one body contains several', async () => {
+      const canvas = makeCanvas({
+        pages: [
+          {
+            page_id: 1,
+            url: 'p',
+            title: 'P',
+            published: true,
+            updated_at: '',
+            body: '<a href="/courses/2/pages/a">x</a><img src="/courses/3/files/b">',
+          },
+        ],
+      })
+      const [tool] = linkAuditTools(canvas)
+      const result = (await tool.handler({ course_id: 100, include: ['pages'] })) as AuditResult
+
+      expect(result.findings).toHaveLength(2)
+      expect(result.findings.map((f) => f.cross_course_id).sort()).toEqual([2, 3])
+    })
+
+    it('classifies an empty href on a link as empty_or_malformed', async () => {
+      const canvas = makeCanvas({
+        pages: [
+          {
+            page_id: 1,
+            url: 'p',
+            title: 'P',
+            published: true,
+            updated_at: '',
+            body: '<a href="">x</a>',
+          },
+        ],
+      })
+      const [tool] = linkAuditTools(canvas)
+      const result = (await tool.handler({ course_id: 100, include: ['pages'] })) as AuditResult
+
+      expect(result.findings).toHaveLength(1)
+      expect(result.findings[0]).toMatchObject({ kind: 'link', reason: 'empty_or_malformed' })
+    })
+
+    it('does not flag a /courses/{id} reference that lacks a trailing slash', async () => {
+      // v1 boundary: the cross-course regex requires a trailing slash after the
+      // course id, so a bare course-landing link is intentionally not flagged.
+      const canvas = makeCanvas({
+        pages: [
+          {
+            page_id: 1,
+            url: 'p',
+            title: 'P',
+            published: true,
+            updated_at: '',
+            body: '<a href="/courses/55">other course</a>',
+          },
+        ],
+      })
+      const [tool] = linkAuditTools(canvas)
+      const result = (await tool.handler({ course_id: 100, include: ['pages'] })) as AuditResult
+
+      expect(result.findings).toHaveLength(0)
+    })
+  })
+
+  describe('empty include array', () => {
+    it('scans nothing when include is an explicit empty array', async () => {
+      // `[] ?? [...CONTENT_SOURCES]` does not fall back (an empty array is not
+      // nullish), so an explicit empty selection scans no sources. Only omitting
+      // `include` entirely scans all four.
+      const canvas = buildMockCanvas()
+      const [tool] = linkAuditTools(canvas)
+
+      const result = (await tool.handler({ course_id: 100, include: [] })) as AuditResult
+
+      expect(canvas.pages.listWithBodies).not.toHaveBeenCalled()
+      expect(canvas.assignments.list).not.toHaveBeenCalled()
+      expect(canvas.courses.getSyllabus).not.toHaveBeenCalled()
+      expect(canvas.discussions.listAnnouncements).not.toHaveBeenCalled()
+      expect(result.summary.sources_scanned).toEqual([])
+      expect(result.summary.total_findings).toBe(0)
       expect(result.findings).toHaveLength(0)
     })
   })

--- a/tests/tools/link-audit.test.ts
+++ b/tests/tools/link-audit.test.ts
@@ -1,0 +1,368 @@
+import { describe, it, expect, vi } from 'vitest'
+import { linkAuditTools } from '../../src/tools/link-audit'
+import type { CanvasClient } from '../../src/canvas'
+
+interface Finding {
+  location: { type: string; id: number; title: string }
+  kind: string
+  href: string
+  reason: string
+  cross_course_id?: number
+}
+
+interface AuditResult {
+  summary: { course_id: number; sources_scanned: string[]; total_findings: number }
+  findings: Finding[]
+}
+
+/**
+ * Default mock with course id = 100. Provides one cross-course finding per
+ * source type plus same-course (no-finding) controls.
+ */
+function buildMockCanvas(): CanvasClient {
+  return {
+    pages: {
+      listWithBodies: vi.fn().mockResolvedValue([
+        {
+          page_id: 1,
+          url: 'intro',
+          title: 'Introduction',
+          published: true,
+          updated_at: '',
+          body: '<p>Read more at <a href="/courses/100/pages/foo">here</a></p>',
+        },
+        {
+          page_id: 2,
+          url: 'week1',
+          title: 'Week 1',
+          published: true,
+          updated_at: '',
+          body: '<p>See <img src="/courses/999/files/42/download"> for details.</p>',
+        },
+      ]),
+    },
+    assignments: {
+      list: vi.fn().mockResolvedValue([
+        {
+          id: 10,
+          name: 'Essay',
+          description: '<p>Submit via <a href="/courses/100/assignments/5">Canvas</a></p>',
+          course_id: 100,
+          due_at: null,
+          points_possible: 10,
+          grading_type: 'points',
+          submission_types: [],
+          allowed_attempts: -1,
+        },
+        {
+          id: 11,
+          name: 'Quiz',
+          description: null,
+          course_id: 100,
+          due_at: null,
+          points_possible: 5,
+          grading_type: 'points',
+          submission_types: [],
+          allowed_attempts: -1,
+        },
+      ]),
+    },
+    courses: {
+      getSyllabus: vi
+        .fn()
+        .mockResolvedValue('<p>Week 1: <a href="/courses/50/pages/overview">Old link</a></p>'),
+    },
+    discussions: {
+      listAnnouncements: vi
+        .fn()
+        .mockResolvedValue([
+          { id: 20, title: 'Welcome', message: '<p>See <img src=""> for info.</p>', posted_at: '' },
+        ]),
+    },
+  } as unknown as CanvasClient
+}
+
+/** Minimal mock builder for classification edge cases. */
+function makeCanvas(opts: {
+  pages?: unknown[]
+  assignments?: unknown[]
+  syllabus?: string | null
+  announcements?: unknown[]
+}): CanvasClient {
+  return {
+    pages: { listWithBodies: vi.fn().mockResolvedValue(opts.pages ?? []) },
+    assignments: { list: vi.fn().mockResolvedValue(opts.assignments ?? []) },
+    courses: { getSyllabus: vi.fn().mockResolvedValue(opts.syllabus ?? null) },
+    discussions: { listAnnouncements: vi.fn().mockResolvedValue(opts.announcements ?? []) },
+  } as unknown as CanvasClient
+}
+
+describe('linkAuditTools', () => {
+  it('returns exactly one tool definition', () => {
+    const tools = linkAuditTools(buildMockCanvas())
+    expect(tools).toHaveLength(1)
+  })
+
+  it('defines the audit_course_links tool with read-only annotations', () => {
+    const [tool] = linkAuditTools(buildMockCanvas())
+    expect(tool.name).toBe('audit_course_links')
+    expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+  })
+
+  describe('full scan (all sources)', () => {
+    async function runFullScan(): Promise<AuditResult> {
+      const [tool] = linkAuditTools(buildMockCanvas())
+      return (await tool.handler({ course_id: 100 })) as AuditResult
+    }
+
+    it('flags a cross-course image reference in a page', async () => {
+      const result = await runFullScan()
+      expect(result.findings).toContainEqual(
+        expect.objectContaining({
+          location: { type: 'pages', id: 2, title: 'Week 1' },
+          kind: 'image',
+          reason: 'cross_course_reference',
+          cross_course_id: 999,
+        }),
+      )
+    })
+
+    it('does not flag a same-course page link', async () => {
+      const result = await runFullScan()
+      expect(result.findings.some((f) => f.href.includes('/courses/100/pages/foo'))).toBe(false)
+    })
+
+    it('does not flag a same-course assignment link', async () => {
+      const result = await runFullScan()
+      expect(
+        result.findings.some((f) => f.location.type === 'assignments' && f.location.id === 10),
+      ).toBe(false)
+    })
+
+    it('does not flag an assignment with a null description', async () => {
+      const result = await runFullScan()
+      expect(
+        result.findings.some((f) => f.location.type === 'assignments' && f.location.id === 11),
+      ).toBe(false)
+    })
+
+    it('flags a cross-course syllabus link', async () => {
+      const result = await runFullScan()
+      expect(result.findings).toContainEqual(
+        expect.objectContaining({
+          location: { type: 'syllabus', id: 100, title: 'Syllabus' },
+          kind: 'link',
+          reason: 'cross_course_reference',
+          cross_course_id: 50,
+        }),
+      )
+    })
+
+    it('flags an empty image src in an announcement without a cross_course_id', async () => {
+      const result = await runFullScan()
+      const finding = result.findings.find((f) => f.location.type === 'announcements')
+      expect(finding).toMatchObject({
+        location: { type: 'announcements', id: 20, title: 'Welcome' },
+        kind: 'image',
+        reason: 'empty_or_malformed',
+      })
+      expect(finding).not.toHaveProperty('cross_course_id')
+    })
+
+    it('reports total_findings equal to findings.length', async () => {
+      const result = await runFullScan()
+      expect(result.summary.total_findings).toBe(result.findings.length)
+    })
+
+    it('lists all four sources in stable order', async () => {
+      const result = await runFullScan()
+      expect(result.summary.sources_scanned).toEqual([
+        'pages',
+        'assignments',
+        'syllabus',
+        'announcements',
+      ])
+    })
+  })
+
+  describe('include filter', () => {
+    it('fetches only the syllabus when include is ["syllabus"]', async () => {
+      const canvas = buildMockCanvas()
+      const [tool] = linkAuditTools(canvas)
+
+      const result = (await tool.handler({
+        course_id: 100,
+        include: ['syllabus'],
+      })) as AuditResult
+
+      expect(canvas.pages.listWithBodies).not.toHaveBeenCalled()
+      expect(canvas.assignments.list).not.toHaveBeenCalled()
+      expect(canvas.discussions.listAnnouncements).not.toHaveBeenCalled()
+      expect(canvas.courses.getSyllabus).toHaveBeenCalled()
+      expect(result.summary.sources_scanned).toEqual(['syllabus'])
+    })
+
+    it('fetches only the requested multi-source subset', async () => {
+      const canvas = buildMockCanvas()
+      const [tool] = linkAuditTools(canvas)
+
+      const result = (await tool.handler({
+        course_id: 100,
+        include: ['pages', 'announcements'],
+      })) as AuditResult
+
+      expect(canvas.pages.listWithBodies).toHaveBeenCalled()
+      expect(canvas.discussions.listAnnouncements).toHaveBeenCalled()
+      expect(canvas.assignments.list).not.toHaveBeenCalled()
+      expect(canvas.courses.getSyllabus).not.toHaveBeenCalled()
+      expect(
+        result.findings.every(
+          (f) => f.location.type === 'pages' || f.location.type === 'announcements',
+        ),
+      ).toBe(true)
+    })
+  })
+
+  describe('classification edge cases', () => {
+    it('classifies a javascript: href as empty_or_malformed', async () => {
+      const canvas = makeCanvas({
+        pages: [
+          {
+            page_id: 1,
+            url: 'p',
+            title: 'P',
+            published: true,
+            updated_at: '',
+            body: '<a href="javascript:void(0)">click</a>',
+          },
+        ],
+      })
+      const [tool] = linkAuditTools(canvas)
+      const result = (await tool.handler({ course_id: 100, include: ['pages'] })) as AuditResult
+
+      expect(result.findings).toHaveLength(1)
+      expect(result.findings[0]).toMatchObject({ kind: 'link', reason: 'empty_or_malformed' })
+      expect(result.findings[0]).not.toHaveProperty('cross_course_id')
+    })
+
+    it('classifies a pure # anchor as empty_or_malformed', async () => {
+      const canvas = makeCanvas({
+        pages: [
+          {
+            page_id: 1,
+            url: 'p',
+            title: 'P',
+            published: true,
+            updated_at: '',
+            body: '<a href="#">top</a>',
+          },
+        ],
+      })
+      const [tool] = linkAuditTools(canvas)
+      const result = (await tool.handler({ course_id: 100, include: ['pages'] })) as AuditResult
+
+      expect(result.findings).toHaveLength(1)
+      expect(result.findings[0]).toMatchObject({ kind: 'link', reason: 'empty_or_malformed' })
+    })
+
+    it('decodes HTML entities before classifying a cross-course URL', async () => {
+      const canvas = makeCanvas({
+        pages: [
+          {
+            page_id: 1,
+            url: 'p',
+            title: 'P',
+            published: true,
+            updated_at: '',
+            body: '<a href="/courses/999/pages/foo?a=1&amp;b=2">x</a>',
+          },
+        ],
+      })
+      const [tool] = linkAuditTools(canvas)
+      const result = (await tool.handler({ course_id: 100, include: ['pages'] })) as AuditResult
+
+      expect(result.findings).toHaveLength(1)
+      expect(result.findings[0]).toMatchObject({
+        reason: 'cross_course_reference',
+        cross_course_id: 999,
+      })
+    })
+
+    it('classifies an iframe src as a video kind', async () => {
+      const canvas = makeCanvas({
+        assignments: [
+          {
+            id: 10,
+            name: 'Media',
+            description: '<iframe src="/courses/999/media_objects/m1"></iframe>',
+            course_id: 100,
+            due_at: null,
+            points_possible: 0,
+            grading_type: 'points',
+            submission_types: [],
+            allowed_attempts: -1,
+          },
+        ],
+      })
+      const [tool] = linkAuditTools(canvas)
+      const result = (await tool.handler({
+        course_id: 100,
+        include: ['assignments'],
+      })) as AuditResult
+
+      expect(result.findings).toHaveLength(1)
+      expect(result.findings[0]).toMatchObject({
+        kind: 'video',
+        reason: 'cross_course_reference',
+        cross_course_id: 999,
+      })
+    })
+
+    it('does not flag an external link with no /courses/ segment', async () => {
+      const canvas = makeCanvas({
+        pages: [
+          {
+            page_id: 1,
+            url: 'p',
+            title: 'P',
+            published: true,
+            updated_at: '',
+            body: '<a href="https://external.com/docs">docs</a>',
+          },
+        ],
+      })
+      const [tool] = linkAuditTools(canvas)
+      const result = (await tool.handler({ course_id: 100, include: ['pages'] })) as AuditResult
+
+      expect(result.findings).toHaveLength(0)
+    })
+
+    it('emits no findings for an empty page body', async () => {
+      const canvas = makeCanvas({
+        pages: [{ page_id: 1, url: 'p', title: 'P', published: true, updated_at: '', body: '' }],
+      })
+      const [tool] = linkAuditTools(canvas)
+      const result = (await tool.handler({ course_id: 100, include: ['pages'] })) as AuditResult
+
+      expect(result.findings).toHaveLength(0)
+    })
+
+    it('emits no syllabus findings and does not throw when the syllabus is null', async () => {
+      const canvas = makeCanvas({ syllabus: null })
+      const [tool] = linkAuditTools(canvas)
+      const result = (await tool.handler({ course_id: 100, include: ['syllabus'] })) as AuditResult
+
+      expect(result.findings.some((f) => f.location.type === 'syllabus')).toBe(false)
+    })
+
+    it('emits no findings and does not throw for a page with an undefined body', async () => {
+      const canvas = makeCanvas({
+        pages: [{ page_id: 1, url: 'p', title: 'P', published: true, updated_at: '' }],
+      })
+      const [tool] = linkAuditTools(canvas)
+      const result = (await tool.handler({ course_id: 100, include: ['pages'] })) as AuditResult
+
+      expect(result.findings).toHaveLength(0)
+    })
+  })
+})

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -105,6 +105,7 @@ function buildFullMockCanvas(): CanvasClient {
       create: async () => ({}),
       update: async () => ({}),
       delete: async () => undefined,
+      listWithBodies: async () => [],
     },
     calendar: {
       list: async () => [],
@@ -189,7 +190,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 137 tools across all domains', () => {
+  it('returns all 138 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 
@@ -362,8 +363,10 @@ describe('getAllTools', () => {
     expect(names).toContain('explain_grade')
     // Grading Policy (1)
     expect(names).toContain('explain_grading_policy')
+    // Link Audit (1)
+    expect(names).toContain('audit_course_links')
 
-    expect(tools).toHaveLength(137)
+    expect(tools).toHaveLength(138)
   })
 
   it('all tools have openWorldHint: true', () => {


### PR DESCRIPTION
## Summary

Implements the merged design spec for #218 — a read-only `audit_course_links` tool.

**User story:** _"As an instructor using Claude, I want to ask 'which links, images, or videos in my course are broken or still point at a previous copy of the course?' so I can fix them before students hit dead content — especially after copying a course forward into a new term."_

## Approach

`audit_course_links(course_id, { include? })` composes four existing, already-wrapped Canvas content endpoints and scans the returned HTML — no new API dependencies, no undocumented `link_validation` route, no outbound HTTP:

| Source | Canvas method | HTML field |
| ------ | ------------- | ---------- |
| Pages | `pages.listWithBodies` (new) | `CanvasPage.body` |
| Assignments | `assignments.list` | `CanvasAssignment.description` |
| Syllabus | `courses.getSyllabus` | `syllabus_body` |
| Announcements | `discussions.listAnnouncements` | `CanvasAnnouncement.message` |

It extracts `<a href>`, `<img src>`, and `<iframe|embed|video|source src>` references and classifies each as:

- **`cross_course_reference`** — href/src whose path contains `/courses/{N}/` where `N` ≠ the audited course (the canonical stale-copy failure after a course import).
- **`empty_or_malformed`** — empty, `#`-only, or `javascript:` URLs.

Structural-only by design (external liveness deferred to a future opt-in flag). An optional `include` filter scopes the scan and gates each source's fetch, so callers who only care about the syllabus skip the expensive page fan-out. A new `PagesModule.listWithBodies` fans out a `get()` per page because the paginated list endpoint omits page `body`.

**FERPA:** output is course-authored content metadata only (no `CanvasUser`, no `participants`, no `user_name`) → no pseudonymizer wrapping required; `PSEUDONYMIZER_WRAPPED_TOOLS` is unchanged, and the coverage test passes without modification.

## Deviation from spec

The spec's regex-extraction code assumed capture groups are `string`; the repo enables `noUncheckedIndexedAccess`, so groups are `string | undefined`. Handled with safe fallbacks (`m[1] ?? ''`, optional-chained `?.[1]`) — capture groups always match at runtime when the overall pattern matches, so behaviour is unchanged.

Tool count: 137 → 138. Manifests regenerated (`pnpm generate:manifests`); `registry.test.ts` and `discovery/manifests.test.ts` counts bumped.

## Test evidence

`pnpm typecheck && pnpm lint && pnpm test && pnpm build` — all green.

- Test Files: 93 passed
- Tests: 1283 passed | 1 skipped
- Build: success

New coverage: 4 `listWithBodies` cases (fan-out, empty, error propagation from list and from per-page fetch) + 18 tool cases (full scan, `include` filter, and classification edge cases: `javascript:`, `#`, HTML-entity decoding, iframe→video, external link, empty/null/undefined body).

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)
