### PR TITLE
feat(files): add find_duplicate_files tool for accessibility cleanup

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 142,
+  "toolCount": 143,
   "tools": [
     {
       "name": "health_check",
@@ -551,6 +551,18 @@
       "name": "download_file",
       "domain": "files",
       "description": "Download the content of a Canvas file by ID. Text files (plain text, HTML, JSON, XML, JavaScript) are returned as readable text. Binary files (images, PDFs, etc.) are returned as base64-encoded data. Files larger than 10 MB are refused.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
+      "primaryAudience": "shared",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "find_duplicate_files",
+      "domain": "files",
+      "description": "Find duplicate files in a course's Files area — copies with the same name and size, typically left behind by repeated course copies. Each duplicate gets flagged separately by accessibility checkers, so this surfaces them for cleanup with the existing delete_file tool. Groups by display name + size (Canvas file listings carry no content hash), so same-name files of different sizes are not considered duplicates.",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true

--- a/src/tools/files.ts
+++ b/src/tools/files.ts
@@ -1,6 +1,86 @@
 import { z } from 'zod'
 import type { CanvasClient } from '../canvas'
+import type { CanvasFile, CanvasFolder } from '../canvas/types'
 import type { ToolDefinition } from './types'
+
+interface DuplicateFileEntry {
+  id: number
+  folder_path: string
+  created_at?: string
+}
+
+interface DuplicateGroup {
+  display_name: string
+  size: number
+  count: number
+  files: DuplicateFileEntry[]
+}
+
+// Folders in the subtree rooted at `folderId`, including `folderId` itself. If
+// `folderId` isn't present among `folders` (e.g. a stale/foreign id), the
+// subtree is just `{ folderId }` — callers naturally get zero matching files
+// rather than an error.
+function collectFolderSubtree(folders: CanvasFolder[], folderId: number): Set<number> {
+  const childrenByParent = new Map<number, number[]>()
+  for (const folder of folders) {
+    if (folder.parent_folder_id == null) continue
+    const siblings = childrenByParent.get(folder.parent_folder_id) ?? []
+    siblings.push(folder.id)
+    childrenByParent.set(folder.parent_folder_id, siblings)
+  }
+
+  const subtree = new Set<number>([folderId])
+  const queue = [folderId]
+  while (queue.length > 0) {
+    const current = queue.shift()!
+    for (const childId of childrenByParent.get(current) ?? []) {
+      if (!subtree.has(childId)) {
+        subtree.add(childId)
+        queue.push(childId)
+      }
+    }
+  }
+  return subtree
+}
+
+function findDuplicateFiles(
+  files: CanvasFile[],
+  folders: CanvasFolder[],
+  folderId?: number,
+): { duplicate_groups: DuplicateGroup[]; total_redundant_copies: number } {
+  const folderPathById = new Map(folders.map((f) => [f.id, f.full_name]))
+  const scoped =
+    folderId == null
+      ? files
+      : files.filter((f) => collectFolderSubtree(folders, folderId).has(f.folder_id))
+
+  const groups = new Map<string, CanvasFile[]>()
+  for (const file of scoped) {
+    const key = JSON.stringify([file.display_name, file.size])
+    const group = groups.get(key) ?? []
+    group.push(file)
+    groups.set(key, group)
+  }
+
+  const duplicate_groups: DuplicateGroup[] = []
+  let total_redundant_copies = 0
+  for (const group of groups.values()) {
+    if (group.length < 2) continue
+    total_redundant_copies += group.length - 1
+    duplicate_groups.push({
+      display_name: group[0]!.display_name,
+      size: group[0]!.size,
+      count: group.length,
+      files: group.map((f) => ({
+        id: f.id,
+        folder_path: folderPathById.get(f.folder_id) ?? `(unknown folder ${f.folder_id})`,
+        ...(f.created_at !== undefined ? { created_at: f.created_at } : {}),
+      })),
+    })
+  }
+
+  return { duplicate_groups, total_redundant_copies }
+}
 
 export function fileTools(canvas: CanvasClient): ToolDefinition[] {
   return [
@@ -114,6 +194,37 @@ export function fileTools(canvas: CanvasClient): ToolDefinition[] {
         const file_id = params.file_id as number
         const course_id = params.course_id as number | undefined
         return canvas.files.download(file_id, course_id)
+      },
+    },
+    {
+      name: 'find_duplicate_files',
+      description:
+        "Find duplicate files in a course's Files area — copies with the same name and size, " +
+        'typically left behind by repeated course copies. Each duplicate gets flagged separately ' +
+        'by accessibility checkers, so this surfaces them for cleanup with the existing ' +
+        'delete_file tool. Groups by display name + size (Canvas file listings carry no content ' +
+        'hash), so same-name files of different sizes are not considered duplicates.',
+      inputSchema: {
+        course_id: z.number().describe('The Canvas course ID'),
+        folder_id: z
+          .number()
+          .optional()
+          .describe(
+            'Optional Canvas folder ID to scope the search to that folder and its subfolders',
+          ),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const course_id = params.course_id as number
+        const folder_id = params.folder_id as number | undefined
+        const [files, folders] = await Promise.all([
+          canvas.files.list(course_id),
+          canvas.files.listFolders(course_id),
+        ])
+        return findDuplicateFiles(files, folders, folder_id)
       },
     },
   ]

--- a/src/tools/files.ts
+++ b/src/tools/files.ts
@@ -49,10 +49,8 @@ function findDuplicateFiles(
   folderId?: number,
 ): { duplicate_groups: DuplicateGroup[]; total_redundant_copies: number } {
   const folderPathById = new Map(folders.map((f) => [f.id, f.full_name]))
-  const scoped =
-    folderId == null
-      ? files
-      : files.filter((f) => collectFolderSubtree(folders, folderId).has(f.folder_id))
+  const subtree = folderId == null ? null : collectFolderSubtree(folders, folderId)
+  const scoped = subtree == null ? files : files.filter((f) => subtree.has(f.folder_id))
 
   const groups = new Map<string, CanvasFile[]>()
   for (const file of scoped) {

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(142)
+    expect(manifest.tools).toHaveLength(143)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/tools/files.test.ts
+++ b/tests/tools/files.test.ts
@@ -394,5 +394,224 @@ describe('fileTools', () => {
         total_redundant_copies: 1,
       })
     })
+
+    it('scopes through a multi-level subtree (grandchild folders)', async () => {
+      const child = { id: 2, name: 'Unit 1', full_name: 'course files/Unit 1', parent_folder_id: 1 }
+      const grandchild = {
+        id: 3,
+        name: 'Readings',
+        full_name: 'course files/Unit 1/Readings',
+        parent_folder_id: 2,
+      }
+      const outside = {
+        id: 4,
+        name: 'Unit 2',
+        full_name: 'course files/Unit 2',
+        parent_folder_id: null,
+      }
+      const canvas: CanvasClient = {
+        files: {
+          list: vi.fn().mockResolvedValue([
+            {
+              id: 1,
+              display_name: 'dup.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 10,
+              folder_id: 3,
+            },
+            {
+              id: 2,
+              display_name: 'dup.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 10,
+              folder_id: 3,
+            },
+            {
+              id: 3,
+              display_name: 'dup.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 10,
+              folder_id: 4,
+            },
+          ]),
+          listFolders: vi.fn().mockResolvedValue([mockFolder, child, grandchild, outside]),
+        },
+      } as unknown as CanvasClient
+      const tool = fileTools(canvas).find((t) => t.name === 'find_duplicate_files')!
+
+      const result = await tool.handler({ course_id: 1, folder_id: 1 })
+
+      expect(result.duplicate_groups).toHaveLength(1)
+      expect(result.duplicate_groups[0].count).toBe(2)
+      expect(result.duplicate_groups[0].files.map((f: { id: number }) => f.id)).toEqual([1, 2])
+    })
+
+    it('returns an empty result when folder_id does not match any known folder', async () => {
+      const canvas: CanvasClient = {
+        files: {
+          list: vi.fn().mockResolvedValue([
+            {
+              id: 1,
+              display_name: 'dup.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 10,
+              folder_id: 1,
+            },
+            {
+              id: 2,
+              display_name: 'dup.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 10,
+              folder_id: 1,
+            },
+          ]),
+          listFolders: vi.fn().mockResolvedValue([mockFolder]),
+        },
+      } as unknown as CanvasClient
+      const tool = fileTools(canvas).find((t) => t.name === 'find_duplicate_files')!
+
+      const result = await tool.handler({ course_id: 1, folder_id: 999 })
+
+      expect(result).toEqual({ duplicate_groups: [], total_redundant_copies: 0 })
+    })
+
+    it('falls back to a placeholder folder_path when a file references an unknown folder', async () => {
+      const canvas: CanvasClient = {
+        files: {
+          list: vi.fn().mockResolvedValue([
+            {
+              id: 1,
+              display_name: 'dup.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 10,
+              folder_id: 77,
+            },
+            {
+              id: 2,
+              display_name: 'dup.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 10,
+              folder_id: 77,
+            },
+          ]),
+          listFolders: vi.fn().mockResolvedValue([mockFolder]),
+        },
+      } as unknown as CanvasClient
+      const tool = fileTools(canvas).find((t) => t.name === 'find_duplicate_files')!
+
+      const result = await tool.handler({ course_id: 1 })
+
+      expect(result.duplicate_groups[0].files).toEqual([
+        { id: 1, folder_path: '(unknown folder 77)' },
+        { id: 2, folder_path: '(unknown folder 77)' },
+      ])
+    })
+
+    it('handles a group with 3+ files and computes total_redundant_copies as count - 1', async () => {
+      const canvas: CanvasClient = {
+        files: {
+          list: vi.fn().mockResolvedValue([
+            {
+              id: 1,
+              display_name: 'dup.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 10,
+              folder_id: 1,
+            },
+            {
+              id: 2,
+              display_name: 'dup.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 10,
+              folder_id: 1,
+            },
+            {
+              id: 3,
+              display_name: 'dup.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 10,
+              folder_id: 1,
+            },
+          ]),
+          listFolders: vi.fn().mockResolvedValue([mockFolder]),
+        },
+      } as unknown as CanvasClient
+      const tool = fileTools(canvas).find((t) => t.name === 'find_duplicate_files')!
+
+      const result = await tool.handler({ course_id: 1 })
+
+      expect(result.duplicate_groups).toHaveLength(1)
+      expect(result.duplicate_groups[0].count).toBe(3)
+      expect(result.total_redundant_copies).toBe(2)
+    })
+
+    it('returns multiple independent duplicate groups in a single call', async () => {
+      const canvas: CanvasClient = {
+        files: {
+          list: vi.fn().mockResolvedValue([
+            {
+              id: 1,
+              display_name: 'a.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 10,
+              folder_id: 1,
+            },
+            {
+              id: 2,
+              display_name: 'a.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 10,
+              folder_id: 1,
+            },
+            {
+              id: 3,
+              display_name: 'b.docx',
+              content_type: 'application/msword',
+              url: '',
+              size: 30,
+              folder_id: 1,
+            },
+            {
+              id: 4,
+              display_name: 'b.docx',
+              content_type: 'application/msword',
+              url: '',
+              size: 30,
+              folder_id: 1,
+            },
+            {
+              id: 5,
+              display_name: 'unique.png',
+              content_type: 'image/png',
+              url: '',
+              size: 40,
+              folder_id: 1,
+            },
+          ]),
+          listFolders: vi.fn().mockResolvedValue([mockFolder]),
+        },
+      } as unknown as CanvasClient
+      const tool = fileTools(canvas).find((t) => t.name === 'find_duplicate_files')!
+
+      const result = await tool.handler({ course_id: 1 })
+
+      expect(result.duplicate_groups).toHaveLength(2)
+      expect(
+        result.duplicate_groups.map((g: { display_name: string }) => g.display_name).sort(),
+      ).toEqual(['a.pdf', 'b.docx'])
+      expect(result.total_redundant_copies).toBe(2)
+    })
   })
 })

--- a/tests/tools/files.test.ts
+++ b/tests/tools/files.test.ts
@@ -45,8 +45,8 @@ describe('fileTools', () => {
     } as unknown as CanvasClient
   }
 
-  it('returns an array with 6 tool definitions', () => {
-    expect(fileTools(buildMockCanvas())).toHaveLength(6)
+  it('returns an array with 7 tool definitions', () => {
+    expect(fileTools(buildMockCanvas())).toHaveLength(7)
   })
 
   it('exports tools with correct names', () => {
@@ -58,6 +58,7 @@ describe('fileTools', () => {
       'upload_file',
       'delete_file',
       'download_file',
+      'find_duplicate_files',
     ])
   })
 
@@ -183,6 +184,215 @@ describe('fileTools', () => {
       const tool = fileTools(canvas).find((t) => t.name === 'download_file')!
       await tool.handler({ file_id: 42 })
       expect(canvas.files.download).toHaveBeenCalledWith(42, undefined)
+    })
+  })
+
+  describe('find_duplicate_files', () => {
+    it('has read-only annotations', () => {
+      const tool = fileTools(buildMockCanvas()).find((t) => t.name === 'find_duplicate_files')!
+      expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+    })
+
+    it('returns no duplicate groups when every file is unique', async () => {
+      const canvas: CanvasClient = {
+        files: {
+          list: vi.fn().mockResolvedValue([
+            {
+              id: 1,
+              display_name: 'a.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 10,
+              folder_id: 1,
+            },
+            {
+              id: 2,
+              display_name: 'b.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 20,
+              folder_id: 1,
+            },
+          ]),
+          listFolders: vi.fn().mockResolvedValue([mockFolder]),
+        },
+      } as unknown as CanvasClient
+      const tool = fileTools(canvas).find((t) => t.name === 'find_duplicate_files')!
+
+      const result = await tool.handler({ course_id: 1 })
+
+      expect(result).toEqual({ duplicate_groups: [], total_redundant_copies: 0 })
+    })
+
+    it('returns an empty result for a course with no files', async () => {
+      const canvas: CanvasClient = {
+        files: {
+          list: vi.fn().mockResolvedValue([]),
+          listFolders: vi.fn().mockResolvedValue([]),
+        },
+      } as unknown as CanvasClient
+      const tool = fileTools(canvas).find((t) => t.name === 'find_duplicate_files')!
+
+      const result = await tool.handler({ course_id: 1 })
+
+      expect(result).toEqual({ duplicate_groups: [], total_redundant_copies: 0 })
+    })
+
+    it('does not group same-name files that differ in size', async () => {
+      const canvas: CanvasClient = {
+        files: {
+          list: vi.fn().mockResolvedValue([
+            {
+              id: 1,
+              display_name: 'notes.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 100,
+              folder_id: 1,
+            },
+            {
+              id: 2,
+              display_name: 'notes.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 200,
+              folder_id: 1,
+            },
+          ]),
+          listFolders: vi.fn().mockResolvedValue([mockFolder]),
+        },
+      } as unknown as CanvasClient
+      const tool = fileTools(canvas).find((t) => t.name === 'find_duplicate_files')!
+
+      const result = await tool.handler({ course_id: 1 })
+
+      expect(result).toEqual({ duplicate_groups: [], total_redundant_copies: 0 })
+    })
+
+    it('groups files with matching name and size, resolving folder paths', async () => {
+      const subFolder = {
+        id: 2,
+        name: 'Week 1',
+        full_name: 'course files/Week 1',
+        parent_folder_id: 1,
+      }
+      const canvas: CanvasClient = {
+        files: {
+          list: vi.fn().mockResolvedValue([
+            {
+              id: 1,
+              display_name: 'syllabus.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 500,
+              folder_id: 1,
+              created_at: '2026-01-01T00:00:00Z',
+            },
+            {
+              id: 2,
+              display_name: 'syllabus.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 500,
+              folder_id: 2,
+              created_at: '2026-02-01T00:00:00Z',
+            },
+            {
+              id: 3,
+              display_name: 'other.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 999,
+              folder_id: 1,
+            },
+          ]),
+          listFolders: vi.fn().mockResolvedValue([mockFolder, subFolder]),
+        },
+      } as unknown as CanvasClient
+      const tool = fileTools(canvas).find((t) => t.name === 'find_duplicate_files')!
+
+      const result = await tool.handler({ course_id: 1 })
+
+      expect(result).toEqual({
+        duplicate_groups: [
+          {
+            display_name: 'syllabus.pdf',
+            size: 500,
+            count: 2,
+            files: [
+              { id: 1, folder_path: 'course files', created_at: '2026-01-01T00:00:00Z' },
+              { id: 2, folder_path: 'course files/Week 1', created_at: '2026-02-01T00:00:00Z' },
+            ],
+          },
+        ],
+        total_redundant_copies: 1,
+      })
+      expect(canvas.files.list).toHaveBeenCalledWith(1)
+      expect(canvas.files.listFolders).toHaveBeenCalledWith(1)
+    })
+
+    it('scopes to a folder subtree when folder_id is provided', async () => {
+      const subFolder = {
+        id: 2,
+        name: 'Week 1',
+        full_name: 'course files/Week 1',
+        parent_folder_id: 1,
+      }
+      const otherFolder = {
+        id: 3,
+        name: 'Week 2',
+        full_name: 'course files/Week 2',
+        parent_folder_id: null,
+      }
+      const canvas: CanvasClient = {
+        files: {
+          list: vi.fn().mockResolvedValue([
+            {
+              id: 1,
+              display_name: 'dup.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 10,
+              folder_id: 2,
+            },
+            {
+              id: 2,
+              display_name: 'dup.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 10,
+              folder_id: 2,
+            },
+            {
+              id: 3,
+              display_name: 'dup.pdf',
+              content_type: 'application/pdf',
+              url: '',
+              size: 10,
+              folder_id: 3,
+            },
+          ]),
+          listFolders: vi.fn().mockResolvedValue([mockFolder, subFolder, otherFolder]),
+        },
+      } as unknown as CanvasClient
+      const tool = fileTools(canvas).find((t) => t.name === 'find_duplicate_files')!
+
+      const result = await tool.handler({ course_id: 1, folder_id: 1 })
+
+      expect(result).toEqual({
+        duplicate_groups: [
+          {
+            display_name: 'dup.pdf',
+            size: 10,
+            count: 2,
+            files: [
+              { id: 1, folder_path: 'course files/Week 1' },
+              { id: 2, folder_path: 'course files/Week 1' },
+            ],
+          },
+        ],
+        total_redundant_copies: 1,
+      })
     })
   })
 })

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -374,8 +374,10 @@ describe('getAllTools', () => {
     expect(names).toContain('audit_course_links')
     // Submissions Awaiting Grading (1)
     expect(names).toContain('list_submissions_awaiting_grading')
+    // Files (1)
+    expect(names).toContain('find_duplicate_files')
 
-    expect(tools).toHaveLength(142)
+    expect(tools).toHaveLength(143)
   })
 
   it('all tools have openWorldHint: true', () => {


### PR DESCRIPTION
## Summary

- Adds a new read-only `find_duplicate_files` tool to the `files` domain: groups a course's files by `display_name` + `size` (Canvas file listings carry no content hash) and returns each group with more than one file, plus a `total_redundant_copies` count.
- Optional `folder_id` scopes the search to that folder and its subfolders (BFS over `parent_folder_id`).
- Each file in a duplicate group resolves its `folder_path` from the course's folder list (`full_name`), falling back to a placeholder if the folder can't be found.
- Composes entirely on the existing `canvas.files.list` and `canvas.files.listFolders` — no new Canvas client methods or dependencies.
- No student PII is involved (course Files carry no `user`/`user_name` field), so no pseudonymizer wrapping is required.
- Regenerated `docs/generated/tool-manifest.json` and updated the two hardcoded tool-count assertions (`tests/tools/registry.test.ts`, `tests/discovery/manifests.test.ts`) to 143.

## Approach

Implemented directly in `src/tools/files.ts` (the tool contract in the issue was already settled — "Design unknowns: none blocking"), adding:
- `collectFolderSubtree` — walks `parent_folder_id` to build the folder-id subtree rooted at an optional `folder_id`.
- `findDuplicateFiles` — pure grouping function taking files + folders and returning `{ duplicate_groups, total_redundant_copies }`.
- The `find_duplicate_files` tool definition, `readOnlyHint`/`openWorldHint` annotated, inheriting the `files` domain's `shared` default audience.

## Test evidence

New `find_duplicate_files` describe block in `tests/tools/files.test.ts` covers the acceptance criteria:
- no duplicates (unique files) → empty result
- empty course → empty result
- same display name, different size → NOT grouped
- several files with matching name + size → grouped, with resolved `folder_path` per file and correct `total_redundant_copies`
- `folder_id` scoping → files outside the requested subtree are excluded from grouping

`pnpm typecheck && pnpm lint && pnpm test && pnpm build` all green locally.

Closes #233

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017EgfqJhPEhJita9cHeM6K4)_