### PR TITLE
feat(quizzes): add get_quiz_question_responses grade-by-question tool

### DIFF
--- a/docs/generated/tool-manifest.json
+++ b/docs/generated/tool-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "packageName": "canvas-lms-mcp",
-  "toolCount": 143,
+  "toolCount": 144,
   "tools": [
     {
       "name": "health_check",
@@ -484,6 +484,18 @@
         "openWorldHint": true
       },
       "access": "write",
+      "primaryAudience": "educator",
+      "relatedWorkflows": []
+    },
+    {
+      "name": "get_quiz_question_responses",
+      "domain": "quiz_question_responses",
+      "description": "Review every student's answer to one or all questions in a Classic Quiz, pivoted by question instead of by student — for grading essay/short-answer/file-upload questions consistently across a class instead of paging through SpeedGrader one student at a time. Classic Quizzes only (quiz_type: assignment, practice_quiz, graded_survey, survey) — New Quizzes exposes responses through a different API. Omit question_id to get every question; provide it to scope to one. Each question reports needs_manual_grading (true for essay and file-upload questions) and points_possible. Scans one Canvas API call per completed or pending-review submission; a failed per-submission fetch is recorded in submissions_failed rather than aborting the whole call. When CANVAS_PSEUDONYMIZE_STUDENTS is enabled, student names are replaced with stable pseudonyms.",
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true
+      },
+      "access": "read",
       "primaryAudience": "educator",
       "relatedWorkflows": []
     },

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -425,7 +425,15 @@ export interface CanvasQuizQuestion {
 export interface CanvasQuizSubmissionQuestion {
   id: number
   quiz_id: number
-  answer: string | number | null
+  // Widened from `string | number | null`: matching / multiple-answer question
+  // types return arrays or keyed objects, not a plain scalar. Still backward
+  // compatible — the scalar members remain valid.
+  answer: string | number | string[] | Record<string, unknown> | null
+  // Present once Canvas has graded an auto-graded question type; omitted for
+  // manually-graded (essay / file-upload) answers not yet scored, so it is
+  // optional and surfaced as `correct ?? null`. See
+  // docs/superpowers/specs/2026-07-09-issue-240-quiz-question-responses.md §3.
+  correct?: boolean | null
   flagged: boolean
 }
 

--- a/src/pseudonym/coverage.ts
+++ b/src/pseudonym/coverage.ts
@@ -62,4 +62,7 @@ export const PSEUDONYMIZER_WRAPPED_TOOLS: readonly string[] = [
 
   // src/tools/student.ts
   'get_my_submission_feedback',
+
+  // src/tools/quiz-question-responses.ts
+  'get_quiz_question_responses',
 ] as const

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -25,6 +25,7 @@ import { outcomeTools } from './outcomes'
 import { pageTools } from './pages'
 import { peerReviewTools } from './peer-reviews'
 import { quizTools } from './quizzes'
+import { quizQuestionResponseTools } from './quiz-question-responses'
 import { quizAccommodationTools } from './quiz-accommodations'
 import { newQuizAccommodationTools } from './new-quiz-accommodations'
 import { newQuizTools } from './new-quizzes'
@@ -88,6 +89,11 @@ export const toolDomainCatalog: readonly ToolDomainRegistration[] = [
     domain: 'new_quizzes',
     defaultPrimaryAudience: 'educator',
     getTools: newQuizTools,
+  },
+  {
+    domain: 'quiz_question_responses',
+    defaultPrimaryAudience: 'educator',
+    getTools: quizQuestionResponseTools,
   },
   {
     domain: 'files',

--- a/src/tools/quiz-question-responses.ts
+++ b/src/tools/quiz-question-responses.ts
@@ -1,0 +1,189 @@
+import { z } from 'zod'
+import type { CanvasClient } from '../canvas'
+import type { CanvasQuizSubmissionQuestion } from '../canvas/types'
+import type { Pseudonymizer } from '../pseudonym/pseudonymizer'
+import type { ToolDefinition } from './types'
+
+// Classic Quiz `quiz_type` values. An allow-list (not a `!== 'quizzes.next'`
+// deny-list) so an unrecognized future quiz_type fails closed rather than being
+// treated as Classic. Mirrors src/tools/quiz-accommodations.ts's CLASSIC_QUIZ_TYPES.
+const CLASSIC_QUIZ_TYPES = new Set(['assignment', 'practice_quiz', 'graded_survey', 'survey'])
+
+// The two Classic Quiz question types Canvas never auto-grades. short_answer is
+// auto-graded by exact text match, so it is deliberately excluded even though the
+// issue mentions "short answer" colloquially.
+const MANUALLY_GRADED_QUESTION_TYPES = new Set(['essay_question', 'file_upload_question'])
+
+// Only submissions in these workflow states carry answers worth scanning.
+// `pending_review` is the state of an essay attempt awaiting manual grading — the
+// core case for this tool — so it must be included, not excluded.
+const RESPONDED_WORKFLOW_STATES = new Set(['complete', 'pending_review'])
+
+interface QuestionResponse {
+  user_id: number
+  user_name: string | null
+  quiz_submission_id: number
+  attempt: number
+  answer: CanvasQuizSubmissionQuestion['answer']
+  correct: boolean | null
+  flagged: boolean
+}
+
+interface QuestionGroup {
+  question_id: number
+  question_text: string
+  question_type: string
+  position: number
+  points_possible: number
+  needs_manual_grading: boolean
+  responses: QuestionResponse[]
+}
+
+export function quizQuestionResponseTools(
+  canvas: CanvasClient,
+  pseudonymizer?: Pseudonymizer,
+): ToolDefinition[] {
+  return [
+    {
+      name: 'get_quiz_question_responses',
+      description:
+        "Review every student's answer to one or all questions in a Classic Quiz, pivoted by " +
+        'question instead of by student — for grading essay/short-answer/file-upload questions ' +
+        'consistently across a class instead of paging through SpeedGrader one student at a time. ' +
+        'Classic Quizzes only (quiz_type: assignment, practice_quiz, graded_survey, survey) — New ' +
+        'Quizzes exposes responses through a different API. Omit question_id to get every question; ' +
+        'provide it to scope to one. Each question reports needs_manual_grading (true for essay and ' +
+        'file-upload questions) and points_possible. Scans one Canvas API call per completed or ' +
+        'pending-review submission; a failed per-submission fetch is recorded in submissions_failed ' +
+        'rather than aborting the whole call. When CANVAS_PSEUDONYMIZE_STUDENTS is enabled, student ' +
+        'names are replaced with stable pseudonyms.',
+      inputSchema: {
+        course_id: z.number().int().positive().describe('The Canvas course ID'),
+        quiz_id: z.number().int().positive().describe('The Canvas quiz ID (Classic Quizzes only)'),
+        question_id: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe(
+            'Scope the result to a single question ID (from list_quiz_questions). ' +
+              "Omit to return every question with every student's response.",
+          ),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const courseId = params.course_id as number
+        const quizId = params.quiz_id as number
+        const questionId = params.question_id as number | undefined
+
+        // Gate Classic vs New Quizzes first, before any further Canvas calls, so a
+        // New Quiz fails fast with a clear message instead of an opaque 404 later.
+        const quiz = await canvas.quizzes.get(courseId, quizId)
+        if (!CLASSIC_QUIZ_TYPES.has(quiz.quiz_type)) {
+          throw new Error(
+            `This tool only supports Classic Quizzes (assignment, practice_quiz, graded_survey, ` +
+              `survey). Quiz ${quizId} has quiz_type "${quiz.quiz_type}" (New Quizzes), which ` +
+              `exposes responses through a different API not covered by this tool.`,
+          )
+        }
+
+        let questions = await canvas.quizzes.listQuestions(courseId, quizId)
+        if (questionId !== undefined) {
+          questions = questions.filter((q) => q.id === questionId)
+          if (questions.length === 0) {
+            throw new Error(`Question ${questionId} not found on quiz ${quizId}.`)
+          }
+        }
+        questions = [...questions].sort((a, b) => a.position - b.position)
+
+        const allSubmissions = await canvas.quizzes.listSubmissions(courseId, quizId)
+        const submissions = allSubmissions.filter((s) =>
+          RESPONDED_WORKFLOW_STATES.has(s.workflow_state),
+        )
+
+        // Resolve user_id -> name once. listStudents' users carry no `enrollments`,
+        // so classifyRole() sees them as 'unknown' and the conservative default
+        // pseudonymizes them anyway when the flag is on. user_id itself is never
+        // scrubbed — it is the stable join key, not FERPA-identifying in isolation.
+        const students = await canvas.users.listStudents(courseId)
+        const anonymizedStudents =
+          pseudonymizer?.isEnabled() === true
+            ? await pseudonymizer.anonymizeUsers(courseId, students)
+            : students
+        const nameById = new Map(anonymizedStudents.map((u) => [u.id, u.name]))
+
+        // One answer-fetch per submission, tolerating individual failures: a single
+        // broken submission must not blank out the whole grade-by-question view.
+        const settled = await Promise.allSettled(
+          submissions.map((s) => canvas.quizzes.getSubmissionAnswers(s.id)),
+        )
+
+        const answersBySubmission = new Map<number, CanvasQuizSubmissionQuestion[]>()
+        const submissionsFailed: number[] = []
+        settled.forEach((outcome, i) => {
+          const submission = submissions[i]
+          if (!submission) return // index-aligned with `settled`; guard for the type checker
+          if (outcome.status === 'fulfilled') {
+            answersBySubmission.set(submission.id, outcome.value)
+          } else {
+            submissionsFailed.push(submission.id)
+            console.error(
+              `get_quiz_question_responses: failed fetching answers for quiz submission ` +
+                `${submission.id} (course ${courseId}, quiz ${quizId}):`,
+              outcome.reason,
+            )
+          }
+        })
+
+        const groups = new Map<number, QuestionGroup>(
+          questions.map((q) => [
+            q.id,
+            {
+              question_id: q.id,
+              question_text: q.question_text,
+              question_type: q.question_type,
+              position: q.position,
+              points_possible: q.points_possible,
+              needs_manual_grading: MANUALLY_GRADED_QUESTION_TYPES.has(q.question_type),
+              responses: [],
+            },
+          ]),
+        )
+
+        for (const submission of submissions) {
+          const answers = answersBySubmission.get(submission.id)
+          if (!answers) continue
+          for (const answer of answers) {
+            // Assumes CanvasQuizSubmissionQuestion.id === CanvasQuizQuestion.id (the
+            // quiz's question ID). If Canvas ever returns a different identifier here,
+            // this lookup silently misses and responses[] comes back empty — see spec
+            // 2026-07-09-issue-240 design unknown §3 (the pivot's single highest risk).
+            const group = groups.get(answer.id)
+            if (!group) continue // not one of the (possibly question_id-filtered) target questions
+            group.responses.push({
+              user_id: submission.user_id,
+              user_name: nameById.get(submission.user_id) ?? null,
+              quiz_submission_id: submission.id,
+              attempt: submission.attempt,
+              answer: answer.answer,
+              correct: answer.correct ?? null,
+              flagged: answer.flagged,
+            })
+          }
+        }
+
+        return {
+          quiz_id: quiz.id,
+          quiz_title: quiz.title,
+          question_count: groups.size,
+          questions: [...groups.values()],
+          submissions_scanned: submissions.length,
+          submissions_failed: submissionsFailed,
+        }
+      },
+    },
+  ]
+}

--- a/tests/discovery/manifests.test.ts
+++ b/tests/discovery/manifests.test.ts
@@ -35,7 +35,7 @@ describe('tool manifest generation', () => {
     const manifest = buildToolManifest()
 
     expect(manifest.schemaVersion).toBe('1.0')
-    expect(manifest.tools).toHaveLength(143)
+    expect(manifest.tools).toHaveLength(144)
     expect(manifest.tools.find((tool) => tool.name === 'grade_submission')).toEqual({
       name: 'grade_submission',
       domain: 'submissions',

--- a/tests/pseudonym/coverage.test.ts
+++ b/tests/pseudonym/coverage.test.ts
@@ -31,6 +31,7 @@ const EXPECTED_PII_BEARING_TOOLS = new Set([
   'list_students_needing_attention',
   'explain_grade',
   'get_my_submission_feedback',
+  'get_quiz_question_responses',
 ])
 
 function buildMinimalCanvas(): CanvasClient {

--- a/tests/tools/quiz-question-responses.test.ts
+++ b/tests/tools/quiz-question-responses.test.ts
@@ -1,0 +1,385 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { CanvasClient } from '../../src/canvas'
+import type {
+  CanvasQuiz,
+  CanvasQuizQuestion,
+  CanvasQuizSubmission,
+  CanvasQuizSubmissionQuestion,
+  CanvasUser,
+} from '../../src/canvas/types'
+import type { Pseudonymizer } from '../../src/pseudonym/pseudonymizer'
+import { quizQuestionResponseTools } from '../../src/tools/quiz-question-responses'
+import { getAllTools } from '../../src/tools'
+
+// ── Output shape (mirrors the handler's return; tests aren't typechecked) ──────
+
+interface ResponseRow {
+  user_id: number
+  user_name: string | null
+  quiz_submission_id: number
+  attempt: number
+  answer: unknown
+  correct: boolean | null
+  flagged: boolean
+}
+
+interface QuestionGroupOut {
+  question_id: number
+  question_text: string
+  question_type: string
+  position: number
+  points_possible: number
+  needs_manual_grading: boolean
+  responses: ResponseRow[]
+}
+
+interface Result {
+  quiz_id: number
+  quiz_title: string
+  question_count: number
+  questions: QuestionGroupOut[]
+  submissions_scanned: number
+  submissions_failed: number[]
+}
+
+// ── Fixtures — built to match src/canvas/types.ts, not copied from the existing
+//    quizzes.test.ts mocks which carry fields absent from the real interfaces. ──
+
+const defaultQuiz: CanvasQuiz = {
+  id: 1,
+  title: 'Essay Quiz',
+  quiz_type: 'assignment',
+  points_possible: 20,
+  question_count: 2,
+  due_at: null,
+  published: true,
+}
+
+// Q1 is an essay (manually graded); Q2 is auto-graded. listQuestions returns them
+// out of position order to exercise the position sort.
+const q1Essay: CanvasQuizQuestion = {
+  id: 10,
+  quiz_id: 1,
+  position: 1,
+  question_text: 'Explain photosynthesis.',
+  question_type: 'essay_question',
+  points_possible: 10,
+}
+const q2Mc: CanvasQuizQuestion = {
+  id: 20,
+  quiz_id: 1,
+  position: 2,
+  question_text: 'What is 2 + 2?',
+  question_type: 'multiple_choice_question',
+  points_possible: 10,
+}
+
+const subComplete: CanvasQuizSubmission = {
+  id: 100,
+  quiz_id: 1,
+  user_id: 5,
+  submission_id: 500,
+  attempt: 1,
+  score: null,
+  kept_score: null,
+  workflow_state: 'complete',
+}
+const subPendingReview: CanvasQuizSubmission = {
+  id: 101,
+  quiz_id: 1,
+  user_id: 6,
+  submission_id: 501,
+  attempt: 2,
+  score: null,
+  kept_score: null,
+  workflow_state: 'pending_review',
+}
+
+const answersForSub100: CanvasQuizSubmissionQuestion[] = [
+  {
+    id: 10,
+    quiz_id: 1,
+    answer: 'Plants convert light to chemical energy.',
+    correct: null,
+    flagged: false,
+  },
+  { id: 20, quiz_id: 1, answer: '4', correct: true, flagged: false },
+]
+const answersForSub101: CanvasQuizSubmissionQuestion[] = [
+  // `correct` intentionally omitted here to exercise the `?? null` passthrough.
+  { id: 10, quiz_id: 1, answer: 'It uses sunlight.', flagged: false },
+  { id: 20, quiz_id: 1, answer: '5', correct: false, flagged: true },
+]
+
+const alice: CanvasUser = { id: 5, name: 'Alice Anderson' }
+const bob: CanvasUser = { id: 6, name: 'Bob Brown' }
+
+interface MockOpts {
+  quiz?: CanvasQuiz
+  questions?: CanvasQuizQuestion[]
+  submissions?: CanvasQuizSubmission[]
+  answersBySubmission?: Record<number, CanvasQuizSubmissionQuestion[]>
+  answersImpl?: (subId: number) => Promise<CanvasQuizSubmissionQuestion[]>
+  students?: CanvasUser[]
+}
+
+function buildMockCanvas(opts: MockOpts = {}): CanvasClient {
+  const answers = opts.answersBySubmission ?? { 100: answersForSub100, 101: answersForSub101 }
+  const getSubmissionAnswers = opts.answersImpl
+    ? vi.fn().mockImplementation(opts.answersImpl)
+    : vi.fn().mockImplementation((subId: number) => Promise.resolve(answers[subId] ?? []))
+  return {
+    quizzes: {
+      get: vi.fn().mockResolvedValue(opts.quiz ?? defaultQuiz),
+      listQuestions: vi.fn().mockResolvedValue(opts.questions ?? [q2Mc, q1Essay]),
+      listSubmissions: vi
+        .fn()
+        .mockResolvedValue(opts.submissions ?? [subComplete, subPendingReview]),
+      getSubmissionAnswers,
+    },
+    users: {
+      listStudents: vi.fn().mockResolvedValue(opts.students ?? [alice, bob]),
+      listCourseUsers: vi.fn().mockResolvedValue([]),
+    },
+  } as unknown as CanvasClient
+}
+
+function getTool(canvas: CanvasClient, pseudonymizer?: Pseudonymizer) {
+  const tool = quizQuestionResponseTools(canvas, pseudonymizer).find(
+    (t) => t.name === 'get_quiz_question_responses',
+  )
+  if (!tool) throw new Error('get_quiz_question_responses not registered')
+  return tool
+}
+
+describe('quizQuestionResponseTools', () => {
+  it('exports exactly the get_quiz_question_responses tool', () => {
+    const names = quizQuestionResponseTools(buildMockCanvas()).map((t) => t.name)
+    expect(names).toEqual(['get_quiz_question_responses'])
+  })
+
+  describe('annotations and audience', () => {
+    it('is read-only with openWorldHint and no destructiveHint', () => {
+      const tool = getTool(buildMockCanvas())
+      expect(tool.annotations).toEqual({ readOnlyHint: true, openWorldHint: true })
+      expect(tool.annotations.destructiveHint).toBeUndefined()
+    })
+
+    it('resolves to the educator audience (no override on the tool)', () => {
+      const tool = getTool(buildMockCanvas())
+      expect(tool.audience).toBeUndefined()
+      const resolved = getAllTools(buildMockCanvas()).find(
+        (t) => t.name === 'get_quiz_question_responses',
+      )
+      expect(resolved?.audience).toBe('educator')
+    })
+  })
+
+  describe('pivot behaviour', () => {
+    it('pivots every question with every response, ordered by position', async () => {
+      const canvas = buildMockCanvas()
+      const tool = getTool(canvas)
+      const result = (await tool.handler({ course_id: 1, quiz_id: 1 })) as Result
+
+      expect(result.quiz_id).toBe(1)
+      expect(result.quiz_title).toBe('Essay Quiz')
+      expect(result.question_count).toBe(2)
+      expect(result.submissions_scanned).toBe(2)
+      expect(result.submissions_failed).toEqual([])
+
+      // Sorted by position: Q1 (essay, pos 1) then Q2 (mc, pos 2).
+      expect(result.questions.map((q) => q.question_id)).toEqual([10, 20])
+
+      const [essay, mc] = result.questions
+      expect(essay.needs_manual_grading).toBe(true)
+      expect(essay.points_possible).toBe(10)
+      expect(mc.needs_manual_grading).toBe(false)
+
+      // Each question has one response per scanned submission, in submission order.
+      expect(essay.responses.map((r) => r.user_id)).toEqual([5, 6])
+      expect(essay.responses[0]).toMatchObject({
+        user_id: 5,
+        user_name: 'Alice Anderson',
+        quiz_submission_id: 100,
+        attempt: 1,
+        answer: 'Plants convert light to chemical energy.',
+        correct: null,
+        flagged: false,
+      })
+      expect(mc.responses.map((r) => r.answer)).toEqual(['4', '5'])
+    })
+
+    it('scopes to a single question when question_id is provided', async () => {
+      const canvas = buildMockCanvas()
+      const tool = getTool(canvas)
+      const result = (await tool.handler({ course_id: 1, quiz_id: 1, question_id: 20 })) as Result
+
+      expect(result.question_count).toBe(1)
+      expect(result.questions).toHaveLength(1)
+      expect(result.questions[0].question_id).toBe(20)
+      expect(result.questions[0].responses).toHaveLength(2)
+    })
+
+    it('rejects an unknown question_id with a "not found" message', async () => {
+      const canvas = buildMockCanvas()
+      const tool = getTool(canvas)
+      let message = ''
+      try {
+        await tool.handler({ course_id: 1, quiz_id: 1, question_id: 999 })
+      } catch (err) {
+        message = (err as Error).message
+      }
+      expect(message).toContain('not found')
+      expect(message).toContain('999')
+    })
+  })
+
+  describe('New Quizzes gating', () => {
+    it('rejects a New Quiz before making any further Canvas calls', async () => {
+      const canvas = buildMockCanvas({ quiz: { ...defaultQuiz, quiz_type: 'quizzes.next' } })
+      const tool = getTool(canvas)
+
+      let message = ''
+      try {
+        await tool.handler({ course_id: 1, quiz_id: 1 })
+      } catch (err) {
+        message = (err as Error).message
+      }
+      expect(message).toContain('quizzes.next')
+      expect(message).toContain('New Quizzes')
+
+      expect(canvas.quizzes.listQuestions).not.toHaveBeenCalled()
+      expect(canvas.quizzes.listSubmissions).not.toHaveBeenCalled()
+      expect(canvas.quizzes.getSubmissionAnswers).not.toHaveBeenCalled()
+      expect(canvas.users.listStudents).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('workflow-state filtering', () => {
+    it('scans only responded submissions (excludes untaken)', async () => {
+      const untaken: CanvasQuizSubmission = {
+        ...subComplete,
+        id: 102,
+        user_id: 7,
+        workflow_state: 'untaken',
+      }
+      const canvas = buildMockCanvas({ submissions: [subComplete, untaken] })
+      const tool = getTool(canvas)
+      const result = (await tool.handler({ course_id: 1, quiz_id: 1 })) as Result
+
+      expect(result.submissions_scanned).toBe(1)
+      expect(canvas.quizzes.getSubmissionAnswers).toHaveBeenCalledTimes(1)
+      expect(canvas.quizzes.getSubmissionAnswers).toHaveBeenCalledWith(100)
+    })
+
+    it('includes pending_review submissions (essays awaiting grading)', async () => {
+      const canvas = buildMockCanvas({ submissions: [subPendingReview] })
+      const tool = getTool(canvas)
+      const result = (await tool.handler({ course_id: 1, quiz_id: 1 })) as Result
+
+      expect(result.submissions_scanned).toBe(1)
+      expect(canvas.quizzes.getSubmissionAnswers).toHaveBeenCalledWith(101)
+      expect(result.questions[0].responses.map((r) => r.quiz_submission_id)).toContain(101)
+    })
+  })
+
+  describe('per-submission failure tolerance', () => {
+    it('records a failed answer-fetch without aborting the whole call', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const canvas = buildMockCanvas({
+        answersImpl: (subId) =>
+          subId === 100 ? Promise.resolve(answersForSub100) : Promise.reject(new Error('boom')),
+      })
+      const tool = getTool(canvas)
+      const result = (await tool.handler({ course_id: 1, quiz_id: 1 })) as Result
+
+      expect(result.submissions_failed).toEqual([101])
+      // The healthy submission's answers are still pivoted in.
+      const essay = result.questions.find((q) => q.question_id === 10)!
+      expect(essay.responses.map((r) => r.quiz_submission_id)).toEqual([100])
+      expect(errorSpy).toHaveBeenCalled()
+      errorSpy.mockRestore()
+    })
+  })
+
+  describe('correct passthrough', () => {
+    it('surfaces correct verbatim and null when Canvas omits it', async () => {
+      const canvas = buildMockCanvas()
+      const tool = getTool(canvas)
+      const result = (await tool.handler({ course_id: 1, quiz_id: 1 })) as Result
+
+      const mc = result.questions.find((q) => q.question_id === 20)!
+      const bySub = new Map(mc.responses.map((r) => [r.quiz_submission_id, r.correct]))
+      expect(bySub.get(100)).toBe(true) // correct: true
+      expect(bySub.get(101)).toBe(false) // correct: false
+
+      const essay = result.questions.find((q) => q.question_id === 10)!
+      const essayBySub = new Map(essay.responses.map((r) => [r.quiz_submission_id, r.correct]))
+      expect(essayBySub.get(100)).toBeNull() // correct: null
+      expect(essayBySub.get(101)).toBeNull() // correct omitted -> null
+    })
+  })
+
+  describe('pseudonymizer', () => {
+    it('uses raw student names when no pseudonymizer is passed', async () => {
+      const canvas = buildMockCanvas()
+      const tool = getTool(canvas)
+      const result = (await tool.handler({ course_id: 1, quiz_id: 1 })) as Result
+
+      const names = result.questions[0].responses.map((r) => r.user_name)
+      expect(names).toEqual(['Alice Anderson', 'Bob Brown'])
+    })
+
+    it('replaces names via anonymizeUsers when enabled, using the student roster', async () => {
+      const canvas = buildMockCanvas()
+      const pseudonymizer = {
+        isEnabled: () => true,
+        anonymizeUsers: vi.fn(async (_courseId: number, users: CanvasUser[]) =>
+          users.map((u) => ({ ...u, name: `Student ${u.id}` })),
+        ),
+      } as unknown as Pseudonymizer
+
+      const tool = getTool(canvas, pseudonymizer)
+      const result = (await tool.handler({ course_id: 1, quiz_id: 1 })) as Result
+
+      const names = result.questions[0].responses.map((r) => r.user_name)
+      expect(names).toEqual(['Student 5', 'Student 6'])
+      expect(canvas.users.listStudents).toHaveBeenCalledWith(1)
+      expect(canvas.users.listCourseUsers).not.toHaveBeenCalled()
+    })
+
+    it('does not call anonymizeUsers when the pseudonymizer is disabled', async () => {
+      const canvas = buildMockCanvas()
+      const anonymizeUsers = vi.fn()
+      const pseudonymizer = {
+        isEnabled: () => false,
+        anonymizeUsers,
+      } as unknown as Pseudonymizer
+
+      const tool = getTool(canvas, pseudonymizer)
+      const result = (await tool.handler({ course_id: 1, quiz_id: 1 })) as Result
+
+      expect(anonymizeUsers).not.toHaveBeenCalled()
+      expect(result.questions[0].responses[0].user_name).toBe('Alice Anderson')
+    })
+  })
+
+  describe('unrostered submitter', () => {
+    it('sets user_name to null when the submitter is not on the roster', async () => {
+      const strayUser: CanvasQuizSubmission = { ...subComplete, id: 103, user_id: 99 }
+      const canvas = buildMockCanvas({
+        submissions: [strayUser],
+        answersBySubmission: {
+          103: [{ id: 10, quiz_id: 1, answer: 'Ghost answer', flagged: false }],
+        },
+        students: [alice, bob], // user 99 absent
+      })
+      const tool = getTool(canvas)
+      const result = (await tool.handler({ course_id: 1, quiz_id: 1 })) as Result
+
+      const essay = result.questions.find((q) => q.question_id === 10)!
+      expect(essay.responses).toHaveLength(1)
+      expect(essay.responses[0]).toMatchObject({ user_id: 99, user_name: null })
+    })
+  })
+})

--- a/tests/tools/quiz-question-responses.test.ts
+++ b/tests/tools/quiz-question-responses.test.ts
@@ -382,4 +382,75 @@ describe('quizQuestionResponseTools', () => {
       expect(essay.responses[0]).toMatchObject({ user_id: 99, user_name: null })
     })
   })
+
+  describe('empty states', () => {
+    it('returns questions with empty responses when no submissions exist', async () => {
+      const canvas = buildMockCanvas({ submissions: [] })
+      const tool = getTool(canvas)
+      const result = (await tool.handler({ course_id: 1, quiz_id: 1 })) as Result
+
+      expect(result.submissions_scanned).toBe(0)
+      expect(result.submissions_failed).toEqual([])
+      expect(result.question_count).toBe(2)
+      expect(result.questions.every((q) => q.responses.length === 0)).toBe(true)
+      expect(canvas.quizzes.getSubmissionAnswers).not.toHaveBeenCalled()
+    })
+
+    it('returns an empty question list when the quiz has no questions', async () => {
+      const canvas = buildMockCanvas({ questions: [] })
+      const tool = getTool(canvas)
+      const result = (await tool.handler({ course_id: 1, quiz_id: 1 })) as Result
+
+      expect(result.question_count).toBe(0)
+      expect(result.questions).toEqual([])
+    })
+  })
+
+  describe('join-key robustness', () => {
+    // The pivot's single load-bearing assumption is CanvasQuizSubmissionQuestion.id
+    // === CanvasQuizQuestion.id. This pins the documented guard: an answer whose id
+    // matches no question is dropped silently rather than crashing. See spec §3.
+    it('silently ignores an answer whose id matches no question', async () => {
+      const canvas = buildMockCanvas({
+        submissions: [subComplete],
+        answersBySubmission: {
+          100: [
+            { id: 999, quiz_id: 1, answer: 'orphan answer', flagged: false },
+            { id: 10, quiz_id: 1, answer: 'real essay answer', correct: null, flagged: false },
+          ],
+        },
+      })
+      const tool = getTool(canvas)
+      const result = (await tool.handler({ course_id: 1, quiz_id: 1 })) as Result
+
+      const essay = result.questions.find((q) => q.question_id === 10)!
+      expect(essay.responses.map((r) => r.answer)).toEqual(['real essay answer'])
+      // The orphan id 999 never surfaces as its own group or a stray response.
+      expect(result.questions.some((q) => q.question_id === 999)).toBe(false)
+      const mc = result.questions.find((q) => q.question_id === 20)!
+      expect(mc.responses).toEqual([])
+    })
+  })
+
+  describe('multiple submissions per student', () => {
+    it('keeps one response row per submission when a user appears twice', async () => {
+      const attempt1: CanvasQuizSubmission = { ...subComplete, id: 100, user_id: 5, attempt: 1 }
+      const attempt2: CanvasQuizSubmission = { ...subComplete, id: 101, user_id: 5, attempt: 2 }
+      const canvas = buildMockCanvas({
+        submissions: [attempt1, attempt2],
+        answersBySubmission: {
+          100: [{ id: 10, quiz_id: 1, answer: 'first attempt', correct: null, flagged: false }],
+          101: [{ id: 10, quiz_id: 1, answer: 'second attempt', correct: null, flagged: false }],
+        },
+      })
+      const tool = getTool(canvas)
+      const result = (await tool.handler({ course_id: 1, quiz_id: 1 })) as Result
+
+      const essay = result.questions.find((q) => q.question_id === 10)!
+      expect(essay.responses.map((r) => r.quiz_submission_id)).toEqual([100, 101])
+      expect(essay.responses.map((r) => r.attempt)).toEqual([1, 2])
+      // Both rows resolve to the same student identity.
+      expect(essay.responses.every((r) => r.user_name === 'Alice Anderson')).toBe(true)
+    })
+  })
 })

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -376,8 +376,10 @@ describe('getAllTools', () => {
     expect(names).toContain('list_submissions_awaiting_grading')
     // Files (1)
     expect(names).toContain('find_duplicate_files')
+    // Quiz Question Responses (1)
+    expect(names).toContain('get_quiz_question_responses')
 
-    expect(tools).toHaveLength(143)
+    expect(tools).toHaveLength(144)
   })
 
   it('all tools have openWorldHint: true', () => {


### PR DESCRIPTION
## Summary

Implements the merged design spec for #240 (`docs/superpowers/specs/2026-07-09-issue-240-quiz-question-responses.md`).

> **User story:** As an instructor using Claude, I want to review every student's response to a single quiz question side by side — instead of paging through SpeedGrader student-by-student — so I can grade essay/short-answer questions consistently and quickly.

Adds a read-only `get_quiz_question_responses` tool that pivots a **Classic Quiz** by *question* instead of by *student*.

## Approach

- **Composition, no new endpoint.** The handler fans out over already-wrapped Canvas client methods — `quizzes.get`, `quizzes.listQuestions`, `quizzes.listSubmissions`, `quizzes.getSubmissionAnswers`, `users.listStudents` — and pivots the results in memory. No new package dependency.
- **Classic Quizzes only.** `quiz_type` is checked against a `CLASSIC_QUIZ_TYPES` allow-list (mirroring `quiz-accommodations.ts`); a New Quiz fails fast with a clear message before any further Canvas call, rather than 404-ing opaquely later.
- **Per-question metadata:** each question carries `points_possible` and a `needs_manual_grading` flag computed from `question_type` (essay / file-upload), not from an uncertain per-answer signal.
- **Partial-failure tolerance:** answer-fetches run under `Promise.allSettled`; a single failed submission is recorded in `submissions_failed` (and stderr-logged) instead of blanking the whole grade-by-question view.
- **FERPA:** each response row carries `user_name`, so the roster is routed through `pseudonymizer.anonymizeUsers` when enabled and the tool is registered in `PSEUDONYMIZER_WRAPPED_TOOLS` (+ the mirrored `EXPECTED_PII_BEARING_TOOLS` test set). `user_id` is preserved as the stable join key.
- **Type widening:** `CanvasQuizSubmissionQuestion.answer` widened to include array/object answers, and an optional `correct?: boolean | null` added (backward compatible).

### Deviations noted from the spec
- The spec quoted the tool count as **143 → 144**; verified against the live assertions (`registry.test.ts`, `manifests.test.ts` were both at 143) — bumped to **144**.
- Error-case tests assert the handler **rejects** with the expected message (the codebase's actual test idiom — `formatError`/the registry wrapper convert the throw to `isError`), rather than asserting `isError: true` on the raw handler as the spec plan's wording suggested. Same behavior, matches existing `quizzes.test.ts`.

## Test evidence

New `tests/tools/quiz-question-responses.test.ts` covers the 13 spec cases: pivot ordering, `question_id` scoping (found + not-found), New-Quizzes gating (with fail-fast assertion), workflow-state filtering, `pending_review` inclusion, per-submission failure tolerance, `correct` passthrough, pseudonymizer off/on (roster source asserted), and an unrostered submitter → `user_name: null`.

Full local gate green at the pushed commit:

```
pnpm typecheck  ✓
pnpm lint       ✓ (ESLint + Prettier)
pnpm test       ✓ 1410 passed | 1 skipped (96 files)
pnpm build      ✓ Build success
```

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)
