### PR TITLE
feat(link-audit): scan quizzes for broken and cross-course links

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1726,7 +1726,7 @@
     {
       "name": "audit_course_links",
       "domain": "link_audit",
-      "description": "Scan a course's content (pages, assignments, syllabus, announcements) for broken or outdated links and images. Returns structured findings: cross-course references (links that still point at a previous copy of the course — the canonical stale-copy failure after a course import) and empty/malformed URLs. Structural checks only — no outbound HTTP requests. Requires instructor permissions in the course.",
+      "description": "Scan a course's content (pages, assignments, syllabus, announcements, and optionally quizzes) for broken or outdated links and images. Returns structured findings: cross-course references (links that still point at a previous copy of the course — the canonical stale-copy failure after a course import) and empty/malformed URLs. Pass \"quizzes\" in `include` to also scan Classic quiz descriptions/questions and New Quiz item stems — these break silently for students while still rendering in the instructor’s own preview. `quizzes` is opt-in (off by default). Structural checks only — no outbound HTTP requests. Requires instructor permissions in the course.",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -194,6 +194,7 @@ export interface CanvasAssignment {
   }
   assignment_visibility?: number[]
   is_quiz_assignment?: boolean
+  is_quiz_lti_assignment?: boolean // true when backed by the New Quizzes (Quizzes.Next) LTI tool
   in_closed_grading_period?: boolean
   post_to_sis?: boolean
   integration_id?: string | null
@@ -387,6 +388,7 @@ export interface CanvasQuiz {
   id: number
   title: string
   quiz_type: string
+  description?: string | null // HTML shown above the quiz's questions
   points_possible: number
   question_count: number
   due_at: string | null

--- a/src/tools/link-audit.ts
+++ b/src/tools/link-audit.ts
@@ -2,8 +2,26 @@ import { z } from 'zod'
 import type { CanvasClient } from '../canvas'
 import type { ToolDefinition } from './types'
 
-const CONTENT_SOURCES = ['pages', 'assignments', 'syllabus', 'announcements'] as const
+const CONTENT_SOURCES = ['pages', 'assignments', 'syllabus', 'announcements', 'quizzes'] as const
 type ContentSource = (typeof CONTENT_SOURCES)[number]
+
+// `quizzes` is opt-in — see spec Design unknown §3. It is a valid `include` value
+// but is excluded from the default set scanned when `include` is omitted, so the
+// existing four sources' default cost and behavior are unchanged.
+const DEFAULT_CONTENT_SOURCES: ContentSource[] = [
+  'pages',
+  'assignments',
+  'syllabus',
+  'announcements',
+]
+
+// Allow-list of Classic quiz_type values, mirroring the convention in
+// src/tools/quiz-accommodations.ts. Kept as a local constant (each tool file owns
+// its own small constants). Filtering with `.has()` skips listQuestions for any
+// quiz whose quiz_type is not a known-Classic value (e.g. the `quizzes.next` stub
+// Canvas leaves after a New Quizzes migration, or any future/unrecognized type).
+const CLASSIC_QUIZ_TYPES = new Set(['assignment', 'practice_quiz', 'graded_survey', 'survey'])
+
 type LinkKind = 'link' | 'image' | 'video'
 type FindingReason = 'cross_course_reference' | 'empty_or_malformed'
 
@@ -11,6 +29,14 @@ interface ContentLocation {
   type: ContentSource
   id: number
   title: string
+  // Set only when type === 'quizzes'. Classic ids resolve at
+  // /courses/:id/quizzes/:id; New Quiz ids are the backing assignment id and
+  // resolve at /courses/:id/assignments/:id.
+  quiz_engine?: 'classic' | 'new'
+  // Set only when the finding is inside a specific question/item, not the quiz's
+  // own description. Classic question ids are numeric; New Quiz item ids are
+  // Canvas-assigned strings (CanvasNewQuizItem.id: string).
+  question_id?: number | string
 }
 
 interface LinkFinding {
@@ -88,24 +114,82 @@ function scanHtml(
   return findings
 }
 
+async function scanQuizzes(canvas: CanvasClient, courseId: number): Promise<LinkFinding[]> {
+  // `assignments` here is a separate, locally-scoped fetch from the outer
+  // handler's `assignments` variable — the two never share state. When both the
+  // `assignments` and `quizzes` sources are active, canvas.assignments.list is
+  // called twice, concurrently (each inside its own Promise.all branch) — an
+  // accepted v1 inefficiency, not a bug (see spec Design unknown §1).
+  const [quizzes, assignments] = await Promise.all([
+    canvas.quizzes.list(courseId),
+    canvas.assignments.list(courseId),
+  ])
+
+  const classicQuizzes = quizzes.filter((quiz) => CLASSIC_QUIZ_TYPES.has(quiz.quiz_type))
+  const classicFindings = await Promise.all(
+    classicQuizzes.map(async (quiz) => {
+      const location: ContentLocation = {
+        type: 'quizzes',
+        id: quiz.id,
+        title: quiz.title,
+        quiz_engine: 'classic',
+      }
+      const findings = scanHtml(quiz.description, courseId, location)
+      const questions = await canvas.quizzes.listQuestions(courseId, quiz.id)
+      for (const question of questions) {
+        findings.push(
+          ...scanHtml(question.question_text, courseId, {
+            ...location,
+            question_id: question.id,
+          }),
+        )
+      }
+      return findings
+    }),
+  )
+
+  const newQuizAssignments = assignments.filter((a) => a.is_quiz_lti_assignment === true)
+  const newQuizFindings = await Promise.all(
+    newQuizAssignments.map(async (assignment) => {
+      const location: ContentLocation = {
+        type: 'quizzes',
+        id: assignment.id,
+        title: assignment.name,
+        quiz_engine: 'new',
+      }
+      const items = await canvas.newQuizzes.listItems(courseId, assignment.id)
+      return items.flatMap((item) =>
+        scanHtml(item.entry.item_body, courseId, { ...location, question_id: item.id }),
+      )
+    }),
+  )
+
+  return [...classicFindings.flat(), ...newQuizFindings.flat()]
+}
+
 export function linkAuditTools(canvas: CanvasClient): ToolDefinition[] {
   return [
     {
       name: 'audit_course_links',
       description:
-        "Scan a course's content (pages, assignments, syllabus, announcements) for broken or " +
-        'outdated links and images. Returns structured findings: cross-course references (links ' +
-        'that still point at a previous copy of the course — the canonical stale-copy failure ' +
-        'after a course import) and empty/malformed URLs. Structural checks only — no outbound ' +
-        'HTTP requests. Requires instructor permissions in the course.',
+        "Scan a course's content (pages, assignments, syllabus, announcements, and optionally " +
+        'quizzes) for broken or outdated links and images. Returns structured findings: ' +
+        'cross-course references (links that still point at a previous copy of the course — the ' +
+        'canonical stale-copy failure after a course import) and empty/malformed URLs. Pass ' +
+        '"quizzes" in `include` to also scan Classic quiz descriptions/questions and New Quiz ' +
+        'item stems — these break silently for students while still rendering in the ' +
+        'instructor’s own preview. `quizzes` is opt-in (off by default). Structural checks ' +
+        'only — no outbound HTTP requests. Requires instructor permissions in the course.',
       inputSchema: {
         course_id: z.number().int().positive().describe('Canvas course ID'),
         include: z
-          .array(z.enum(['pages', 'assignments', 'syllabus', 'announcements']))
+          .array(z.enum(['pages', 'assignments', 'syllabus', 'announcements', 'quizzes']))
           .optional()
           .describe(
-            'Content sources to scan. Omit to scan all four. ' +
-              'Valid values: pages, assignments, syllabus, announcements.',
+            'Content sources to scan. Omit to scan the default four: pages, assignments, ' +
+              'syllabus, announcements. `quizzes` is opt-in — pass it explicitly to also scan ' +
+              'Classic quiz descriptions/questions and New Quiz item stems; it issues one extra ' +
+              'Canvas API call per quiz/New Quiz in the course.',
           ),
       },
       annotations: {
@@ -115,10 +199,10 @@ export function linkAuditTools(canvas: CanvasClient): ToolDefinition[] {
       handler: async (params) => {
         const courseId = params.course_id as number
         const activeInclude = new Set<ContentSource>(
-          (params.include as ContentSource[] | undefined) ?? [...CONTENT_SOURCES],
+          (params.include as ContentSource[] | undefined) ?? DEFAULT_CONTENT_SOURCES,
         )
 
-        const [pages, assignments, syllabus, announcements] = await Promise.all([
+        const [pages, assignments, syllabus, announcements, quizFindings] = await Promise.all([
           activeInclude.has('pages') ? canvas.pages.listWithBodies(courseId) : Promise.resolve([]),
           activeInclude.has('assignments')
             ? canvas.assignments.list(courseId)
@@ -129,6 +213,9 @@ export function linkAuditTools(canvas: CanvasClient): ToolDefinition[] {
           activeInclude.has('announcements')
             ? canvas.discussions.listAnnouncements(courseId)
             : Promise.resolve([]),
+          activeInclude.has('quizzes')
+            ? scanQuizzes(canvas, courseId)
+            : Promise.resolve([] as LinkFinding[]),
         ])
 
         const findings: LinkFinding[] = []
@@ -174,6 +261,8 @@ export function linkAuditTools(canvas: CanvasClient): ToolDefinition[] {
             )
           }
         }
+
+        findings.push(...quizFindings)
 
         return {
           summary: {

--- a/src/tools/link-audit.ts
+++ b/src/tools/link-audit.ts
@@ -158,8 +158,12 @@ async function scanQuizzes(canvas: CanvasClient, courseId: number): Promise<Link
         quiz_engine: 'new',
       }
       const items = await canvas.newQuizzes.listItems(courseId, assignment.id)
+      // `entry` is optional-chained defensively: New Quizzes list items include
+      // Stimulus blocks and other entry shapes, and a malformed/entry-less item
+      // would otherwise throw a raw TypeError that aborts the whole audit. A
+      // missing body is treated as "no links" by extractUrls' null-guard.
       return items.flatMap((item) =>
-        scanHtml(item.entry.item_body, courseId, { ...location, question_id: item.id }),
+        scanHtml(item.entry?.item_body, courseId, { ...location, question_id: item.id }),
       )
     }),
   )

--- a/tests/tools/link-audit.test.ts
+++ b/tests/tools/link-audit.test.ts
@@ -141,6 +141,27 @@ function buildMockCanvas(): CanvasClient {
             properties: {},
           },
         },
+        {
+          // Link-free control: a same-course image must NOT be flagged.
+          id: 'item-2',
+          position: 2,
+          points_possible: 5,
+          entry_type: 'Item',
+          entry: {
+            interaction_type_slug: 'choice',
+            item_body: '<p>Local image: <img src="/courses/100/files/3/download"></p>',
+            interaction_data: {},
+            properties: {},
+          },
+        },
+        {
+          // Malformed/entry-less item (e.g. an unexpected Stimulus shape): must be
+          // skipped safely, never throw. `entry` is intentionally absent here.
+          id: 'item-3',
+          position: 3,
+          points_possible: 0,
+          entry_type: 'Stimulus',
+        },
       ]),
     },
     courses: {
@@ -691,6 +712,46 @@ describe('linkAuditTools', () => {
 
       expect(canvas.assignments.list).toHaveBeenCalledTimes(2)
       expect(result.summary.sources_scanned).toEqual(['assignments', 'quizzes'])
+    })
+
+    // 36 — absolute count guard, mirroring the full-scan suite's exact-count test.
+    // Locks the quizzes source to its 3 expected findings (quiz-30 description link,
+    // quiz-30 question-300 image, New-Quiz item-1 image) so a duplicate, stub-quiz
+    // leak, or same-course false positive cannot slip past the existential matchers.
+    it('emits exactly the three expected quiz findings (no over- or under-counting)', async () => {
+      const [tool] = linkAuditTools(buildMockCanvas())
+      const result = (await tool.handler({
+        course_id: 100,
+        include: ['quizzes'],
+      })) as AuditResult
+
+      expect(result.findings).toHaveLength(3)
+      expect(result.summary.total_findings).toBe(3)
+    })
+
+    // 37 — clean New Quiz control: a same-course item image must NOT be flagged
+    // (symmetric to Classic question 301's no-finding control).
+    it('does not flag a same-course image in a New Quiz item', async () => {
+      const [tool] = linkAuditTools(buildMockCanvas())
+      const result = (await tool.handler({
+        course_id: 100,
+        include: ['quizzes'],
+      })) as AuditResult
+
+      expect(result.findings.some((f) => f.location.question_id === 'item-2')).toBe(false)
+    })
+
+    // 38 — robustness: a malformed/entry-less New Quiz item (e.g. an unexpected
+    // Stimulus shape) is skipped safely rather than throwing a TypeError that would
+    // abort the whole multi-source audit.
+    it('skips an entry-less New Quiz item without throwing', async () => {
+      const [tool] = linkAuditTools(buildMockCanvas())
+      const result = (await tool.handler({
+        course_id: 100,
+        include: ['quizzes'],
+      })) as AuditResult
+
+      expect(result.findings.some((f) => f.location.question_id === 'item-3')).toBe(false)
     })
   })
 

--- a/tests/tools/link-audit.test.ts
+++ b/tests/tools/link-audit.test.ts
@@ -738,6 +738,8 @@ describe('linkAuditTools', () => {
         include: ['quizzes'],
       })) as AuditResult
 
+      // item-1 IS flagged in the same result, so this negative control cannot pass vacuously.
+      expect(result.findings.some((f) => f.location.question_id === 'item-1')).toBe(true)
       expect(result.findings.some((f) => f.location.question_id === 'item-2')).toBe(false)
     })
 
@@ -751,6 +753,8 @@ describe('linkAuditTools', () => {
         include: ['quizzes'],
       })) as AuditResult
 
+      // item-1 IS flagged in the same result, proving the New Quiz items were scanned.
+      expect(result.findings.some((f) => f.location.question_id === 'item-1')).toBe(true)
       expect(result.findings.some((f) => f.location.question_id === 'item-3')).toBe(false)
     })
   })

--- a/tests/tools/link-audit.test.ts
+++ b/tests/tools/link-audit.test.ts
@@ -3,7 +3,13 @@ import { linkAuditTools } from '../../src/tools/link-audit'
 import type { CanvasClient } from '../../src/canvas'
 
 interface Finding {
-  location: { type: string; id: number; title: string }
+  location: {
+    type: string
+    id: number
+    title: string
+    quiz_engine?: 'classic' | 'new'
+    question_id?: number | string
+  }
   kind: string
   href: string
   reason: string
@@ -64,6 +70,76 @@ function buildMockCanvas(): CanvasClient {
           grading_type: 'points',
           submission_types: [],
           allowed_attempts: -1,
+        },
+        {
+          id: 40,
+          name: 'Final (New Quiz)',
+          description: null, // no href here — keeps existing assignments-source finding counts unaffected
+          course_id: 100,
+          due_at: null,
+          points_possible: 20,
+          grading_type: 'points',
+          submission_types: ['external_tool'],
+          allowed_attempts: -1,
+          is_quiz_lti_assignment: true,
+        },
+      ]),
+    },
+    quizzes: {
+      list: vi.fn().mockResolvedValue([
+        {
+          id: 30,
+          title: 'Midterm',
+          quiz_type: 'assignment',
+          description: '<p>Read <a href="/courses/999/pages/notes">notes</a> first.</p>',
+          points_possible: 20,
+          question_count: 2,
+          due_at: null,
+          published: true,
+        },
+        {
+          id: 31,
+          title: 'Migrated Stub',
+          quiz_type: 'quizzes.next',
+          description: null,
+          points_possible: 0,
+          question_count: 0,
+          due_at: null,
+          published: true,
+        },
+      ]),
+      listQuestions: vi.fn().mockResolvedValue([
+        {
+          id: 300,
+          quiz_id: 30,
+          position: 1,
+          question_text: '<p>See <img src="/courses/999/files/1/download"> above.</p>',
+          question_type: 'multiple_choice_question',
+          points_possible: 10,
+        },
+        {
+          id: 301,
+          quiz_id: 30,
+          position: 2,
+          question_text: '<p>No links here.</p>',
+          question_type: 'true_false_question',
+          points_possible: 10,
+        },
+      ]),
+    },
+    newQuizzes: {
+      listItems: vi.fn().mockResolvedValue([
+        {
+          id: 'item-1',
+          position: 1,
+          points_possible: 5,
+          entry_type: 'Item',
+          entry: {
+            interaction_type_slug: 'choice',
+            item_body: '<p>Pick the diagram: <img src="/courses/999/files/2/download"></p>',
+            interaction_data: {},
+            properties: {},
+          },
         },
       ]),
     },
@@ -461,6 +537,160 @@ describe('linkAuditTools', () => {
       const result = (await tool.handler({ course_id: 100, include: ['pages'] })) as AuditResult
 
       expect(result.findings).toHaveLength(0)
+    })
+  })
+
+  describe('quizzes source', () => {
+    // 27
+    it('does not scan quizzes by default (opt-in)', async () => {
+      const canvas = buildMockCanvas()
+      const [tool] = linkAuditTools(canvas)
+
+      const result = (await tool.handler({ course_id: 100 })) as AuditResult
+
+      expect(canvas.quizzes.list).not.toHaveBeenCalled()
+      expect(canvas.newQuizzes.listItems).not.toHaveBeenCalled()
+      expect(result.summary.sources_scanned).toEqual([
+        'pages',
+        'assignments',
+        'syllabus',
+        'announcements',
+      ])
+    })
+
+    // 28
+    it('flags a cross-course link in a Classic quiz description without a question_id', async () => {
+      const [tool] = linkAuditTools(buildMockCanvas())
+      const result = (await tool.handler({
+        course_id: 100,
+        include: ['quizzes'],
+      })) as AuditResult
+
+      const finding = result.findings.find(
+        (f) => f.location.type === 'quizzes' && f.location.id === 30 && f.kind === 'link',
+      )
+      expect(finding).toBeDefined()
+      expect(finding?.location).toEqual({
+        type: 'quizzes',
+        id: 30,
+        title: 'Midterm',
+        quiz_engine: 'classic',
+      })
+      expect(finding?.location).not.toHaveProperty('question_id')
+      expect(finding).toMatchObject({ reason: 'cross_course_reference', cross_course_id: 999 })
+    })
+
+    // 29
+    it('flags a cross-course image in a Classic quiz question with a question_id', async () => {
+      const [tool] = linkAuditTools(buildMockCanvas())
+      const result = (await tool.handler({
+        course_id: 100,
+        include: ['quizzes'],
+      })) as AuditResult
+
+      expect(result.findings).toContainEqual(
+        expect.objectContaining({
+          location: {
+            type: 'quizzes',
+            id: 30,
+            title: 'Midterm',
+            quiz_engine: 'classic',
+            question_id: 300,
+          },
+          kind: 'image',
+          reason: 'cross_course_reference',
+          cross_course_id: 999,
+        }),
+      )
+    })
+
+    // 30
+    it('emits no finding for a Classic quiz question with no links', async () => {
+      const [tool] = linkAuditTools(buildMockCanvas())
+      const result = (await tool.handler({
+        course_id: 100,
+        include: ['quizzes'],
+      })) as AuditResult
+
+      expect(result.findings.some((f) => f.location.question_id === 301)).toBe(false)
+    })
+
+    // 31
+    it('skips a migrated stub Classic quiz (quiz_type quizzes.next)', async () => {
+      const canvas = buildMockCanvas()
+      const [tool] = linkAuditTools(canvas)
+      const result = (await tool.handler({
+        course_id: 100,
+        include: ['quizzes'],
+      })) as AuditResult
+
+      expect(canvas.quizzes.listQuestions).toHaveBeenCalledTimes(1)
+      expect(canvas.quizzes.listQuestions).toHaveBeenCalledWith(100, 30)
+      expect(result.findings.some((f) => f.location.id === 31)).toBe(false)
+    })
+
+    // 32
+    it('flags a cross-course image in a New Quiz item', async () => {
+      const [tool] = linkAuditTools(buildMockCanvas())
+      const result = (await tool.handler({
+        course_id: 100,
+        include: ['quizzes'],
+      })) as AuditResult
+
+      expect(result.findings).toContainEqual(
+        expect.objectContaining({
+          location: {
+            type: 'quizzes',
+            id: 40,
+            title: 'Final (New Quiz)',
+            quiz_engine: 'new',
+            question_id: 'item-1',
+          },
+          kind: 'image',
+          reason: 'cross_course_reference',
+          cross_course_id: 999,
+        }),
+      )
+    })
+
+    // 33
+    it('scans items only for the New-Quiz-flagged assignment', async () => {
+      const canvas = buildMockCanvas()
+      const [tool] = linkAuditTools(canvas)
+      await tool.handler({ course_id: 100, include: ['quizzes'] })
+
+      expect(canvas.newQuizzes.listItems).toHaveBeenCalledTimes(1)
+      expect(canvas.newQuizzes.listItems).toHaveBeenCalledWith(100, 40)
+    })
+
+    // 34
+    it('reports sources_scanned as ["quizzes"] and skips other sources when only quizzes is opted in', async () => {
+      const canvas = buildMockCanvas()
+      const [tool] = linkAuditTools(canvas)
+      const result = (await tool.handler({
+        course_id: 100,
+        include: ['quizzes'],
+      })) as AuditResult
+
+      expect(result.summary.sources_scanned).toEqual(['quizzes'])
+      expect(canvas.pages.listWithBodies).not.toHaveBeenCalled()
+      expect(canvas.courses.getSyllabus).not.toHaveBeenCalled()
+      expect(canvas.discussions.listAnnouncements).not.toHaveBeenCalled()
+      // assignments.list is still needed for New Quiz discovery
+      expect(canvas.assignments.list).toHaveBeenCalled()
+    })
+
+    // 35
+    it('fetches assignments twice for the accepted double-fetch when both assignments and quizzes are included', async () => {
+      const canvas = buildMockCanvas()
+      const [tool] = linkAuditTools(canvas)
+      const result = (await tool.handler({
+        course_id: 100,
+        include: ['assignments', 'quizzes'],
+      })) as AuditResult
+
+      expect(canvas.assignments.list).toHaveBeenCalledTimes(2)
+      expect(result.summary.sources_scanned).toEqual(['assignments', 'quizzes'])
     })
   })
 


### PR DESCRIPTION
## Summary

Extends `audit_course_links` with an opt-in `quizzes` content source, implementing the merged design spec for #227.

> **User story:** As an instructor using Claude, when I run the course link/image audit after copying a course, I want it to also flag broken and cross-course images inside quiz descriptions and quiz questions — because those break silently for students while still rendering in my own test-student preview, so I have no way to catch them by eye.

Quizzes are the highest-stakes gap in today's audit: an image that broke after a course copy still renders correctly in the instructor's own "Test Student" preview, so the instructor cannot notice it by eye — while a real student sees a broken image.

## Approach

- Adds `quizzes` as a fifth content source, **opt-in** (off by default). The existing four sources (pages/assignments/syllabus/announcements) keep their exact default behavior and cost — `quizzes` is only scanned when passed explicitly in `include`.
- New module-level `scanQuizzes` helper reuses the existing `scanHtml` / `classifyUrl` machinery unchanged — no new detection logic, no new Canvas client methods.
  - **Classic Quizzes**: scans each quiz's `description` (finding has no `question_id`) and each question's `question_text` (finding carries `question_id`), via the existing `quizzes.list` / `quizzes.listQuestions`.
  - **New Quizzes**: discovered via `assignments.list` filtered on `is_quiz_lti_assignment`, item stems scanned via `newQuizzes.listItems` (`entry.item_body`).
- Migrated New-Quizzes stub rows (`quiz_type: 'quizzes.next'`) are skipped using a `CLASSIC_QUIZ_TYPES` allow-list, mirroring the established convention in `quiz-accommodations.ts` — strictly safer than a `quizzes.next` deny-list.
- Findings tag the quiz with `quiz_engine` (`classic`/`new`) and, for question/item-level hits, `question_id`, so an instructor can jump straight to the broken item.
- **No pseudonymizer change**: quiz/question/item content is course content (same category as the pages/assignments HTML already scanned), not student PII — `audit_course_links` stays out of `PSEUDONYMIZER_WRAPPED_TOOLS`.
- Tool `description` updated and `docs/generated/tool-manifest.json` regenerated via `pnpm generate:manifests` (only the `audit_course_links` description field changes). No tool added/removed — tool count unchanged.

## Test evidence

9 new mocked-response cases (opt-in default, Classic description, Classic question, stub-skip, New Quiz item, scan isolation, `sources_scanned` variants, accepted double-fetch). Full local gate green:

```
typecheck (tsc --noEmit)        exit 0
lint (eslint + prettier)        exit 0
test                            Test Files 95 passed | Tests 1337 passed | 1 skipped
build (tsup)                    Build success
```

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)
