### PR TITLE
feat(submissions): surface course submissions awaiting manual grading

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 138,
+  "toolCount": 139,
   "tools": [
     {
       "name": "health_check",
@@ -215,6 +215,18 @@
       "name": "list_course_submission_files",
       "domain": "submission_files",
       "description": "List every file attachment submitted by students across all assignments in a course. Returns a manifest — one entry per file — including the original filename, a file_id for re-fetching via download_file, content type, and size. Useful for bulk-archiving student work before a course expires or a Free-For-Teacher account is concluded. Outputs are bounded by max_files (default 500); when the limit is hit, truncated is true and truncation_note explains how to retrieve the rest. Download URLs are time-limited (typically 1 hour) — use the returned file_id with download_file to get a fresh URL at download time. When CANVAS_PSEUDONYMIZE_STUDENTS is enabled, user_name is a stable per-course pseudonym (e.g. \"Student 1\"); user_id (the raw numeric Canvas ID) is always returned and works as a stable per-student folder key.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_submissions_awaiting_grading",
+      "domain": "submissions_awaiting_grading",
+      "description": "Lists all submissions in a course that still need a human grade, sorted oldest-waiting first.\n\nSurfaces two categories:\n- workflow_state=submitted: assignments submitted by students but not yet graded at all.\n- workflow_state=pending_review: Classic Quiz submissions where Canvas auto-graded the objective questions but left essays or manually-scored questions for the instructor.\n\nReturns a triage list grouped by assignment or Classic Quiz, with per-submission details: student identity, workflow state, submitted_at, and whether the submission has pending manual-grading questions.\n\nParameters:\n- course_id (required): Canvas course ID to scan.\n- assignment_ids (optional): limit the scan to specific assignment IDs.\n- include_quizzes (default true): include Classic Quiz assignments in the scan.\n- include_assignments (default true): include non-quiz assignments.\n- only_pending_review (default false): when true, return only pending_review submissions (quiz essays awaiting manual scoring), omitting regular ungraded assignments.\n\nKnown limitations:\n- New Quizzes (Quizzes.Next) may not appear with 'pending_review' workflow state here; use SpeedGrader or the New Quizzes interface for their grading queue.\n- Fill-in-the-blank answers that Canvas auto-marked are not surfaced.\n- V1 returns submission-level state only; per-question detail is not included.\n- When CANVAS_PSEUDONYMIZE_STUDENTS is enabled, student names are replaced with pseudonyms. Use resolve_pseudonym to look up the real identity.",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true

--- a/src/pseudonym/coverage.ts
+++ b/src/pseudonym/coverage.ts
@@ -35,6 +35,9 @@ export const PSEUDONYMIZER_WRAPPED_TOOLS: readonly string[] = [
   // src/tools/submission-files.ts
   'list_course_submission_files',
 
+  // src/tools/submissions-awaiting-grading.ts
+  'list_submissions_awaiting_grading',
+
   // src/tools/conversations.ts
   'list_conversations',
   'get_conversation',

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -31,6 +31,7 @@ import { rubricTools } from './rubrics'
 import { studentTools } from './student'
 import { submissionTools } from './submissions'
 import { submissionFileTools } from './submission-files'
+import { submissionsAwaitingGradingTools } from './submissions-awaiting-grading'
 import type { ToolAudience, ToolDefinition } from './types'
 import { userTools } from './users'
 import { linkAuditTools } from './link-audit'
@@ -66,6 +67,11 @@ export const toolDomainCatalog: readonly ToolDomainRegistration[] = [
     domain: 'submission_files',
     defaultPrimaryAudience: 'educator',
     getTools: submissionFileTools,
+  },
+  {
+    domain: 'submissions_awaiting_grading',
+    defaultPrimaryAudience: 'educator',
+    getTools: submissionsAwaitingGradingTools,
   },
   {
     domain: 'rubrics',

--- a/src/tools/submissions-awaiting-grading.ts
+++ b/src/tools/submissions-awaiting-grading.ts
@@ -165,6 +165,23 @@ export function submissionsAwaitingGradingTools(
           caveats.push(FILL_IN_BLANK_CAVEAT)
         }
 
+        // Step 5b: surface assignments dropped because Canvas did not report
+        // needs_grading_count at all (undefined, not 0). Without this caveat an
+        // empty/partial result is indistinguishable from "nothing to grade" when
+        // the token lacks grading permission on those assignments — silent data
+        // loss. Computed before the early-return so the all-empty case is covered.
+        const missingCountCount = eligibleAssignments.filter(
+          (a) => a.needs_grading_count === undefined,
+        ).length
+        if (missingCountCount > 0) {
+          caveats.push(
+            `Canvas did not report needs_grading_count for ${missingCountCount} assignment(s); they ` +
+              'were skipped and any ungraded work on them is NOT shown here. This usually means the ' +
+              'token lacks grading permission on those assignments, or the Canvas instance requires ' +
+              'needs_grading_count_by_section. Verify in SpeedGrader.',
+          )
+        }
+
         // Step 6: early-return when nothing needs fetching.
         if (toFetch.length === 0) {
           return { course_id: courseId, total_submissions_awaiting: 0, items: [], caveats }

--- a/src/tools/submissions-awaiting-grading.ts
+++ b/src/tools/submissions-awaiting-grading.ts
@@ -1,0 +1,271 @@
+import { z } from 'zod'
+import type { CanvasClient } from '../canvas'
+import type { CanvasAssignment, CanvasSubmission } from '../canvas/types'
+import type { Pseudonymizer } from '../pseudonym/pseudonymizer'
+import type { ToolDefinition } from './types'
+
+// ── Caveats ──────────────────────────────────────────────────────────────────
+
+/** Always appended: New Quizzes manage their own grading queue outside the REST API. */
+const NEW_QUIZZES_CAVEAT =
+  'New Quizzes (Quizzes.Next) manage their own grading queue and their submission records ' +
+  "may not appear with 'pending_review' workflow state here. Use SpeedGrader or the New " +
+  'Quizzes interface to check for pending New Quiz grading.'
+
+/** Appended unless only_pending_review is set: fill-in-the-blank auto-grade gaps are invisible. */
+const FILL_IN_BLANK_CAVEAT =
+  'Fill-in-the-blank submissions that Canvas auto-marked as graded are not included, even if ' +
+  'the answer-key variant was incomplete.'
+
+/** Defensive: Canvas returned a submission whose assignment was not in the fetch set. */
+const UNMATCHED_CAVEAT = 'Some submissions could not be matched to an assignment and were excluded.'
+
+// ── Output shape ─────────────────────────────────────────────────────────────
+
+interface AwaitingSubmissionRow {
+  submission_id: number
+  /** Always the raw Canvas numeric ID; never pseudonymized. */
+  user_id: number
+  /** Pseudonymized when the flag is on; null when the user object was not sideloaded. */
+  user_name: string | null
+  workflow_state: 'submitted' | 'pending_review'
+  submitted_at: string | null
+  /** True when the submission is in pending_review (quiz questions await manual scoring). */
+  has_pending_manual_questions: boolean
+}
+
+interface AwaitingItem {
+  assignment_id: number
+  assignment_name: string
+  type: 'classic_quiz' | 'assignment'
+  due_at: string | null
+  submissions_awaiting_count: number
+  submissions: AwaitingSubmissionRow[]
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Classic Quizzes carry both is_quiz_assignment and a non-null quiz_id. */
+function isClassicQuiz(a: CanvasAssignment): boolean {
+  return a.is_quiz_assignment === true && a.quiz_id != null
+}
+
+/** Oldest submitted_at across a group's submissions, or Infinity when all are null. */
+function oldestSubmittedAt(submissions: ReadonlyArray<AwaitingSubmissionRow>): number {
+  return submissions
+    .filter((s) => s.submitted_at)
+    .map((s) => Date.parse(s.submitted_at as string))
+    .reduce((min, t) => (t < min ? t : min), Infinity)
+}
+
+// ── Tool definition ──────────────────────────────────────────────────────────
+
+export function submissionsAwaitingGradingTools(
+  canvas: CanvasClient,
+  pseudonymizer?: Pseudonymizer,
+): ToolDefinition[] {
+  return [
+    {
+      name: 'list_submissions_awaiting_grading',
+      description:
+        'Lists all submissions in a course that still need a human grade, sorted oldest-waiting ' +
+        'first.\n\n' +
+        'Surfaces two categories:\n' +
+        '- workflow_state=submitted: assignments submitted by students but not yet graded at all.\n' +
+        '- workflow_state=pending_review: Classic Quiz submissions where Canvas auto-graded the ' +
+        'objective questions but left essays or manually-scored questions for the instructor.\n\n' +
+        'Returns a triage list grouped by assignment or Classic Quiz, with per-submission details: ' +
+        'student identity, workflow state, submitted_at, and whether the submission has pending ' +
+        'manual-grading questions.\n\n' +
+        'Parameters:\n' +
+        '- course_id (required): Canvas course ID to scan.\n' +
+        '- assignment_ids (optional): limit the scan to specific assignment IDs.\n' +
+        '- include_quizzes (default true): include Classic Quiz assignments in the scan.\n' +
+        '- include_assignments (default true): include non-quiz assignments.\n' +
+        '- only_pending_review (default false): when true, return only pending_review submissions ' +
+        '(quiz essays awaiting manual scoring), omitting regular ungraded assignments.\n\n' +
+        'Known limitations:\n' +
+        "- New Quizzes (Quizzes.Next) may not appear with 'pending_review' workflow state here; " +
+        'use SpeedGrader or the New Quizzes interface for their grading queue.\n' +
+        '- Fill-in-the-blank answers that Canvas auto-marked are not surfaced.\n' +
+        '- V1 returns submission-level state only; per-question detail is not included.\n' +
+        '- When CANVAS_PSEUDONYMIZE_STUDENTS is enabled, student names are replaced with ' +
+        'pseudonyms. Use resolve_pseudonym to look up the real identity.',
+      inputSchema: {
+        course_id: z
+          .number()
+          .int()
+          .positive()
+          .describe('Canvas course ID to scan for submissions awaiting grading.'),
+        assignment_ids: z
+          .array(z.number().int().positive())
+          .optional()
+          .describe(
+            'Limit the scan to these specific assignment IDs (numeric Canvas IDs). ' +
+              'When omitted, all assignments in the course are scanned.',
+          ),
+        include_quizzes: z
+          .boolean()
+          .default(true)
+          .describe(
+            'Include Classic Quiz assignments in the scan. Default: true. New Quizzes are always ' +
+              'covered by the global New Quizzes caveat — see response.caveats.',
+          ),
+        include_assignments: z
+          .boolean()
+          .default(true)
+          .describe('Include non-quiz assignments in the scan. Default: true.'),
+        only_pending_review: z
+          .boolean()
+          .default(false)
+          .describe(
+            'When true, return only submissions with workflow_state=pending_review — quiz essays ' +
+              'and manually-scored questions that Canvas auto-graded but left for human review. ' +
+              'When false (default), return both submitted (ungraded) and pending_review submissions.',
+          ),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+        const assignmentIds = params.assignment_ids as number[] | undefined
+        // Zod defaults are not applied when the handler is invoked directly (tests),
+        // so the toggles are interpreted with explicit comparisons: undefined means
+        // "use the default" (include = true, only_pending_review = false).
+        const includeQuizzes = params.include_quizzes as boolean | undefined
+        const includeAssignments = params.include_assignments as boolean | undefined
+        const onlyPendingReview = params.only_pending_review as boolean | undefined
+
+        // Guard: at least one assignment category must be in scope.
+        if (includeQuizzes === false && includeAssignments === false) {
+          throw new Error('At least one of include_quizzes or include_assignments must be true.')
+        }
+
+        // Step 1: fetch the assignment list, optionally scoped by assignment_ids.
+        const allAssignments = await canvas.assignments.list(
+          courseId,
+          assignmentIds && assignmentIds.length > 0 ? { assignment_ids: assignmentIds } : {},
+        )
+
+        // Step 2-3: classify and apply the include toggles.
+        const eligibleAssignments = allAssignments.filter((a) =>
+          isClassicQuiz(a) ? includeQuizzes !== false : includeAssignments !== false,
+        )
+
+        // Step 4: pre-filter by needs_grading_count. When the field is absent
+        // (undefined), `?? 0` excludes the assignment — conservative and correct.
+        const toFetch = eligibleAssignments.filter((a) => (a.needs_grading_count ?? 0) > 0)
+
+        // Step 5: build caveats.
+        const caveats: string[] = [NEW_QUIZZES_CAVEAT]
+        if (onlyPendingReview !== true) {
+          caveats.push(FILL_IN_BLANK_CAVEAT)
+        }
+
+        // Step 6: early-return when nothing needs fetching.
+        if (toFetch.length === 0) {
+          return { course_id: courseId, total_submissions_awaiting: 0, items: [], caveats }
+        }
+
+        // Step 7: bulk-fetch submissions for the filtered assignments. workflow_state
+        // is omitted intentionally: the API accepts a single value, but we need both
+        // 'submitted' and 'pending_review', so filtering happens client-side below.
+        const rawSubmissions = await canvas.submissions.listForStudents(courseId, {
+          student_ids: ['all'],
+          assignment_ids: toFetch.map((a) => a.id),
+          include: ['user'],
+        })
+
+        // Step 8: filter to the target workflow states.
+        const targetStates = new Set<string>(
+          onlyPendingReview === true ? ['pending_review'] : ['submitted', 'pending_review'],
+        )
+        const awaitingSubmissions = rawSubmissions.filter((s) => targetStates.has(s.workflow_state))
+
+        // Step 9: pseudonymize when enabled and a user object is present.
+        const processedSubmissions: CanvasSubmission[] = await Promise.all(
+          awaitingSubmissions.map((s) =>
+            pseudonymizer?.isEnabled() && s.user
+              ? pseudonymizer.anonymizeSubmission(courseId, s)
+              : Promise.resolve(s),
+          ),
+        )
+
+        // Step 10: group by assignment_id.
+        const byAssignment = new Map<number, CanvasSubmission[]>()
+        for (const sub of processedSubmissions) {
+          const group = byAssignment.get(sub.assignment_id) ?? []
+          group.push(sub)
+          byAssignment.set(sub.assignment_id, group)
+        }
+
+        // Step 11: assignment lookup.
+        const assignmentById = new Map(toFetch.map((a) => [a.id, a]))
+
+        // Step 12: assemble items; submissions within each item sorted oldest-first.
+        // Stray submissions (assignment not in toFetch) are skipped defensively.
+        const unmatchedIds: number[] = []
+        const items: AwaitingItem[] = [...byAssignment.entries()].flatMap(
+          ([assignmentId, subs]) => {
+            const assignment = assignmentById.get(assignmentId)
+            if (!assignment) {
+              unmatchedIds.push(assignmentId)
+              return []
+            }
+            const sortedSubs = [...subs].sort((a, b) => {
+              if (!a.submitted_at) return 1 // null sorts last
+              if (!b.submitted_at) return -1
+              return a.submitted_at < b.submitted_at ? -1 : 1
+            })
+            return [
+              {
+                assignment_id: assignmentId,
+                assignment_name: assignment.name,
+                type: isClassicQuiz(assignment)
+                  ? ('classic_quiz' as const)
+                  : ('assignment' as const),
+                due_at: assignment.due_at,
+                submissions_awaiting_count: sortedSubs.length,
+                submissions: sortedSubs.map((s) => ({
+                  submission_id: s.id,
+                  user_id: s.user_id,
+                  user_name: s.user?.name ?? null,
+                  workflow_state: s.workflow_state as 'submitted' | 'pending_review',
+                  submitted_at: s.submitted_at,
+                  has_pending_manual_questions: s.workflow_state === 'pending_review',
+                })),
+              },
+            ]
+          },
+        )
+
+        // Step 13: sort items by oldest submitted_at (ascending; all-null sorts last).
+        items.sort((a, b) => {
+          const aOldest = oldestSubmittedAt(a.submissions)
+          const bOldest = oldestSubmittedAt(b.submissions)
+          // Infinity - Infinity is NaN (violates the sort contract); treat as a tie.
+          if (aOldest === Infinity && bOldest === Infinity) return 0
+          return aOldest - bOldest
+        })
+
+        // Step 14: surface the defensive skip if it happened.
+        if (unmatchedIds.length > 0) {
+          caveats.push(UNMATCHED_CAVEAT)
+        }
+
+        return {
+          course_id: courseId,
+          total_submissions_awaiting: items.reduce(
+            (sum, i) => sum + i.submissions_awaiting_count,
+            0,
+          ),
+          items,
+          caveats,
+        }
+      },
+    },
+  ]
+}

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(138)
+    expect(manifest.tools).toHaveLength(139)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/pseudonym/coverage.test.ts
+++ b/tests/pseudonym/coverage.test.ts
@@ -19,6 +19,7 @@ const EXPECTED_PII_BEARING_TOOLS = new Set([
   'list_submissions',
   'get_submission',
   'list_course_submission_files',
+  'list_submissions_awaiting_grading',
   'list_conversations',
   'get_conversation',
   'list_gradebook_history_submissions',

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -190,7 +190,7 @@ describe('getAllTools', () => {
     expect(Array.isArray(tools)).toBe(true)
   })
 
-  it('returns all 138 tools across all domains', () => {
+  it('returns all 139 tools across all domains', () => {
     const tools = getAllTools(buildFullMockCanvas())
     const names = tools.map((t) => t.name)
 
@@ -365,8 +365,10 @@ describe('getAllTools', () => {
     expect(names).toContain('explain_grading_policy')
     // Link Audit (1)
     expect(names).toContain('audit_course_links')
+    // Submissions Awaiting Grading (1)
+    expect(names).toContain('list_submissions_awaiting_grading')
 
-    expect(tools).toHaveLength(138)
+    expect(tools).toHaveLength(139)
   })
 
   it('all tools have openWorldHint: true', () => {

--- a/tests/tools/submissions-awaiting-grading.test.ts
+++ b/tests/tools/submissions-awaiting-grading.test.ts
@@ -91,6 +91,7 @@ const A2 = mkAssignment({
   needs_grading_count: 1,
   is_quiz_assignment: true,
   quiz_id: 10,
+  due_at: '2026-07-01T00:00:00Z',
 })
 const A3 = mkAssignment({ id: 3, name: 'Graded already', needs_grading_count: 0 })
 
@@ -176,6 +177,7 @@ describe('list_submissions_awaiting_grading', () => {
     // A2's oldest submission (06-19) precedes A1's oldest (06-20).
     expect(result.items[0].assignment_id).toBe(A2.id)
     expect(result.items[0].type).toBe('classic_quiz')
+    expect(result.items[0].due_at).toBe('2026-07-01T00:00:00Z')
     expect(result.items[0].submissions[0].has_pending_manual_questions).toBe(true)
     expect(result.items[1].assignment_id).toBe(A1.id)
     expect(result.items[1].submissions[0].submitted_at).toBe('2026-06-20T10:00:00Z')
@@ -199,6 +201,8 @@ describe('list_submissions_awaiting_grading', () => {
     expect(result.items[0].assignment_id).toBe(A2.id)
     expect(result.items[0].submissions[0].workflow_state).toBe('pending_review')
     expect(result.caveats.some((c) => c.includes('Fill-in-the-blank'))).toBe(false)
+    // The New Quizzes caveat is unconditional — not gated behind only_pending_review.
+    expect(result.caveats.some((c) => c.includes('New Quizzes'))).toBe(true)
   })
 
   it('Fixture C — assignment_ids scope', async () => {
@@ -250,6 +254,11 @@ describe('list_submissions_awaiting_grading', () => {
     expect(result.items).toHaveLength(0)
     expect(result.total_submissions_awaiting).toBe(0)
     expect(canvas.submissions.listForStudents).not.toHaveBeenCalled()
+    // The early-return branch must still carry the fixed caveats (counts were 0,
+    // not undefined, so no missing-count caveat).
+    expect(result.caveats.some((c) => c.includes('New Quizzes'))).toBe(true)
+    expect(result.caveats.some((c) => c.includes('Fill-in-the-blank'))).toBe(true)
+    expect(result.caveats.some((c) => c.includes('needs_grading_count'))).toBe(false)
   })
 
   it('Fixture G2 — needs_grading_count absent (undefined) on all assignments', async () => {
@@ -261,6 +270,10 @@ describe('list_submissions_awaiting_grading', () => {
 
     expect(result.items).toHaveLength(0)
     expect(canvas.submissions.listForStudents).not.toHaveBeenCalled()
+    // Undefined counts must not be mistaken for "nothing to grade": a caveat names
+    // the skipped count so the empty result is not silently authoritative.
+    expect(result.caveats.some((c) => c.includes('needs_grading_count'))).toBe(true)
+    expect(result.caveats.some((c) => c.includes('2 assignment(s)'))).toBe(true)
   })
 
   it('Fixture H — FERPA pseudonymization rewrites the name, keeps the id', async () => {
@@ -290,6 +303,20 @@ describe('list_submissions_awaiting_grading', () => {
 
     expect(result.items[0].submissions[0].user_name).toBeNull()
     expect(ps.anonymizeSubmission).not.toHaveBeenCalled()
+  })
+
+  it('Fixture H3 — FERPA: tool does not second-guess the pseudonymizer (staff passthrough)', async () => {
+    const canvas = buildMockCanvas({ assignments: [A1], submissions: [S1] })
+    // The real pseudonymizer leaves staff names intact; the tool must surface
+    // whatever name the pseudonymizer returns, not impose its own decision.
+    const ps = {
+      isEnabled: () => true,
+      anonymizeSubmission: vi.fn(async (_courseId: number, sub: CanvasSubmission) => sub),
+    } as unknown as Pseudonymizer
+    const result = await run(canvas, { course_id: COURSE_ID }, ps)
+
+    expect(ps.anonymizeSubmission).toHaveBeenCalledTimes(1)
+    expect(result.items[0].submissions[0].user_name).toBe('Alice')
   })
 
   it('Fixture I — sorting correctness: older item first', async () => {

--- a/tests/tools/submissions-awaiting-grading.test.ts
+++ b/tests/tools/submissions-awaiting-grading.test.ts
@@ -276,6 +276,54 @@ describe('list_submissions_awaiting_grading', () => {
     expect(result.caveats.some((c) => c.includes('2 assignment(s)'))).toBe(true)
   })
 
+  it('Fixture G3 — mixed counts: caveat survives the non-early-return path, counts exactly 1', async () => {
+    const withCount = mkAssignment({ id: 1, needs_grading_count: 2 })
+    const undefinedCount = mkAssignment({ id: 2 }) // needs_grading_count absent
+    const canvas = buildMockCanvas({
+      assignments: [withCount, undefinedCount],
+      submissions: [
+        mkSubmission({
+          id: 1,
+          assignment_id: withCount.id,
+          workflow_state: 'submitted',
+          user: { id: 1, name: 'A' },
+        }),
+      ],
+    })
+    const result = await run(canvas)
+
+    // toFetch is non-empty (withCount), so the early-return is NOT taken.
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0].assignment_id).toBe(withCount.id)
+    expect(canvas.submissions.listForStudents).toHaveBeenCalled()
+    // The caveat must still fire on this path, naming exactly the one undefined-count assignment.
+    expect(result.caveats.some((c) => c.includes('needs_grading_count'))).toBe(true)
+    expect(result.caveats.some((c) => c.includes('1 assignment(s)'))).toBe(true)
+  })
+
+  it('Fixture G4 — missing-count caveat counts eligible (post-toggle) assignments, not all', async () => {
+    const withCount = mkAssignment({ id: 1, needs_grading_count: 2 })
+    // An undefined-count Classic Quiz that is excluded by include_quizzes:false must
+    // NOT be named in the caveat — the count is over eligibleAssignments, not allAssignments.
+    const undefinedQuiz = mkAssignment({ id: 3, is_quiz_assignment: true, quiz_id: 30 })
+    const canvas = buildMockCanvas({
+      assignments: [withCount, undefinedQuiz],
+      submissions: [
+        mkSubmission({
+          id: 1,
+          assignment_id: withCount.id,
+          workflow_state: 'submitted',
+          user: { id: 1, name: 'A' },
+        }),
+      ],
+    })
+    const result = await run(canvas, { course_id: COURSE_ID, include_quizzes: false })
+
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0].assignment_id).toBe(withCount.id)
+    expect(result.caveats.some((c) => c.includes('needs_grading_count'))).toBe(false)
+  })
+
   it('Fixture H — FERPA pseudonymization rewrites the name, keeps the id', async () => {
     const canvas = buildMockCanvas({
       assignments: [A1],

--- a/tests/tools/submissions-awaiting-grading.test.ts
+++ b/tests/tools/submissions-awaiting-grading.test.ts
@@ -1,0 +1,413 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { CanvasClient } from '../../src/canvas'
+import type { CanvasAssignment, CanvasSubmission } from '../../src/canvas/types'
+import type { Pseudonymizer } from '../../src/pseudonym/pseudonymizer'
+import { submissionsAwaitingGradingTools } from '../../src/tools/submissions-awaiting-grading'
+
+const COURSE_ID = 555
+
+// ── Output shape (mirrors the tool contract; for assertion typing) ───────────
+
+interface SubmissionRow {
+  submission_id: number
+  user_id: number
+  user_name: string | null
+  workflow_state: 'submitted' | 'pending_review'
+  submitted_at: string | null
+  has_pending_manual_questions: boolean
+}
+
+interface Item {
+  assignment_id: number
+  assignment_name: string
+  type: 'classic_quiz' | 'assignment'
+  due_at: string | null
+  submissions_awaiting_count: number
+  submissions: SubmissionRow[]
+}
+
+interface Result {
+  course_id: number
+  total_submissions_awaiting: number
+  items: Item[]
+  caveats: string[]
+}
+
+// ── Fixtures factories ───────────────────────────────────────────────────────
+
+function mkAssignment(props: {
+  id: number
+  name?: string
+  needs_grading_count?: number
+  is_quiz_assignment?: boolean
+  quiz_id?: number | null
+  submission_types?: string[]
+  due_at?: string | null
+}): CanvasAssignment {
+  return {
+    id: props.id,
+    name: props.name ?? `Assignment ${props.id}`,
+    description: null,
+    due_at: props.due_at ?? null,
+    points_possible: 100,
+    grading_type: 'points',
+    submission_types: props.submission_types ?? ['online_text_entry'],
+    course_id: COURSE_ID,
+    allowed_attempts: 1,
+    is_quiz_assignment: props.is_quiz_assignment,
+    quiz_id: props.quiz_id ?? null,
+    needs_grading_count: props.needs_grading_count,
+  } as CanvasAssignment
+}
+
+function mkSubmission(props: {
+  id: number
+  assignment_id: number
+  workflow_state: string
+  submitted_at?: string | null
+  user?: { id: number; name: string } | null
+  user_id?: number
+}): CanvasSubmission {
+  return {
+    id: props.id,
+    assignment_id: props.assignment_id,
+    user_id: props.user_id ?? props.user?.id ?? 0,
+    submitted_at: props.submitted_at ?? null,
+    score: null,
+    grade: null,
+    body: null,
+    url: null,
+    attempt: 1,
+    workflow_state: props.workflow_state,
+    user: props.user ?? undefined,
+  } as CanvasSubmission
+}
+
+// A1: regular assignment, 2 awaiting; A2: Classic Quiz, 1 awaiting; A3: nothing.
+const A1 = mkAssignment({ id: 1, name: 'Essay', needs_grading_count: 2 })
+const A2 = mkAssignment({
+  id: 2,
+  name: 'Midterm Quiz',
+  needs_grading_count: 1,
+  is_quiz_assignment: true,
+  quiz_id: 10,
+})
+const A3 = mkAssignment({ id: 3, name: 'Graded already', needs_grading_count: 0 })
+
+const S1 = mkSubmission({
+  id: 1001,
+  assignment_id: A1.id,
+  user: { id: 101, name: 'Alice' },
+  workflow_state: 'submitted',
+  submitted_at: '2026-06-20T10:00:00Z',
+})
+const S2 = mkSubmission({
+  id: 1002,
+  assignment_id: A1.id,
+  user: { id: 102, name: 'Bob' },
+  workflow_state: 'submitted',
+  submitted_at: '2026-06-21T10:00:00Z',
+})
+const S3 = mkSubmission({
+  id: 1003,
+  assignment_id: A2.id,
+  user: { id: 103, name: 'Carol' },
+  workflow_state: 'pending_review',
+  submitted_at: '2026-06-19T10:00:00Z',
+})
+
+function buildMockCanvas(opts: {
+  assignments?: CanvasAssignment[]
+  submissions?: CanvasSubmission[]
+  /** When false, listForStudents ignores assignment_ids (simulates a stray Canvas response). */
+  filterSubmissions?: boolean
+}): CanvasClient {
+  const filterSubmissions = opts.filterSubmissions ?? true
+  return {
+    assignments: {
+      list: vi.fn(async (_courseId: number, listOpts?: { assignment_ids?: number[] }) => {
+        const all = opts.assignments ?? []
+        const ids = listOpts?.assignment_ids
+        return ids && ids.length > 0 ? all.filter((a) => ids.includes(a.id)) : all
+      }),
+    },
+    submissions: {
+      listForStudents: vi.fn(async (_courseId: number, subOpts?: { assignment_ids?: number[] }) => {
+        const all = opts.submissions ?? []
+        const ids = subOpts?.assignment_ids
+        if (!filterSubmissions || !ids || ids.length === 0) return all
+        return all.filter((s) => ids.includes(s.assignment_id))
+      }),
+    },
+  } as unknown as CanvasClient
+}
+
+function makeEnabledPseudonymizer(): Pseudonymizer {
+  return {
+    isEnabled: () => true,
+    anonymizeSubmission: vi.fn(async (_courseId: number, sub: CanvasSubmission) => ({
+      ...sub,
+      user: sub.user ? { ...sub.user, name: 'Student 0' } : sub.user,
+    })),
+  } as unknown as Pseudonymizer
+}
+
+async function run(
+  canvas: CanvasClient,
+  params: Record<string, unknown> = { course_id: COURSE_ID },
+  pseudonymizer?: Pseudonymizer,
+): Promise<Result> {
+  const tool = submissionsAwaitingGradingTools(canvas, pseudonymizer)[0]
+  return (await tool.handler(params)) as Result
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('list_submissions_awaiting_grading', () => {
+  it('Fixture A — happy path: mixed states, sorting, type detection', async () => {
+    const canvas = buildMockCanvas({
+      assignments: [A1, A2, A3],
+      submissions: [S1, S2, S3],
+    })
+    const result = await run(canvas)
+
+    expect(result.total_submissions_awaiting).toBe(3)
+    expect(result.items).toHaveLength(2)
+    // A2's oldest submission (06-19) precedes A1's oldest (06-20).
+    expect(result.items[0].assignment_id).toBe(A2.id)
+    expect(result.items[0].type).toBe('classic_quiz')
+    expect(result.items[0].submissions[0].has_pending_manual_questions).toBe(true)
+    expect(result.items[1].assignment_id).toBe(A1.id)
+    expect(result.items[1].submissions[0].submitted_at).toBe('2026-06-20T10:00:00Z')
+    expect(result.items[1].submissions[0].has_pending_manual_questions).toBe(false)
+
+    const listForStudents = canvas.submissions.listForStudents as ReturnType<typeof vi.fn>
+    const calledWith = listForStudents.mock.calls[0][1] as { assignment_ids: number[] }
+    expect(calledWith.assignment_ids).toContain(A1.id)
+    expect(calledWith.assignment_ids).toContain(A2.id)
+    expect(calledWith.assignment_ids).not.toContain(A3.id)
+
+    expect(result.caveats.some((c) => c.includes('New Quizzes'))).toBe(true)
+  })
+
+  it('Fixture B — only_pending_review: true', async () => {
+    const canvas = buildMockCanvas({ assignments: [A1, A2, A3], submissions: [S1, S2, S3] })
+    const result = await run(canvas, { course_id: COURSE_ID, only_pending_review: true })
+
+    expect(result.total_submissions_awaiting).toBe(1)
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0].assignment_id).toBe(A2.id)
+    expect(result.items[0].submissions[0].workflow_state).toBe('pending_review')
+    expect(result.caveats.some((c) => c.includes('Fill-in-the-blank'))).toBe(false)
+  })
+
+  it('Fixture C — assignment_ids scope', async () => {
+    const canvas = buildMockCanvas({ assignments: [A1, A2, A3], submissions: [S1, S2, S3] })
+    const result = await run(canvas, { course_id: COURSE_ID, assignment_ids: [A2.id] })
+
+    expect(result.total_submissions_awaiting).toBe(1)
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0].assignment_id).toBe(A2.id)
+
+    const list = canvas.assignments.list as ReturnType<typeof vi.fn>
+    const calledWith = list.mock.calls[0][1] as { assignment_ids: number[] }
+    expect(calledWith.assignment_ids).toEqual([A2.id])
+  })
+
+  it('Fixture D — include_quizzes: false', async () => {
+    const canvas = buildMockCanvas({ assignments: [A1, A2, A3], submissions: [S1, S2, S3] })
+    const result = await run(canvas, { course_id: COURSE_ID, include_quizzes: false })
+
+    expect(result.items.every((i) => i.type === 'assignment')).toBe(true)
+    expect(result.items.some((i) => i.assignment_id === A2.id)).toBe(false)
+  })
+
+  it('Fixture E — include_assignments: false', async () => {
+    const canvas = buildMockCanvas({ assignments: [A1, A2, A3], submissions: [S1, S2, S3] })
+    const result = await run(canvas, { course_id: COURSE_ID, include_assignments: false })
+
+    expect(result.items.every((i) => i.type === 'classic_quiz')).toBe(true)
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0].assignment_id).toBe(A2.id)
+  })
+
+  it('Fixture F — both toggles false rejects', async () => {
+    const canvas = buildMockCanvas({ assignments: [A1, A2, A3], submissions: [S1, S2, S3] })
+    // Codebase convention: the handler throws; buildHandler converts it to an
+    // isError response. This asserts the guard directly (per spec, Fixture F).
+    await expect(
+      run(canvas, { course_id: COURSE_ID, include_quizzes: false, include_assignments: false }),
+    ).rejects.toThrow('At least one of include_quizzes or include_assignments must be true')
+  })
+
+  it('Fixture G — no submissions awaiting (all graded): early-return, no fetch', async () => {
+    const canvas = buildMockCanvas({
+      assignments: [mkAssignment({ id: 1, needs_grading_count: 0 })],
+      submissions: [],
+    })
+    const result = await run(canvas)
+
+    expect(result.items).toHaveLength(0)
+    expect(result.total_submissions_awaiting).toBe(0)
+    expect(canvas.submissions.listForStudents).not.toHaveBeenCalled()
+  })
+
+  it('Fixture G2 — needs_grading_count absent (undefined) on all assignments', async () => {
+    const canvas = buildMockCanvas({
+      assignments: [mkAssignment({ id: 1 }), mkAssignment({ id: 2 })],
+      submissions: [],
+    })
+    const result = await run(canvas)
+
+    expect(result.items).toHaveLength(0)
+    expect(canvas.submissions.listForStudents).not.toHaveBeenCalled()
+  })
+
+  it('Fixture H — FERPA pseudonymization rewrites the name, keeps the id', async () => {
+    const canvas = buildMockCanvas({
+      assignments: [A1],
+      submissions: [S1],
+    })
+    const ps = makeEnabledPseudonymizer()
+    const result = await run(canvas, { course_id: COURSE_ID }, ps)
+
+    expect(result.items[0].submissions[0].user_name).toBe('Student 0')
+    expect(result.items[0].submissions[0].user_id).toBe(101)
+  })
+
+  it('Fixture H2 — FERPA: user absent → null name, anonymizeSubmission not called', async () => {
+    const subNoUser = mkSubmission({
+      id: 1001,
+      assignment_id: A1.id,
+      user: null,
+      user_id: 101,
+      workflow_state: 'submitted',
+      submitted_at: '2026-06-20T10:00:00Z',
+    })
+    const canvas = buildMockCanvas({ assignments: [A1], submissions: [subNoUser] })
+    const ps = makeEnabledPseudonymizer()
+    const result = await run(canvas, { course_id: COURSE_ID }, ps)
+
+    expect(result.items[0].submissions[0].user_name).toBeNull()
+    expect(ps.anonymizeSubmission).not.toHaveBeenCalled()
+  })
+
+  it('Fixture I — sorting correctness: older item first', async () => {
+    const a1 = mkAssignment({ id: 1, needs_grading_count: 1 })
+    const a2 = mkAssignment({ id: 2, needs_grading_count: 1 })
+    const canvas = buildMockCanvas({
+      assignments: [a1, a2],
+      submissions: [
+        mkSubmission({
+          id: 1,
+          assignment_id: a1.id,
+          workflow_state: 'submitted',
+          submitted_at: '2026-06-25T10:00:00Z',
+          user: { id: 1, name: 'A' },
+        }),
+        mkSubmission({
+          id: 2,
+          assignment_id: a2.id,
+          workflow_state: 'submitted',
+          submitted_at: '2026-06-23T10:00:00Z',
+          user: { id: 2, name: 'B' },
+        }),
+      ],
+    })
+    const result = await run(canvas)
+
+    expect(result.items[0].assignment_id).toBe(a2.id)
+    expect(result.items[1].assignment_id).toBe(a1.id)
+  })
+
+  it('Fixture I2 — null submitted_at: no NaN corruption in items sort', async () => {
+    const a1 = mkAssignment({ id: 1, needs_grading_count: 1 })
+    const a2 = mkAssignment({ id: 2, needs_grading_count: 1 })
+    const canvas = buildMockCanvas({
+      assignments: [a1, a2],
+      submissions: [
+        mkSubmission({
+          id: 1,
+          assignment_id: a1.id,
+          workflow_state: 'submitted',
+          submitted_at: null,
+          user: { id: 1, name: 'A' },
+        }),
+        mkSubmission({
+          id: 2,
+          assignment_id: a2.id,
+          workflow_state: 'submitted',
+          submitted_at: null,
+          user: { id: 2, name: 'B' },
+        }),
+      ],
+    })
+    const result = await run(canvas)
+
+    expect(result.items).toHaveLength(2)
+  })
+
+  it('Fixture J — external-tool (LTI) assignment included, labeled assignment', async () => {
+    const aLti = mkAssignment({
+      id: 1,
+      needs_grading_count: 2,
+      submission_types: ['external_tool'],
+      is_quiz_assignment: false,
+      quiz_id: null,
+    })
+    const canvas = buildMockCanvas({
+      assignments: [aLti],
+      submissions: [
+        mkSubmission({
+          id: 1,
+          assignment_id: aLti.id,
+          workflow_state: 'submitted',
+          user: { id: 1, name: 'A' },
+        }),
+        mkSubmission({
+          id: 2,
+          assignment_id: aLti.id,
+          workflow_state: 'submitted',
+          user: { id: 2, name: 'B' },
+        }),
+      ],
+    })
+    const result = await run(canvas)
+
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0].assignment_id).toBe(aLti.id)
+    expect(result.items[0].type).toBe('assignment')
+    expect(result.total_submissions_awaiting).toBe(2)
+  })
+
+  it('Fixture K — stray submission defensively skipped with caveat', async () => {
+    const a1 = mkAssignment({ id: 1, needs_grading_count: 2 })
+    const canvas = buildMockCanvas({
+      assignments: [a1],
+      filterSubmissions: false,
+      submissions: [
+        mkSubmission({
+          id: 1,
+          assignment_id: a1.id,
+          workflow_state: 'submitted',
+          user: { id: 1, name: 'A' },
+        }),
+        mkSubmission({
+          id: 2,
+          assignment_id: 9999,
+          workflow_state: 'submitted',
+          user: { id: 2, name: 'B' },
+        }),
+      ],
+    })
+    const result = await run(canvas)
+
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0].assignment_id).toBe(a1.id)
+    expect(
+      result.caveats.some((c) =>
+        c.includes('Some submissions could not be matched to an assignment'),
+      ),
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Implements the merged design-first spec for #221 (`docs/superpowers/specs/2026-06-26-issue-221-submissions-awaiting-grading.md`).

> **User story:** As an instructor using Claude, I want to see every submission in my course that still needs a human grade — especially quiz essays, file uploads, and fill-in-the-blank answers Canvas auto-graded but left "pending review" — so I don't publish deflated grades early or forget to circle back before grades post.

Adds **`list_submissions_awaiting_grading`**, a read-only educator triage tool that returns a course-wide list of submissions still needing a human grade — `workflow_state=submitted` (never graded) and `workflow_state=pending_review` (Classic Quiz auto-graded the objective questions but left essays/manually-scored questions). Items are grouped by assignment or Classic Quiz and sorted oldest-waiting first.

## Approach

- **Two paginated Canvas calls, no fan-out:** `assignments.list` (optionally scoped by `assignment_ids`), pre-filtered by `needs_grading_count > 0`, then a single `submissions.listForStudents({ student_ids: ['all'], assignment_ids, include: ['user'] })`. Workflow-state filtering happens client-side because the API accepts only one state and both `submitted` and `pending_review` are needed.
- **Composes existing modules only** — no new Canvas module, no `src/canvas/` changes, no new dependencies.
- **Toggles:** `include_quizzes` / `include_assignments` (default true; both false → error), `only_pending_review` (default false). Defaults are interpreted with explicit `!== false` / `=== true` comparisons so the handler behaves correctly when invoked directly (Zod defaults are only applied at the SDK registration boundary).
- **Caveats over silent exclusion:** New Quizzes and fill-in-the-blank auto-grade gaps are surfaced as fixed caveats rather than excluding `external_tool` assignments (which would hide legitimate LTI grading work). A defensive caveat covers stray submissions Canvas may return outside the requested set.
- **FERPA:** each submission is routed through `pseudonymizer.anonymizeSubmission` when enabled and `user` is present; `list_submissions_awaiting_grading` is added to `PSEUDONYMIZER_WRAPPED_TOOLS` and the test mirror so the coverage CI passes.
- **Tool-count / manifest gate:** ran `pnpm generate:manifests` and bumped the hard-coded counts (138 → 139) in `tests/tools/registry.test.ts` and `tests/discovery/manifests.test.ts`.

## Deviations from the spec (followed code reality)

- Test files live under `tests/tools/` (repo convention), not the spec's `tests/` path.
- Fixture F asserts the handler **rejects** with the guard message (`.rejects.toThrow(...)`) — the established codebase pattern for validation errors — rather than asserting `isError: true`. `buildHandler` converts the throw into an `isError` response and that conversion is covered by existing generic tests.

## Test evidence

Full local gate green:

```
pnpm typecheck   ✓
pnpm lint        ✓  All matched files use Prettier code style!
pnpm test        ✓  Test Files 94 passed (94) | Tests 1303 passed | 1 skipped
pnpm build       ✓  Build success
```

New tests (`tests/tools/submissions-awaiting-grading.test.ts`) cover Fixtures A–K from the spec: mixed-state happy path + sorting + type detection, `only_pending_review`, `assignment_ids` scoping, both include toggles, the both-false guard, empty / absent-`needs_grading_count` early-return, FERPA pseudonymization (name replaced, id kept) and the user-absent path, sort correctness, the null-`submitted_at` NaN guard, external-tool inclusion, and the stray-submission defensive skip.

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)
