### PR TITLE
feat(course-setup): flag assignments still open past their due date

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1714,7 +1714,7 @@
     {
       "name": "check_course_setup",
       "domain": "course_setup",
-      "description": "Run a factual course-readiness report that surfaces common configuration problems — assignments missing due dates, unpublished items students will not see, gradebook weighting gaps, and graded assignments with no points. Returns findings grouped by check with a plain-language detail per item. This is a config-health report only; it does not inspect student submissions or performance (see list_students_needing_attention / get_missing_submissions for those). Requires instructor permissions in the course.",
+      "description": "Run a factual course-readiness report that surfaces common configuration problems — assignments missing due dates, unpublished items students will not see, gradebook weighting gaps, graded assignments with no points, and published assignments still accepting submissions after their due date. Returns findings grouped by check with a plain-language detail per item. This is a config-health report only; it does not inspect student submissions or performance (see list_students_needing_attention / get_missing_submissions for those). Requires instructor permissions in the course.",
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": true

--- a/src/tools/course-setup.ts
+++ b/src/tools/course-setup.ts
@@ -14,6 +14,7 @@ const ALL_CHECKS = [
   'unpublished_items',
   'assignment_group_weights',
   'ungraded_setup',
+  'submissions_open_past_due',
 ] as const
 
 type CheckName = (typeof ALL_CHECKS)[number]
@@ -32,6 +33,75 @@ interface CheckResult {
   items: SetupFinding[]
 }
 
+// submission_types values that mean there is no Canvas drop box to lock — an
+// in-class / paper / no-submission assignment would otherwise flag forever once
+// its due date passed (design-unknown §1).
+const NON_SUBMITTABLE_TYPES = new Set(['none', 'not_graded', 'on_paper'])
+
+// Defensive `?? []`: submission_types is a required field on CanvasAssignment and
+// Canvas always populates it, but guarding against an absent value keeps the check
+// from throwing on a partial response (and on test fixtures that omit it). An empty
+// or absent submission_types is conservatively treated as "no drop box".
+function hasDigitalDropBox(a: CanvasAssignment): boolean {
+  return (a.submission_types ?? []).some((t) => !NON_SUBMITTABLE_TYPES.has(t))
+}
+
+interface DateSet {
+  due_at: string | null
+  unlock_at: string | null
+  lock_at: string | null
+  base: boolean
+  title?: string
+}
+
+// One date set per relevant audience (base + each override). When all_dates is
+// empty, synthesize a single base set from the top-level dates. When the base is
+// not visible to anyone (only_visible_to_overrides), drop it so a phantom
+// "everyone" audience no student is bound by cannot produce a finding.
+function buildDateSets(a: CanvasAssignment): DateSet[] {
+  const raw = a.all_dates ?? []
+  const sets: DateSet[] =
+    raw.length > 0
+      ? raw.map((d) => ({
+          due_at: d.due_at,
+          unlock_at: d.unlock_at,
+          lock_at: d.lock_at,
+          base: d.base === true,
+          title: d.title,
+        }))
+      : [
+          {
+            due_at: a.due_at,
+            unlock_at: a.unlock_at ?? null,
+            lock_at: a.lock_at ?? null,
+            base: true,
+          },
+        ]
+  return a.only_visible_to_overrides === true ? sets.filter((d) => !d.base) : sets
+}
+
+// "Right now" predicate: the due date has passed, the assignment is already
+// unlocked (unlock_at null or in the past), and it has not yet locked (lock_at
+// null or in the future) — i.e. Canvas is accepting submissions this instant.
+function isOpenPastDue(d: DateSet, nowMs: number): boolean {
+  if (d.due_at === null) return false
+  if (new Date(d.due_at).getTime() >= nowMs) return false
+  if (d.unlock_at !== null && new Date(d.unlock_at).getTime() > nowMs) return false
+  if (d.lock_at !== null && new Date(d.lock_at).getTime() <= nowMs) return false
+  return true
+}
+
+// Earliest-due open date set drives the finding. Strict `<` keeps the first
+// entry (typically the base) on an exact due_at tie — a stated, intentional
+// tie-break (design-unknown §2).
+function pickEarliestOpen(openSets: DateSet[]): DateSet {
+  return openSets.reduce((earliest, d) =>
+    new Date(d.due_at as string).getTime() < new Date(earliest.due_at as string).getTime()
+      ? d
+      : earliest,
+  )
+}
+
 export function courseSetupTools(canvas: CanvasClient): ToolDefinition[] {
   return [
     {
@@ -39,7 +109,8 @@ export function courseSetupTools(canvas: CanvasClient): ToolDefinition[] {
       description:
         'Run a factual course-readiness report that surfaces common configuration problems — ' +
         'assignments missing due dates, unpublished items students will not see, ' +
-        'gradebook weighting gaps, and graded assignments with no points. ' +
+        'gradebook weighting gaps, graded assignments with no points, and published assignments ' +
+        'still accepting submissions after their due date. ' +
         'Returns findings grouped by check with a plain-language detail per item. ' +
         'This is a config-health report only; it does not inspect student submissions or performance ' +
         '(see list_students_needing_attention / get_missing_submissions for those). ' +
@@ -53,13 +124,14 @@ export function courseSetupTools(canvas: CanvasClient): ToolDefinition[] {
               'unpublished_items',
               'assignment_group_weights',
               'ungraded_setup',
+              'submissions_open_past_due',
             ]),
           )
           .optional()
           .describe(
-            'Subset of checks to run. Omit to run all four checks. ' +
+            'Subset of checks to run. Omit to run all five checks. ' +
               'Valid values: missing_due_dates, unpublished_items, ' +
-              'assignment_group_weights, ungraded_setup.',
+              'assignment_group_weights, ungraded_setup, submissions_open_past_due.',
           ),
       },
       annotations: {
@@ -191,6 +263,38 @@ export function courseSetupTools(canvas: CanvasClient): ToolDefinition[] {
             }
           }
           results.push({ check: 'ungraded_setup', severity: 'warn', items })
+        }
+
+        // ── check: submissions_open_past_due ──────────────────────────
+        // Evaluated against "right now," not "was this ever open past due" — see spec
+        // design-unknown §1. A lock_at already in the past means the instructor closed
+        // it (even via a grace period); only a null or still-future lock_at is flagged.
+        // Assignments with no digital drop box (on_paper / none / not_graded) are
+        // skipped — there is nothing to "still be open."
+        if (activeChecks.has('submissions_open_past_due')) {
+          const items: SetupFinding[] = []
+          const nowMs = Date.now()
+          for (const a of assignments) {
+            if (a.published !== true) continue
+            if (!hasDigitalDropBox(a)) continue
+            const dateSets = buildDateSets(a)
+            const openSets = dateSets.filter((d) => isOpenPastDue(d, nowMs))
+            if (openSets.length === 0) continue
+            const chosen = pickEarliestOpen(openSets)
+            const lockDisplay = chosen.lock_at ?? 'not set'
+            const scopeText = chosen.base
+              ? ''
+              : ` for override "${chosen.title ?? 'untitled override'}"`
+            const moreText =
+              openSets.length > 1 ? ` (+${openSets.length - 1} more date set(s) also open)` : ''
+            items.push({
+              type: 'assignment',
+              id: a.id,
+              name: a.name,
+              detail: `due ${chosen.due_at}${scopeText} has passed; lock_at is ${lockDisplay} — submissions still open${moreText}`,
+            })
+          }
+          results.push({ check: 'submissions_open_past_due', severity: 'warn', items })
         }
 
         const totalFindings = results.reduce((n, r) => n + r.items.length, 0)

--- a/src/tools/course-setup.ts
+++ b/src/tools/course-setup.ts
@@ -83,11 +83,26 @@ function buildDateSets(a: CanvasAssignment): DateSet[] {
 // "Right now" predicate: the due date has passed, the assignment is already
 // unlocked (unlock_at null or in the past), and it has not yet locked (lock_at
 // null or in the future) — i.e. Canvas is accepting submissions this instant.
+//
+// Every non-null date is NaN-guarded. An unparseable date string parses to NaN,
+// and every comparison against NaN is false, which without a guard would let a
+// garbage `due_at` slip past the `>= nowMs` gate and fabricate a finding with a
+// nonsense detail. A malformed date is treated conservatively as "not open" so
+// the check fails closed (suppresses the finding) rather than open — matching the
+// check's false-positive discipline. Real Canvas always returns ISO 8601 or null
+// here; this only bites on a malformed/partial response.
 function isOpenPastDue(d: DateSet, nowMs: number): boolean {
   if (d.due_at === null) return false
-  if (new Date(d.due_at).getTime() >= nowMs) return false
-  if (d.unlock_at !== null && new Date(d.unlock_at).getTime() > nowMs) return false
-  if (d.lock_at !== null && new Date(d.lock_at).getTime() <= nowMs) return false
+  const dueMs = new Date(d.due_at).getTime()
+  if (Number.isNaN(dueMs) || dueMs >= nowMs) return false
+  if (d.unlock_at !== null) {
+    const unlockMs = new Date(d.unlock_at).getTime()
+    if (Number.isNaN(unlockMs) || unlockMs > nowMs) return false
+  }
+  if (d.lock_at !== null) {
+    const lockMs = new Date(d.lock_at).getTime()
+    if (Number.isNaN(lockMs) || lockMs <= nowMs) return false
+  }
   return true
 }
 

--- a/tests/tools/course-setup.test.ts
+++ b/tests/tools/course-setup.test.ts
@@ -58,6 +58,7 @@ const DAY_MS = 24 * 60 * 60 * 1000
 const PAST_DUE = new Date(Date.now() - 5 * DAY_MS).toISOString()
 const EARLIER_PAST_DUE = new Date(Date.now() - 10 * DAY_MS).toISOString()
 const PAST_LOCK = new Date(Date.now() - 1 * DAY_MS).toISOString()
+const PAST_UNLOCK = new Date(Date.now() - 2 * DAY_MS).toISOString()
 const FUTURE_LOCK = new Date(Date.now() + 5 * DAY_MS).toISOString()
 const FUTURE_DUE = new Date(Date.now() + 5 * DAY_MS).toISOString()
 const FUTURE_UNLOCK = new Date(Date.now() + 5 * DAY_MS).toISOString()
@@ -765,6 +766,97 @@ describe('courseSetupTools', () => {
       const finding = report.findings.find((f) => f.check === 'submissions_open_past_due')
       expect(finding).toBeDefined()
       expect(finding!.items).toEqual([])
+    })
+
+    // Review add-on (test-analyzer T1): the "unlock_at already passed" side of the
+    // unlock gate — case 9's inverse. Pins that a released-in-the-past, past-due,
+    // unlocked assignment is still flagged (a mutation to `unlock_at !== null →
+    // return false` would otherwise pass silently).
+    it('flags when unlock_at is set but already in the past', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [{ ...OPEN_PAST_DUE_ASSIGNMENT, unlock_at: PAST_UNLOCK }],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'submissions_open_past_due')).toHaveLength(1)
+    })
+
+    // Review add-on (test-analyzer T2): the spec's stated equal-due_at tie-break.
+    // Two open date sets share the identical due_at; strict `<` keeps the first
+    // entry (base), so the base — not the override — must drive the finding. A
+    // switch to `<=` would flip the winner and this test would catch it.
+    it('keeps the base on an exact due_at tie between base and override', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [
+          {
+            ...OPEN_PAST_DUE_ASSIGNMENT,
+            all_dates: [
+              { base: true, due_at: PAST_DUE, unlock_at: null, lock_at: null },
+              {
+                base: false,
+                title: 'Section C',
+                due_at: PAST_DUE,
+                unlock_at: null,
+                lock_at: null,
+              },
+            ],
+          },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      const items = itemsFor(report, 'submissions_open_past_due')
+      expect(items).toHaveLength(1)
+      expect(items[0].detail).not.toContain('for override')
+      expect(items[0].detail).toContain('(+1 more date set(s) also open)')
+    })
+
+    // Review add-on (test-analyzer T3): the spec's conservative-exclusion of an
+    // empty submission_types (treated as "no drop box").
+    it('does not flag an assignment with an empty submission_types array', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [{ ...OPEN_PAST_DUE_ASSIGNMENT, submission_types: [] }],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'submissions_open_past_due')).toEqual([])
+    })
+
+    // Review add-on (test-analyzer T4): the `chosen.title ?? 'untitled override'`
+    // fallback — an open override date set with no title.
+    it('labels an open override with no title as "untitled override"', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [
+          {
+            ...OPEN_PAST_DUE_ASSIGNMENT,
+            all_dates: [
+              { base: true, due_at: PAST_DUE, unlock_at: null, lock_at: PAST_LOCK },
+              { base: false, due_at: PAST_DUE, unlock_at: null, lock_at: null },
+            ],
+          },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      const items = itemsFor(report, 'submissions_open_past_due')
+      expect(items).toHaveLength(1)
+      expect(items[0].detail).toContain('for override "untitled override"')
+    })
+
+    // Review add-on (silent-failure S1): a malformed, non-null date string must not
+    // fabricate a finding. Without the NaN guard, `new Date('garbage').getTime()`
+    // is NaN, every comparison is false, and the assignment would be flagged with a
+    // nonsense detail. The check must fail closed (no finding) instead.
+    it('does not flag when due_at is a malformed date string', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [{ ...OPEN_PAST_DUE_ASSIGNMENT, due_at: 'not-a-real-date' }],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'submissions_open_past_due')).toEqual([])
+    })
+
+    it('does not flag when lock_at is a malformed date string (fails closed)', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [{ ...OPEN_PAST_DUE_ASSIGNMENT, lock_at: 'garbage-lock' }],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'submissions_open_past_due')).toEqual([])
     })
   })
 

--- a/tests/tools/course-setup.test.ts
+++ b/tests/tools/course-setup.test.ts
@@ -48,6 +48,33 @@ const DEFAULT_ASSIGNMENTS = [
   },
 ]
 
+// Time-relative fixtures for the submissions_open_past_due check. Computed
+// relative to Date.now() (not fixed calendar dates) so the "right now" predicate
+// is exercised deterministically regardless of when the suite runs — matching the
+// convention in tests/tools/attention.test.ts. Kept scoped to this file's new
+// describe block; deliberately NOT added to DEFAULT_ASSIGNMENTS so the other four
+// checks' exact-items assertions are not perturbed.
+const DAY_MS = 24 * 60 * 60 * 1000
+const PAST_DUE = new Date(Date.now() - 5 * DAY_MS).toISOString()
+const EARLIER_PAST_DUE = new Date(Date.now() - 10 * DAY_MS).toISOString()
+const PAST_LOCK = new Date(Date.now() - 1 * DAY_MS).toISOString()
+const FUTURE_LOCK = new Date(Date.now() + 5 * DAY_MS).toISOString()
+const FUTURE_DUE = new Date(Date.now() + 5 * DAY_MS).toISOString()
+const FUTURE_UNLOCK = new Date(Date.now() + 5 * DAY_MS).toISOString()
+
+const OPEN_PAST_DUE_ASSIGNMENT = {
+  id: 8,
+  name: 'Reflection',
+  published: true,
+  due_at: PAST_DUE,
+  unlock_at: null,
+  lock_at: null,
+  all_dates: [],
+  grading_type: 'points',
+  points_possible: 10,
+  submission_types: ['online_upload'],
+}
+
 const DEFAULT_GROUPS = [
   { id: 1, name: 'Homework', position: 1, group_weight: 50 },
   { id: 2, name: 'Exams', position: 2, group_weight: 50 },
@@ -120,15 +147,16 @@ describe('courseSetupTools', () => {
     expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
   })
 
-  it('runs all four checks when no checks param is supplied', async () => {
+  it('runs all five checks when no checks param is supplied', async () => {
     const report = await run(buildMockCanvas(), { course_id: 10 })
     expect(report.summary.checks_run).toEqual([
       'missing_due_dates',
       'unpublished_items',
       'assignment_group_weights',
       'ungraded_setup',
+      'submissions_open_past_due',
     ])
-    expect(report.findings).toHaveLength(4)
+    expect(report.findings).toHaveLength(5)
   })
 
   describe('missing_due_dates', () => {
@@ -450,6 +478,293 @@ describe('courseSetupTools', () => {
       })
       const report = await run(canvas, { course_id: 10 })
       expect(itemsFor(report, 'ungraded_setup').some((i) => i.id === 7)).toBe(false)
+    })
+  })
+
+  describe('submissions_open_past_due', () => {
+    // Case 2 (also exercises the all_dates:[] top-level fallback — design-unknown §2 —
+    // so case 8 is folded here, not a separate block).
+    it('flags a published assignment past due with no lock date (top-level fallback)', async () => {
+      const canvas = buildMockCanvas({ assignments: [OPEN_PAST_DUE_ASSIGNMENT] })
+      const report = await run(canvas, { course_id: 10 })
+      const items = itemsFor(report, 'submissions_open_past_due')
+      expect(items).toContainEqual(
+        expect.objectContaining({ type: 'assignment', id: 8, name: 'Reflection' }),
+      )
+      const finding = items.find((i) => i.id === 8)!
+      expect(finding.detail).toBe(
+        `due ${PAST_DUE} has passed; lock_at is not set — submissions still open`,
+      )
+    })
+
+    // Case 3
+    it('flags a published assignment past due with a future lock date', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [{ ...OPEN_PAST_DUE_ASSIGNMENT, lock_at: FUTURE_LOCK }],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      const items = itemsFor(report, 'submissions_open_past_due')
+      expect(items).toHaveLength(1)
+      expect(items[0].detail).toContain(FUTURE_LOCK)
+      expect(items[0].detail).not.toContain('not set')
+    })
+
+    // Case 4
+    it('does not flag when already locked (lock_at in the past)', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [{ ...OPEN_PAST_DUE_ASSIGNMENT, lock_at: PAST_LOCK }],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'submissions_open_past_due')).toEqual([])
+    })
+
+    // Case 5
+    it('does not flag when not yet due', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [{ ...OPEN_PAST_DUE_ASSIGNMENT, due_at: FUTURE_DUE }],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'submissions_open_past_due')).toEqual([])
+    })
+
+    // Case 6
+    it('does not flag when due_at is null', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [{ ...OPEN_PAST_DUE_ASSIGNMENT, due_at: null }],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'submissions_open_past_due')).toEqual([])
+    })
+
+    // Case 7
+    it('does not flag an unpublished assignment even when past due and unlocked', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [{ ...OPEN_PAST_DUE_ASSIGNMENT, published: false }],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'submissions_open_past_due')).toEqual([])
+    })
+
+    // Case 9
+    it('does not flag when unlock_at is still in the future', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [{ ...OPEN_PAST_DUE_ASSIGNMENT, unlock_at: FUTURE_UNLOCK }],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'submissions_open_past_due')).toEqual([])
+    })
+
+    // Case 10
+    it('does not flag an assignment with no digital drop box (on_paper)', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [{ ...OPEN_PAST_DUE_ASSIGNMENT, submission_types: ['on_paper'] }],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'submissions_open_past_due')).toEqual([])
+    })
+
+    // Case 11
+    it('does not flag an assignment with submission_types: [none]', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [{ ...OPEN_PAST_DUE_ASSIGNMENT, submission_types: ['none'] }],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'submissions_open_past_due')).toEqual([])
+    })
+
+    // Case 12
+    it('still flags when submission_types mixes a digital and a non-digital entry', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [
+          { ...OPEN_PAST_DUE_ASSIGNMENT, submission_types: ['on_paper', 'online_upload'] },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'submissions_open_past_due')).toHaveLength(1)
+    })
+
+    // Case 13
+    it('flags an override still open while the base is already locked', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [
+          {
+            ...OPEN_PAST_DUE_ASSIGNMENT,
+            all_dates: [
+              { base: true, due_at: PAST_DUE, unlock_at: null, lock_at: PAST_LOCK },
+              {
+                base: false,
+                title: 'Late Registrants',
+                due_at: PAST_DUE,
+                unlock_at: null,
+                lock_at: null,
+              },
+            ],
+          },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      const items = itemsFor(report, 'submissions_open_past_due')
+      expect(items).toHaveLength(1)
+      expect(items[0].detail).toContain('for override "Late Registrants"')
+      expect(items[0].detail).toContain('submissions still open')
+    })
+
+    // Case 14
+    it('flags the base still open while a named override is already locked', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [
+          {
+            ...OPEN_PAST_DUE_ASSIGNMENT,
+            all_dates: [
+              { base: true, due_at: PAST_DUE, unlock_at: null, lock_at: null },
+              {
+                base: false,
+                title: 'Section B',
+                due_at: PAST_DUE,
+                unlock_at: null,
+                lock_at: PAST_LOCK,
+              },
+            ],
+          },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      const items = itemsFor(report, 'submissions_open_past_due')
+      expect(items).toHaveLength(1)
+      expect(items[0].detail).not.toContain('for override')
+    })
+
+    // Case 15
+    it('excludes the phantom base entry when only_visible_to_overrides is true', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [
+          {
+            ...OPEN_PAST_DUE_ASSIGNMENT,
+            only_visible_to_overrides: true,
+            all_dates: [
+              { base: true, due_at: PAST_DUE, unlock_at: null, lock_at: null },
+              {
+                base: false,
+                title: 'Group A',
+                due_at: FUTURE_DUE,
+                unlock_at: null,
+                lock_at: null,
+              },
+            ],
+          },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'submissions_open_past_due')).toEqual([])
+    })
+
+    // Case 16
+    it('still flags an open override when only_visible_to_overrides is true', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [
+          {
+            ...OPEN_PAST_DUE_ASSIGNMENT,
+            only_visible_to_overrides: true,
+            all_dates: [
+              { base: true, due_at: PAST_DUE, unlock_at: null, lock_at: null },
+              {
+                base: false,
+                title: 'Group A',
+                due_at: PAST_DUE,
+                unlock_at: null,
+                lock_at: null,
+              },
+            ],
+          },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      const items = itemsFor(report, 'submissions_open_past_due')
+      expect(items).toHaveLength(1)
+      expect(items[0].detail).toContain('for override "Group A"')
+    })
+
+    // Case 17 — multiple open date sets, base earliest; count worded generically.
+    it('picks the earliest open base set and notes the extra open set generically', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [
+          {
+            ...OPEN_PAST_DUE_ASSIGNMENT,
+            all_dates: [
+              { base: true, due_at: EARLIER_PAST_DUE, unlock_at: null, lock_at: null },
+              {
+                base: false,
+                title: 'Extended',
+                due_at: PAST_DUE,
+                unlock_at: null,
+                lock_at: null,
+              },
+            ],
+          },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      const items = itemsFor(report, 'submissions_open_past_due')
+      expect(items).toHaveLength(1)
+      expect(items[0].detail).toContain(EARLIER_PAST_DUE)
+      expect(items[0].detail).not.toContain('for override')
+      expect(items[0].detail).toContain('(+1 more date set(s) also open)')
+    })
+
+    // Case 18 — multiple open date sets, override earliest; suffix must not say "override(s)".
+    it('picks the earliest open override yet still counts the base as a generic date set', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [
+          {
+            ...OPEN_PAST_DUE_ASSIGNMENT,
+            all_dates: [
+              { base: true, due_at: PAST_DUE, unlock_at: null, lock_at: null },
+              {
+                base: false,
+                title: 'Extended',
+                due_at: EARLIER_PAST_DUE,
+                unlock_at: null,
+                lock_at: null,
+              },
+            ],
+          },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      const items = itemsFor(report, 'submissions_open_past_due')
+      expect(items).toHaveLength(1)
+      expect(items[0].detail).toContain(EARLIER_PAST_DUE)
+      expect(items[0].detail).toContain('for override "Extended"')
+      expect(items[0].detail).toContain('(+1 more date set(s) also open)')
+    })
+
+    // Case 19
+    it('runs alone without triggering the other checks fetches', async () => {
+      const canvas = buildMockCanvas({ assignments: [OPEN_PAST_DUE_ASSIGNMENT] })
+      const report = await run(canvas, {
+        course_id: 10,
+        checks: ['submissions_open_past_due'],
+      })
+      expect(canvas.assignments.list).toHaveBeenCalled()
+      expect(canvas.modules.listWithItems).not.toHaveBeenCalled()
+      expect(canvas.assignments.listGroups).not.toHaveBeenCalled()
+      expect(canvas.courses.get).not.toHaveBeenCalled()
+      expect(report.summary.checks_run).toEqual(['submissions_open_past_due'])
+      expect(report.findings).toHaveLength(1)
+    })
+
+    // Case 20
+    it('emits an empty items array when nothing is open past due', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [
+          { ...OPEN_PAST_DUE_ASSIGNMENT, id: 30, due_at: FUTURE_DUE },
+          { ...OPEN_PAST_DUE_ASSIGNMENT, id: 31, due_at: null },
+        ],
+      })
+      const report = await run(canvas, { course_id: 10, checks: ['submissions_open_past_due'] })
+      const finding = report.findings.find((f) => f.check === 'submissions_open_past_due')
+      expect(finding).toBeDefined()
+      expect(finding!.items).toEqual([])
     })
   })
 

--- a/tests/tools/course-setup.test.ts
+++ b/tests/tools/course-setup.test.ts
@@ -858,6 +858,18 @@ describe('courseSetupTools', () => {
       const report = await run(canvas, { course_id: 10 })
       expect(itemsFor(report, 'submissions_open_past_due')).toEqual([])
     })
+
+    // Cycle-2 add-on: the third date-parse guard. Without a malformed-unlock_at test
+    // the `Number.isNaN(unlockMs)` branch was the one unguarded-in-tests parse — a
+    // regression dropping only that line would fabricate a finding yet pass. Pins the
+    // three date guards symmetrically.
+    it('does not flag when unlock_at is a malformed date string (fails closed)', async () => {
+      const canvas = buildMockCanvas({
+        assignments: [{ ...OPEN_PAST_DUE_ASSIGNMENT, unlock_at: 'garbage-unlock' }],
+      })
+      const report = await run(canvas, { course_id: 10 })
+      expect(itemsFor(report, 'submissions_open_past_due')).toEqual([])
+    })
   })
 
   describe('checks filter', () => {


### PR DESCRIPTION
## What & why

Closes #237.

> **User story:** As an instructor using Claude, I want to see which of my published assignments are past their due date but still accepting submissions (no lock/availability date set), so I can close the ones I forgot to lock before more late work piles up.

Implements the merged design spec (`docs/superpowers/specs/2026-07-08-issue-237-submissions-open-past-due.md`, from PR #238). Adds a fifth check, `submissions_open_past_due`, to the existing `check_course_setup` tool rather than a new tool — keeping the surface tight (no new tool registration, no tool-count bump).

## Approach

- **Reuses an existing fetch.** `check_course_setup` already calls `assignments.list(course_id, { include: ['all_dates'] })` unconditionally, so the new check adds **zero** Canvas round-trips and needs no Canvas-client changes.
- **"Right now" predicate (reports facts, not prescriptions).** Flags a **published** assignment when its `due_at` has passed AND it is currently unlocked (`unlock_at` null or already passed) AND it has not yet locked (`lock_at` null or still in the future). A `lock_at` already in the past — an instructor's intentional grace-period cutoff — is **not** flagged. The detail string states the fact and never asserts "you forgot to lock this."
- **Overrides handled both directions.** Each date set (base + every override from `all_dates`) is evaluated independently; the earliest-due open set drives one finding per assignment. `only_visible_to_overrides: true` excludes the phantom base entry. When `all_dates` is empty, the top-level dates are used as a synthetic base set.
- **No-drop-box guard.** Assignments whose `submission_types` are limited to `none` / `not_graded` / `on_paper` are skipped — there is nothing to "still be open," and flagging them would fire forever once due.
- **No PII.** Output is assignment IDs, names, ISO dates, and override titles (config metadata Canvas already exposes raw via `list_assignments`). No pseudonymizer wrapping required; `check_course_setup` stays out of `PSEUDONYMIZER_WRAPPED_TOOLS`.

## Deviation from spec (code reality)

The spec's `hasDigitalDropBox` reads `a.submission_types.some(...)`. The mocked test fixtures (and, defensively, a partial Canvas response) can omit `submission_types`, which would throw a `TypeError`. Implemented as `(a.submission_types ?? []).some(...)` — an absent/empty value is conservatively treated as "no drop box," matching the spec's own stated handling of an empty `submission_types`. Behavior for real Canvas responses (which always populate the field) is identical.

## Test evidence

`pnpm typecheck && pnpm lint && pnpm test && pnpm build` — all green.

```
Test Files  95 passed (95)
     Tests  1388 passed | 1 skipped (1389)
```

- 18 new `it()` blocks in `tests/tools/course-setup.test.ts` covering: open/closed/not-yet-due/no-due-date/unpublished/no-drop-box, `unlock_at` gating, both override directions, `only_visible_to_overrides` exclusion, multi-open-date-set selection (base-earliest and override-earliest, regression-testing the generic `date set(s)` wording), the checks-filter fetch gating, and the empty-items case.
- Updated the "runs all checks" test to five checks / five findings.
- `docs/generated/tool-manifest.json` regenerated (`pnpm generate:manifests`) for the updated `check_course_setup` description. Tool count unchanged at 143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
