### PR TITLE
feat(quiz-accommodations): add New Quizzes accommodation tools

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 139,
+  "toolCount": 141,
   "tools": [
     {
       "name": "health_check",
@@ -1606,7 +1606,7 @@
     {
       "name": "set_student_quiz_accommodation",
       "domain": "quiz_accommodations",
-      "description": "Apply extra time and/or extra attempts to a specific student across all Classic Quizzes in a course (or a specified subset). Fans out to the Canvas quiz extensions API for each quiz. New Quizzes (quiz_type quizzes.next) are skipped — they use a different accommodation mechanism not covered by this tool. Only applies to quizzes that exist at call time; re-run after creating new quizzes. Assignment due-date overrides are not handled here (separate fast-follow feature). Note: for courses with many quizzes this makes one Canvas API call per quiz. Partial failures are tolerated — a failure on one quiz does not abort the rest. Returns the standard fan-out envelope: separated applied[], skipped[] (each with a skip_reason), and failed[] (each with an error) arrays, a not_found list of any requested quiz_ids absent from the course, and a summary of counts. Provide user_id as the real Canvas user ID. If CANVAS_PSEUDONYMIZE_STUDENTS is enabled, call resolve_pseudonym first to obtain the real user_id from a pseudonym.",
+      "description": "Apply extra time and/or extra attempts to a specific student across all Classic Quizzes in a course (or a specified subset). Fans out to the Canvas quiz extensions API for each quiz. New Quizzes (quiz_type quizzes.next) are skipped — use set_student_new_quiz_accommodation instead. Only applies to quizzes that exist at call time; re-run after creating new quizzes. Assignment due-date overrides are not handled here (separate fast-follow feature). Note: for courses with many quizzes this makes one Canvas API call per quiz. Partial failures are tolerated — a failure on one quiz does not abort the rest. Returns the standard fan-out envelope: separated applied[], skipped[] (each with a skip_reason), and failed[] (each with an error) arrays, a not_found list of any requested quiz_ids absent from the course, and a summary of counts. Provide user_id as the real Canvas user ID. If CANVAS_PSEUDONYMIZE_STUDENTS is enabled, call resolve_pseudonym first to obtain the real user_id from a pseudonym.",
       "annotations": {
         "destructiveHint": true,
         "openWorldHint": true
@@ -1619,6 +1619,30 @@
       "name": "list_student_quiz_accommodations",
       "domain": "quiz_accommodations",
       "description": "List the current quiz accommodation (extra time and/or extra attempts) for a specific student across all Classic Quizzes in a course. Useful for auditing before or after calling set_student_quiz_accommodation. New Quizzes (quiz_type quizzes.next) are excluded. Reads extra_time / extra_attempts from each quiz's submission records (Canvas exposes no read endpoint for quiz extensions directly) — one Canvas API call per Classic Quiz, so it may be slow for courses with many quizzes. Errors from any quiz's read propagate immediately (no per-quiz error catching). Provide user_id as the real Canvas user ID. If CANVAS_PSEUDONYMIZE_STUDENTS is enabled, call resolve_pseudonym first.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "set_student_new_quiz_accommodation",
+      "domain": "new_quiz_accommodations",
+      "description": "Apply a time and/or attempts accommodation for a student across all New Quizzes in a course (course-level, single Canvas API call when no assignment_ids are given) or for a specified subset of New Quizzes (per-quiz fan-out when assignment_ids are given). New Quizzes use a time_multiplier (ratio, e.g. 1.5 for 1.5× time), not absolute minutes. For Classic Quizzes (quiz_type: assignment / practice_quiz / etc.) use set_student_quiz_accommodation instead. Partial per-quiz failures are tolerated — a failure on one quiz does not abort the rest. In per-quiz mode, fan-out is sequential (one Canvas API call per assignment ID, awaited in series). Canvas errors on the course-level path (no assignment_ids) propagate as a top-level error (no envelope). Returns a uniform envelope: scope (\"course\" or \"per_quiz\"), applied[], failed[], and summary. Provide user_id as the real Canvas user ID. If CANVAS_PSEUDONYMIZE_STUDENTS is enabled, call resolve_pseudonym first to obtain the real user_id from a pseudonym.",
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true
+      },
+      "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "list_student_new_quiz_accommodations",
+      "domain": "new_quiz_accommodations",
+      "description": "Read the current course-level New Quizzes accommodation (time multiplier and/or extra attempts) for a specific student in a course. Useful for auditing before or after calling set_student_new_quiz_accommodation. Returns has_accommodation: false when no accommodation is set (Canvas 404 is treated as \"no record\", not an error). New Quizzes store a single course-level accommodation record per student; this is not per-quiz. For Classic Quizzes, use list_student_quiz_accommodations instead. Provide user_id as the real Canvas user ID. If CANVAS_PSEUDONYMIZE_STUDENTS is enabled, call resolve_pseudonym first.",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true

--- a/src/canvas/new-quizzes.ts
+++ b/src/canvas/new-quizzes.ts
@@ -1,5 +1,5 @@
-import type { CanvasHttpClient } from './client'
-import type { CanvasNewQuiz, CanvasNewQuizItem } from './types'
+import { CanvasApiError, type CanvasHttpClient } from './client'
+import type { CanvasNewQuiz, CanvasNewQuizAccommodation, CanvasNewQuizItem } from './types'
 
 export interface NewQuizPayload {
   title?: string
@@ -146,6 +146,51 @@ export class NewQuizzesModule {
       `/api/quiz/v1/courses/${courseId}/quizzes/${assignmentId}/items/${itemId}`,
       { method: 'DELETE' },
     )
+  }
+
+  async setAccommodation(
+    courseId: number,
+    userId: number,
+    timeMultiplier?: number,
+    extraAttempts?: number,
+  ): Promise<CanvasNewQuizAccommodation> {
+    const body: Record<string, unknown> = { user_id: userId }
+    if (timeMultiplier !== undefined) body.time_multiplier = timeMultiplier
+    if (extraAttempts !== undefined) body.extra_attempts = extraAttempts
+    return this.client.request<CanvasNewQuizAccommodation>(
+      `/api/quiz/v1/courses/${courseId}/accommodations`,
+      { method: 'POST', body: JSON.stringify(body) },
+    )
+  }
+
+  async setQuizAccommodation(
+    courseId: number,
+    assignmentId: number,
+    userId: number,
+    timeMultiplier?: number,
+    extraAttempts?: number,
+  ): Promise<CanvasNewQuizAccommodation> {
+    const body: Record<string, unknown> = { user_id: userId }
+    if (timeMultiplier !== undefined) body.time_multiplier = timeMultiplier
+    if (extraAttempts !== undefined) body.extra_attempts = extraAttempts
+    return this.client.request<CanvasNewQuizAccommodation>(
+      `/api/quiz/v1/courses/${courseId}/quizzes/${assignmentId}/accommodations`,
+      { method: 'POST', body: JSON.stringify(body) },
+    )
+  }
+
+  async getAccommodation(
+    courseId: number,
+    userId: number,
+  ): Promise<CanvasNewQuizAccommodation | null> {
+    try {
+      return await this.client.request<CanvasNewQuizAccommodation>(
+        `/api/quiz/v1/courses/${courseId}/accommodations/${userId}`,
+      )
+    } catch (err) {
+      if (err instanceof CanvasApiError && err.status === 404) return null
+      throw err
+    }
   }
 
   private toWireItem(item: NewQuizItemInput): Record<string, unknown> {

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -1071,6 +1071,12 @@ export interface CanvasNewQuizItem {
   }
 }
 
+export interface CanvasNewQuizAccommodation {
+  user_id: number
+  time_multiplier: number | null
+  extra_attempts: number | null
+}
+
 // --- Peer Reviews ---
 
 export interface CanvasPeerReview {

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -26,6 +26,7 @@ import { pageTools } from './pages'
 import { peerReviewTools } from './peer-reviews'
 import { quizTools } from './quizzes'
 import { quizAccommodationTools } from './quiz-accommodations'
+import { newQuizAccommodationTools } from './new-quiz-accommodations'
 import { newQuizTools } from './new-quizzes'
 import { rubricTools } from './rubrics'
 import { studentTools } from './student'
@@ -187,6 +188,11 @@ export const toolDomainCatalog: readonly ToolDomainRegistration[] = [
     domain: 'quiz_accommodations',
     defaultPrimaryAudience: 'educator',
     getTools: quizAccommodationTools,
+  },
+  {
+    domain: 'new_quiz_accommodations',
+    defaultPrimaryAudience: 'educator',
+    getTools: newQuizAccommodationTools,
   },
   {
     domain: 'assignment_overrides',

--- a/src/tools/new-quiz-accommodations.ts
+++ b/src/tools/new-quiz-accommodations.ts
@@ -1,0 +1,174 @@
+import { z } from 'zod'
+import type { CanvasClient } from '../canvas'
+import { CanvasApiError } from '../canvas/client'
+import type { ToolDefinition } from './types'
+
+interface NewQuizAccommodationResult {
+  assignment_id: number | null
+  time_multiplier: number | null
+  extra_attempts: number | null
+  error?: string
+}
+
+export function newQuizAccommodationTools(canvas: CanvasClient): ToolDefinition[] {
+  return [
+    {
+      name: 'set_student_new_quiz_accommodation',
+      description:
+        'Apply a time and/or attempts accommodation for a student across all New Quizzes in a course ' +
+        '(course-level, single Canvas API call when no assignment_ids are given) or for a specified ' +
+        'subset of New Quizzes (per-quiz fan-out when assignment_ids are given). ' +
+        'New Quizzes use a time_multiplier (ratio, e.g. 1.5 for 1.5× time), not absolute minutes. ' +
+        'For Classic Quizzes (quiz_type: assignment / practice_quiz / etc.) use ' +
+        'set_student_quiz_accommodation instead. ' +
+        'Partial per-quiz failures are tolerated — a failure on one quiz does not abort the rest. ' +
+        'In per-quiz mode, fan-out is sequential (one Canvas API call per assignment ID, awaited in series). ' +
+        'Canvas errors on the course-level path (no assignment_ids) propagate as a top-level error (no envelope). ' +
+        'Returns a uniform envelope: scope ("course" or "per_quiz"), applied[], failed[], and summary. ' +
+        'Provide user_id as the real Canvas user ID. If CANVAS_PSEUDONYMIZE_STUDENTS is enabled, ' +
+        'call resolve_pseudonym first to obtain the real user_id from a pseudonym.',
+      inputSchema: {
+        course_id: z.number().int().positive().describe('Canvas course ID'),
+        user_id: z
+          .number()
+          .int()
+          .positive()
+          .describe('Real Canvas user ID of the student to accommodate'),
+        time_multiplier: z
+          .number()
+          .min(1.01)
+          .optional()
+          .describe(
+            'Time multiplier for New Quizzes (e.g. 1.5 for 1.5× time, 2.0 for double time). ' +
+              "This is the native New Quizzes field; Canvas applies it to each quiz's time limit. " +
+              'Must be > 1.0. Mutually exclusive with nothing — can be combined with extra_attempts.',
+          ),
+        extra_attempts: z
+          .number()
+          .int()
+          .min(1)
+          .optional()
+          .describe("Additional attempts to grant beyond each quiz's default attempt limit."),
+        assignment_ids: z
+          .array(z.number().int().positive())
+          .optional()
+          .describe(
+            'Limit accommodation to these specific New Quiz assignment IDs. ' +
+              'Omit to apply a course-level accommodation (covers all New Quizzes in the course ' +
+              'with a single Canvas API call). When provided, fans out one call per assignment ID.',
+          ),
+      },
+      annotations: {
+        destructiveHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+        const userId = params.user_id as number
+        const timeMultiplier = params.time_multiplier as number | undefined
+        const extraAttempts = params.extra_attempts as number | undefined
+        const assignmentIds = params.assignment_ids as number[] | undefined
+
+        if (timeMultiplier === undefined && extraAttempts === undefined) {
+          throw new Error('Provide at least one of time_multiplier or extra_attempts.')
+        }
+
+        if (!assignmentIds || assignmentIds.length === 0) {
+          const record = await canvas.newQuizzes.setAccommodation(
+            courseId,
+            userId,
+            timeMultiplier,
+            extraAttempts,
+          )
+          const result: NewQuizAccommodationResult = {
+            assignment_id: null,
+            time_multiplier: record.time_multiplier,
+            extra_attempts: record.extra_attempts,
+          }
+          return {
+            scope: 'course',
+            applied: [result],
+            failed: [],
+            summary: { applied: 1, failed: 0 },
+          }
+        }
+
+        const applied: NewQuizAccommodationResult[] = []
+        const failed: NewQuizAccommodationResult[] = []
+
+        for (const assignmentId of assignmentIds) {
+          try {
+            const record = await canvas.newQuizzes.setQuizAccommodation(
+              courseId,
+              assignmentId,
+              userId,
+              timeMultiplier,
+              extraAttempts,
+            )
+            applied.push({
+              assignment_id: assignmentId,
+              time_multiplier: record.time_multiplier,
+              extra_attempts: record.extra_attempts,
+            })
+          } catch (err) {
+            const message = err instanceof CanvasApiError ? err.message : 'Unknown error'
+            failed.push({
+              assignment_id: assignmentId,
+              time_multiplier: null,
+              extra_attempts: null,
+              error: message,
+            })
+          }
+        }
+
+        return {
+          scope: 'per_quiz',
+          applied,
+          failed,
+          summary: { applied: applied.length, failed: failed.length },
+        }
+      },
+    },
+    {
+      name: 'list_student_new_quiz_accommodations',
+      description:
+        'Read the current course-level New Quizzes accommodation (time multiplier and/or extra attempts) ' +
+        'for a specific student in a course. Useful for auditing before or after calling ' +
+        'set_student_new_quiz_accommodation. ' +
+        'Returns has_accommodation: false when no accommodation is set (Canvas 404 is treated as ' +
+        '"no record", not an error). ' +
+        'New Quizzes store a single course-level accommodation record per student; this is not ' +
+        'per-quiz. For Classic Quizzes, use list_student_quiz_accommodations instead. ' +
+        'Provide user_id as the real Canvas user ID. If CANVAS_PSEUDONYMIZE_STUDENTS is enabled, ' +
+        'call resolve_pseudonym first.',
+      inputSchema: {
+        course_id: z.number().int().positive().describe('Canvas course ID'),
+        user_id: z.number().int().positive().describe('Real Canvas user ID of the student'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+        const userId = params.user_id as number
+
+        const record = await canvas.newQuizzes.getAccommodation(courseId, userId)
+
+        if (record === null) {
+          return {
+            has_accommodation: false,
+            time_multiplier: null,
+            extra_attempts: null,
+          }
+        }
+
+        return {
+          has_accommodation: true,
+          time_multiplier: record.time_multiplier,
+          extra_attempts: record.extra_attempts,
+        }
+      },
+    },
+  ]
+}

--- a/src/tools/quiz-accommodations.ts
+++ b/src/tools/quiz-accommodations.ts
@@ -26,8 +26,7 @@ export function quizAccommodationTools(canvas: CanvasClient): ToolDefinition[] {
       description:
         'Apply extra time and/or extra attempts to a specific student across all Classic Quizzes ' +
         'in a course (or a specified subset). Fans out to the Canvas quiz extensions API for each quiz. ' +
-        'New Quizzes (quiz_type quizzes.next) are skipped — they use a different accommodation ' +
-        'mechanism not covered by this tool. ' +
+        'New Quizzes (quiz_type quizzes.next) are skipped — use set_student_new_quiz_accommodation instead. ' +
         'Only applies to quizzes that exist at call time; re-run after creating new quizzes. ' +
         'Assignment due-date overrides are not handled here (separate fast-follow feature). ' +
         'Note: for courses with many quizzes this makes one Canvas API call per quiz. ' +

--- a/tests/canvas/new-quizzes.test.ts
+++ b/tests/canvas/new-quizzes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { NewQuizzesModule } from '../../src/canvas/new-quizzes'
-import { CanvasHttpClient } from '../../src/canvas/client'
+import { CanvasApiError, CanvasHttpClient } from '../../src/canvas/client'
+import type { CanvasNewQuizAccommodation } from '../../src/canvas/types'
 
 const COURSE_ID = 100
 const ASSIGNMENT_ID = 42
@@ -333,6 +334,96 @@ describe('NewQuizzesModule', () => {
     expect(body).toMatchObject({
       points_possible: 3,
       entry: { scoring_data: { value: 'false' } },
+    })
+  })
+})
+
+describe('NewQuizzesModule — accommodations', () => {
+  const USER_ID = 42
+  const mockAccommodation: CanvasNewQuizAccommodation = {
+    user_id: USER_ID,
+    time_multiplier: 1.5,
+    extra_attempts: 1,
+  }
+
+  let client: CanvasHttpClient
+  let mod: NewQuizzesModule
+
+  beforeEach(() => {
+    client = makeClient()
+    vi.spyOn(client, 'request').mockResolvedValue(mockAccommodation)
+    mod = new NewQuizzesModule(client)
+  })
+
+  describe('setAccommodation', () => {
+    it('sends both fields and returns the record', async () => {
+      const result = await mod.setAccommodation(COURSE_ID, USER_ID, 1.5, 1)
+      expect(result).toEqual(mockAccommodation)
+      expect(client.request).toHaveBeenCalledWith(
+        `/api/quiz/v1/courses/${COURSE_ID}/accommodations`,
+        expect.objectContaining({ method: 'POST' }),
+      )
+      const body = JSON.parse(vi.mocked(client.request).mock.calls[0][1]!.body as string)
+      expect(body).toEqual({ user_id: USER_ID, time_multiplier: 1.5, extra_attempts: 1 })
+    })
+
+    it('omits extra_attempts when undefined', async () => {
+      await mod.setAccommodation(COURSE_ID, USER_ID, 1.5, undefined)
+      const body = JSON.parse(vi.mocked(client.request).mock.calls[0][1]!.body as string)
+      expect(body).toEqual({ user_id: USER_ID, time_multiplier: 1.5 })
+      expect(body).not.toHaveProperty('extra_attempts')
+    })
+
+    it('omits time_multiplier when undefined', async () => {
+      await mod.setAccommodation(COURSE_ID, USER_ID, undefined, 2)
+      const body = JSON.parse(vi.mocked(client.request).mock.calls[0][1]!.body as string)
+      expect(body).toEqual({ user_id: USER_ID, extra_attempts: 2 })
+      expect(body).not.toHaveProperty('time_multiplier')
+    })
+  })
+
+  describe('setQuizAccommodation', () => {
+    it('sends to the per-quiz endpoint and returns the record', async () => {
+      const result = await mod.setQuizAccommodation(COURSE_ID, ASSIGNMENT_ID, USER_ID, 1.5, 1)
+      expect(result).toEqual(mockAccommodation)
+      expect(client.request).toHaveBeenCalledWith(
+        `/api/quiz/v1/courses/${COURSE_ID}/quizzes/${ASSIGNMENT_ID}/accommodations`,
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+
+    it('propagates errors', async () => {
+      vi.mocked(client.request).mockRejectedValueOnce(
+        new CanvasApiError('Not Found', 404, '/api/quiz/v1/...'),
+      )
+      await expect(
+        mod.setQuizAccommodation(COURSE_ID, ASSIGNMENT_ID, USER_ID, 1.5),
+      ).rejects.toThrow('Not Found')
+    })
+  })
+
+  describe('getAccommodation', () => {
+    it('returns the record when it exists', async () => {
+      const result = await mod.getAccommodation(COURSE_ID, USER_ID)
+      expect(result).toEqual(mockAccommodation)
+      expect(client.request).toHaveBeenCalledWith(
+        `/api/quiz/v1/courses/${COURSE_ID}/accommodations/${USER_ID}`,
+      )
+    })
+
+    it('returns null on 404', async () => {
+      vi.mocked(client.request).mockRejectedValueOnce(
+        new CanvasApiError('Not Found', 404, '/api/quiz/v1/...'),
+      )
+      const result = await mod.getAccommodation(COURSE_ID, USER_ID)
+      expect(result).toBeNull()
+    })
+
+    it('propagates non-404 errors', async () => {
+      vi.mocked(client.request).mockRejectedValueOnce(
+        new CanvasApiError('Forbidden', 403, '/api/quiz/v1/...'),
+      )
+      await expect(mod.getAccommodation(COURSE_ID, USER_ID)).rejects.toThrow('Forbidden')
     })
   })
 })

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(139)
+    expect(manifest.tools).toHaveLength(141)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/tools/new-quiz-accommodations.test.ts
+++ b/tests/tools/new-quiz-accommodations.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { newQuizAccommodationTools } from '../../src/tools/new-quiz-accommodations'
+import { CanvasApiError } from '../../src/canvas/client'
+import type { CanvasClient } from '../../src/canvas'
+
+function buildMockCanvas() {
+  return {
+    newQuizzes: {
+      setAccommodation: vi
+        .fn()
+        .mockResolvedValue({ user_id: 42, time_multiplier: 1.5, extra_attempts: 1 }),
+      setQuizAccommodation: vi
+        .fn()
+        .mockResolvedValue({ user_id: 42, time_multiplier: 1.5, extra_attempts: 1 }),
+      getAccommodation: vi
+        .fn()
+        .mockResolvedValue({ user_id: 42, time_multiplier: 1.5, extra_attempts: 1 }),
+    },
+  } as unknown as CanvasClient
+}
+
+describe('newQuizAccommodationTools', () => {
+  let canvas: ReturnType<typeof buildMockCanvas>
+
+  beforeEach(() => {
+    canvas = buildMockCanvas()
+  })
+
+  it('returns exactly 2 tool definitions', () => {
+    const tools = newQuizAccommodationTools(canvas)
+    expect(tools).toHaveLength(2)
+  })
+
+  it('tool names are correct', () => {
+    const tools = newQuizAccommodationTools(canvas)
+    expect(tools.map((t) => t.name)).toEqual([
+      'set_student_new_quiz_accommodation',
+      'list_student_new_quiz_accommodations',
+    ])
+  })
+
+  describe('set_student_new_quiz_accommodation', () => {
+    function getTool(c: CanvasClient) {
+      return newQuizAccommodationTools(c)[0]!
+    }
+
+    it('has destructiveHint and openWorldHint annotations', () => {
+      const tool = getTool(canvas)
+      expect(tool.annotations.destructiveHint).toBe(true)
+      expect(tool.annotations.openWorldHint).toBe(true)
+    })
+
+    it('course-level: calls setAccommodation and returns course scope', async () => {
+      const tool = getTool(canvas)
+      const result = (await tool.handler({
+        course_id: 10,
+        user_id: 42,
+        time_multiplier: 1.5,
+      })) as {
+        scope: string
+        applied: Array<{ assignment_id: number | null; time_multiplier: number | null }>
+        failed: unknown[]
+        summary: { applied: number; failed: number }
+      }
+
+      expect(canvas.newQuizzes.setAccommodation).toHaveBeenCalledWith(10, 42, 1.5, undefined)
+      expect(canvas.newQuizzes.setQuizAccommodation).not.toHaveBeenCalled()
+      expect(result.scope).toBe('course')
+      expect(result.applied[0]!.assignment_id).toBeNull()
+      expect(result.applied[0]!.time_multiplier).toBe(1.5)
+      expect(result.summary.applied).toBe(1)
+      expect(result.summary.failed).toBe(0)
+    })
+
+    it('course-level: extra_attempts only', async () => {
+      const tool = getTool(canvas)
+      await tool.handler({ course_id: 10, user_id: 42, extra_attempts: 2 })
+      expect(canvas.newQuizzes.setAccommodation).toHaveBeenCalledWith(10, 42, undefined, 2)
+    })
+
+    it('per-quiz: fans out to setQuizAccommodation for each assignment_id', async () => {
+      const tool = getTool(canvas)
+      const result = (await tool.handler({
+        course_id: 10,
+        user_id: 42,
+        time_multiplier: 1.5,
+        assignment_ids: [101, 102],
+      })) as {
+        scope: string
+        applied: Array<{ assignment_id: number | null }>
+        failed: unknown[]
+        summary: { applied: number; failed: number }
+      }
+
+      expect(canvas.newQuizzes.setQuizAccommodation).toHaveBeenCalledTimes(2)
+      expect(canvas.newQuizzes.setQuizAccommodation).toHaveBeenNthCalledWith(
+        1,
+        10,
+        101,
+        42,
+        1.5,
+        undefined,
+      )
+      expect(canvas.newQuizzes.setQuizAccommodation).toHaveBeenNthCalledWith(
+        2,
+        10,
+        102,
+        42,
+        1.5,
+        undefined,
+      )
+      expect(canvas.newQuizzes.setAccommodation).not.toHaveBeenCalled()
+      expect(result.scope).toBe('per_quiz')
+      expect(result.applied).toHaveLength(2)
+      expect(result.applied[0]!.assignment_id).toBe(101)
+      expect(result.applied[1]!.assignment_id).toBe(102)
+      expect(result.summary.applied).toBe(2)
+      expect(result.summary.failed).toBe(0)
+    })
+
+    it('per-quiz partial failure: captures error and continues', async () => {
+      const tool = getTool(canvas)
+      canvas.newQuizzes.setQuizAccommodation
+        .mockResolvedValueOnce({ user_id: 42, time_multiplier: 1.5, extra_attempts: 1 })
+        .mockRejectedValueOnce(new CanvasApiError('Not Found', 404, '/api/quiz/v1/...'))
+
+      const result = (await tool.handler({
+        course_id: 10,
+        user_id: 42,
+        time_multiplier: 1.5,
+        assignment_ids: [101, 102],
+      })) as {
+        applied: Array<{ assignment_id: number | null }>
+        failed: Array<{ assignment_id: number | null; error?: string }>
+        summary: { applied: number; failed: number }
+      }
+
+      expect(result.applied).toHaveLength(1)
+      expect(result.applied[0]!.assignment_id).toBe(101)
+      expect(result.failed).toHaveLength(1)
+      expect(result.failed[0]!.assignment_id).toBe(102)
+      expect(result.failed[0]!.error).toContain('Not Found')
+      expect(result.summary.applied).toBe(1)
+      expect(result.summary.failed).toBe(1)
+    })
+
+    it('throws when neither time_multiplier nor extra_attempts provided', async () => {
+      const tool = getTool(canvas)
+      await expect(tool.handler({ course_id: 10, user_id: 42 })).rejects.toThrow('at least one')
+    })
+
+    it('empty assignment_ids treated as course-level', async () => {
+      const tool = getTool(canvas)
+      await tool.handler({ course_id: 10, user_id: 42, time_multiplier: 1.5, assignment_ids: [] })
+      expect(canvas.newQuizzes.setAccommodation).toHaveBeenCalled()
+      expect(canvas.newQuizzes.setQuizAccommodation).not.toHaveBeenCalled()
+    })
+
+    it('user_id is not echoed in applied output', async () => {
+      const tool = getTool(canvas)
+      const result = (await tool.handler({
+        course_id: 10,
+        user_id: 42,
+        time_multiplier: 1.5,
+      })) as { applied: Array<Record<string, unknown>> }
+      expect('user_id' in result.applied[0]!).toBe(false)
+    })
+  })
+
+  describe('list_student_new_quiz_accommodations', () => {
+    function getTool(c: CanvasClient) {
+      return newQuizAccommodationTools(c)[1]!
+    }
+
+    it('has readOnlyHint and openWorldHint annotations', () => {
+      const tool = getTool(canvas)
+      expect(tool.annotations.readOnlyHint).toBe(true)
+      expect(tool.annotations.openWorldHint).toBe(true)
+    })
+
+    it('returns accommodation when record exists', async () => {
+      const tool = getTool(canvas)
+      const result = (await tool.handler({ course_id: 10, user_id: 42 })) as {
+        has_accommodation: boolean
+        time_multiplier: number | null
+        extra_attempts: number | null
+      }
+
+      expect(canvas.newQuizzes.getAccommodation).toHaveBeenCalledWith(10, 42)
+      expect(result.has_accommodation).toBe(true)
+      expect(result.time_multiplier).toBe(1.5)
+      expect(result.extra_attempts).toBe(1)
+      expect('user_id' in result).toBe(false)
+    })
+
+    it('returns has_accommodation: false when no record (null from client)', async () => {
+      canvas.newQuizzes.getAccommodation.mockResolvedValueOnce(null)
+      const tool = getTool(canvas)
+      const result = (await tool.handler({ course_id: 10, user_id: 42 })) as {
+        has_accommodation: boolean
+        time_multiplier: number | null
+        extra_attempts: number | null
+      }
+      expect(result).toEqual({
+        has_accommodation: false,
+        time_multiplier: null,
+        extra_attempts: null,
+      })
+    })
+
+    it('propagates non-404 errors', async () => {
+      canvas.newQuizzes.getAccommodation.mockRejectedValueOnce(
+        new CanvasApiError('Forbidden', 403, '/api/quiz/v1/...'),
+      )
+      const tool = getTool(canvas)
+      await expect(tool.handler({ course_id: 10, user_id: 42 })).rejects.toThrow('Forbidden')
+    })
+  })
+})

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -169,6 +169,9 @@ function buildFullMockCanvas(): CanvasClient {
       createItem: async () => ({}),
       updateItem: async () => ({}),
       deleteItem: async () => undefined,
+      setAccommodation: async () => ({}),
+      setQuizAccommodation: async () => ({}),
+      getAccommodation: async () => null,
     },
     contentExports: {
       create: async () => ({}),
@@ -353,6 +356,9 @@ describe('getAllTools', () => {
     // Quiz Accommodations (2)
     expect(names).toContain('set_student_quiz_accommodation')
     expect(names).toContain('list_student_quiz_accommodations')
+    // New Quiz Accommodations (2)
+    expect(names).toContain('set_student_new_quiz_accommodation')
+    expect(names).toContain('list_student_new_quiz_accommodations')
     // Assignment Overrides (3)
     expect(names).toContain('list_assignment_overrides')
     expect(names).toContain('create_assignment_override')
@@ -368,7 +374,7 @@ describe('getAllTools', () => {
     // Submissions Awaiting Grading (1)
     expect(names).toContain('list_submissions_awaiting_grading')
 
-    expect(tools).toHaveLength(139)
+    expect(tools).toHaveLength(141)
   })
 
   it('all tools have openWorldHint: true', () => {
@@ -419,6 +425,7 @@ describe('getAllTools', () => {
       'create_grading_standard',
       'apply_grading_standard_to_course',
       'set_student_quiz_accommodation',
+      'set_student_new_quiz_accommodation',
       'create_assignment_override',
       'set_student_assignment_dates',
     ]
@@ -479,6 +486,7 @@ describe('getAllTools', () => {
       'create_grading_standard',
       'apply_grading_standard_to_course',
       'set_student_quiz_accommodation',
+      'set_student_new_quiz_accommodation',
       'create_assignment_override',
       'set_student_assignment_dates',
     ])


### PR DESCRIPTION
## Summary

- Adds `set_student_new_quiz_accommodation` — applies a `time_multiplier` and/or `extra_attempts` accommodation for a student across all New Quizzes in a course (single Canvas API call), or fans out per-quiz when `assignment_ids` are supplied.
- Adds `list_student_new_quiz_accommodations` — reads the current course-level New Quizzes accommodation for a student (treats Canvas 404 as "no record set", not an error).
- Updates `set_student_quiz_accommodation` description to point callers at the new sibling tool for New Quizzes.
- Closes the gap left by the Classic Quizzes tool, which explicitly skips `quizzes.next` quiz types.

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 1329/1329 passing
- [x] `pnpm build`

## Checklist

- [x] Scope stays focused and does not include unrelated release/versioning changes
- [x] Tests were added or updated when behavior changed
- [x] Docs were updated when setup, usage, or contributor workflow changed
- [x] Any required follow-up work is documented below

## Related

- Issue: Closes #224
- Follow-up: None — all design unknowns retired in spec #225 (merged)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WbL27KbbstaanoXyyyVy6H)_